### PR TITLE
ci: add GHCR docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and push a Docker image to GHCR on every version tag.

- Triggers on `v*` tags (same as `release.yml`, fully independent)
- Publishes `ghcr.io/jrswab/axe` with `x.y.z`, `x.y`, `x`, and `latest` tags
- Uses `GITHUB_TOKEN` — no extra secrets needed
- GHA layer caching for fast rebuilds
- Includes artifact attestation (build provenance)

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a GitHub Actions workflow that automatically builds and publishes Docker images to GitHub Container Registry whenever a version tag is pushed. The workflow uses `GITHUB_TOKEN` for authentication (eliminating the need for additional secrets), generates multiple image tags for semantic versioning, implements layer caching for improved build performance, and includes artifact attestation for supply chain security. This addresses the need to provide pre-built Docker images for users who prefer not to build locally.

## Changelog

### Added
- GitHub Actions workflow "Publish Docker Image" that builds and pushes Docker images to ghcr.io/jrswab/axe on version tag pushes
- Automatic image tagging with full semantic version (x.y.z), major.minor (x.y), major (x), and latest tags
- GitHub Actions layer caching for faster Docker image rebuilds
- Artifact attestation and build provenance tracking for supply chain security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->