### PR TITLE
Fix: Remove Hardcoded /v1 From OpenAI Provider URL Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.dll
 *.so
 *.dylib
-axe
+axe*
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/run_integration_test.go
+++ b/cmd/run_integration_test.go
@@ -112,8 +112,8 @@ model = "openai/gpt-4o"
 		t.Errorf("expected 1 request, got %d", mock.RequestCount())
 	}
 
-	if mock.Requests[0].Path != "/v1/chat/completions" {
-		t.Errorf("expected path /v1/chat/completions, got %q", mock.Requests[0].Path)
+	if mock.Requests[0].Path != "/chat/completions" {
+		t.Errorf("expected path /chat/completions, got %q", mock.Requests[0].Path)
 	}
 
 	body := mock.Requests[0].Body

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -11,7 +11,9 @@ import (
 
 const (
 	// defaultOpenAIBaseURL is the default OpenAI API base URL.
-	defaultOpenAIBaseURL = "https://api.openai.com"
+	// Includes /v1 so custom base URLs (e.g. Gloo, Azure) can set their
+	// own version prefix without the provider injecting /v1.
+	defaultOpenAIBaseURL = "https://api.openai.com/v1"
 )
 
 // OpenAIOption is a functional option for configuring the OpenAI provider.
@@ -244,7 +246,7 @@ func (o *OpenAI) Send(ctx context.Context, req *Request) (*Response, error) {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/v1/chat/completions", bytes.NewReader(jsonBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -127,8 +127,8 @@ func TestOpenAI_Send_RequestFormat(t *testing.T) {
 	if gotMethod != "POST" {
 		t.Errorf("expected POST, got %s", gotMethod)
 	}
-	if gotPath != "/v1/chat/completions" {
-		t.Errorf("expected /v1/chat/completions, got %s", gotPath)
+	if gotPath != "/chat/completions" {
+		t.Errorf("expected /chat/completions, got %s", gotPath)
 	}
 	if gotAuth != "Bearer test-key" {
 		t.Errorf("expected 'Bearer test-key', got %q", gotAuth)
@@ -147,6 +147,35 @@ func TestOpenAI_Send_RequestFormat(t *testing.T) {
 	}
 	if gotSecondRole != "user" {
 		t.Errorf("expected second message role 'user', got %v", gotSecondRole)
+	}
+}
+
+func TestOpenAI_Send_CustomBaseURL_NoV1Prefix(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"model":   "gpt-4o",
+			"choices": []map[string]interface{}{{"message": map[string]string{"content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	// Custom base_url simulating Gloo: server.URL acts as "https://platform.ai.gloo.com/ai/v2"
+	o, _ := NewOpenAI("test-key", WithOpenAIBaseURL(server.URL+"/ai/v2"))
+	_, err := o.Send(context.Background(), &Request{
+		Model:    "gloo-anthropic-claude-sonnet-4.5",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Custom base URL should NOT get /v1 injected — path should be /ai/v2/chat/completions
+	if gotPath != "/ai/v2/chat/completions" {
+		t.Errorf("expected /ai/v2/chat/completions, got %s", gotPath)
 	}
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
This fix removes the hardcoded "/v1" path segment from OpenAI provider URL construction, moving it into the default base URL instead. This prevents automatic injection of "/v1" into custom base URLs, allowing proxies and gateways with their own version prefixes to work correctly without encountering 404 errors.

## Changelog

### Fixed
- Remove hardcoded /v1 from OpenAI provider URL path by moving it into the default base URL
- Prevent automatic injection of /v1 into custom base URLs to avoid routing failures through proxies and gateways with version prefixes

### Changed
- Default OpenAI base URL updated from `https://api.openai.com` to `https://api.openai.com/v1`
- OpenAI request path construction updated to use `baseURL + "/chat/completions"` instead of `baseURL + "/v1/chat/completions"`
- Integration test expectations updated to assert path as "/chat/completions" instead of "/v1/chat/completions"
- Unit test expectations updated to reflect new path behavior
- .gitignore pattern broadened from `axe` to `axe*` for more flexible file matching

### Added
- New test case `TestOpenAI_Send_CustomBaseURL_NoV1Prefix` to verify that custom base URLs (e.g., endpoints with `/ai/v2`) are not modified with additional `/v1` prefixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Entire-Checkpoint: e3e6eed9ea99