### PR TITLE
ISS-28 - Local Agent Directory Support

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -24,7 +24,15 @@ var agentsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all agent configurations",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		agents, err := agent.List()
+		flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)
+		agents, err := agent.List(searchDirs)
 		if err != nil {
 			return err
 		}
@@ -50,7 +58,15 @@ var agentsShowCmd = &cobra.Command{
 	Short: "Show agent configuration details",
 	Args:  exactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := agent.Load(args[0])
+		flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)
+		cfg, err := agent.Load(args[0], searchDirs)
 		if err != nil {
 			return err
 		}
@@ -118,20 +134,41 @@ var agentsInitCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
+		flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
 		configDir, err := xdg.GetConfigDir()
 		if err != nil {
 			return err
 		}
 
-		agentsDir := filepath.Join(configDir, "agents")
-		path := filepath.Join(agentsDir, name+".toml")
+		var targetDir string
+		if flagAgentsDir != "" {
+			// Use the flag-provided directory
+			targetDir = flagAgentsDir
+		} else {
+			// Check if local axe/agents directory exists
+			localDir := filepath.Join(cwd, "axe", "agents")
+			if _, err := os.Stat(localDir); err == nil {
+				targetDir = localDir
+			} else {
+				// Fall back to global config dir
+				targetDir = filepath.Join(configDir, "agents")
+			}
+		}
+
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			return fmt.Errorf("failed to create agents directory: %w", err)
+		}
+
+		path := filepath.Join(targetDir, name+".toml")
 
 		if _, err := os.Stat(path); err == nil {
 			return fmt.Errorf("agent config already exists: %s", path)
-		}
-
-		if err := os.MkdirAll(agentsDir, 0755); err != nil {
-			return fmt.Errorf("failed to create agents directory: %w", err)
 		}
 
 		content, err := agent.Scaffold(name)
@@ -160,14 +197,32 @@ var agentsEditCmd = &cobra.Command{
 
 		name := args[0]
 
+		flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)
+
 		configDir, err := xdg.GetConfigDir()
 		if err != nil {
 			return err
 		}
 
-		path := filepath.Join(configDir, "agents", name+".toml")
+		// Check searchDirs first, then fall back to global config dir
+		allDirs := append(searchDirs, filepath.Join(configDir, "agents"))
+		var path string
+		for _, dir := range allDirs {
+			candidate := filepath.Join(dir, name+".toml")
+			if _, err := os.Stat(candidate); err == nil {
+				path = candidate
+				break
+			}
+		}
 
-		if _, err := os.Stat(path); os.IsNotExist(err) {
+		if path == "" {
 			return fmt.Errorf("agent config not found: %s", name)
 		}
 
@@ -187,4 +242,6 @@ func init() {
 	agentsCmd.AddCommand(agentsInitCmd)
 	agentsCmd.AddCommand(agentsEditCmd)
 	rootCmd.AddCommand(agentsCmd)
+
+	agentsCmd.PersistentFlags().String("agents-dir", "", "Additional agents directory to search before global config")
 }

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/jrswab/axe/internal/agent"
@@ -39,6 +40,7 @@ func init() {
 	gcCmd.Flags().Bool("dry-run", false, "Analyze and print suggestions without trimming the memory file")
 	gcCmd.Flags().Bool("all", false, "Run GC on all agents that have memory.enabled = true")
 	gcCmd.Flags().String("model", "", "Override the model used for pattern detection (provider/model-name format)")
+	gcCmd.Flags().String("agents-dir", "", "Additional agents directory to search before global config")
 	rootCmd.AddCommand(gcCmd)
 }
 
@@ -53,18 +55,26 @@ func runGC(cmd *cobra.Command, args []string) error {
 		return &ExitError{Code: 1, Err: fmt.Errorf("agent name is required (or use --all)")}
 	}
 
+	// Build search directories for agent lookup
+	flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return &ExitError{Code: 2, Err: fmt.Errorf("failed to get working directory: %w", err)}
+	}
+	searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)
+
 	if allFlag {
-		return runAllAgentsGC(cmd)
+		return runAllAgentsGC(cmd, searchDirs)
 	}
 
 	// Single-agent GC flow
 	agentName := args[0]
-	return runSingleAgentGC(cmd, agentName)
+	return runSingleAgentGC(cmd, agentName, searchDirs)
 }
 
-func runSingleAgentGC(cmd *cobra.Command, agentName string) error {
+func runSingleAgentGC(cmd *cobra.Command, agentName string, searchDirs []string) error {
 	// Step 1: Load agent config (Req 3.1)
-	cfg, err := agent.Load(agentName)
+	cfg, err := agent.Load(agentName, searchDirs)
 	if err != nil {
 		return &ExitError{Code: 2, Err: err}
 	}
@@ -195,9 +205,9 @@ func runSingleAgentGC(cmd *cobra.Command, agentName string) error {
 	return nil
 }
 
-func runAllAgentsGC(cmd *cobra.Command) error {
+func runAllAgentsGC(cmd *cobra.Command, searchDirs []string) error {
 	// Step 1: List all agents (Req 5.1)
-	agents, err := agent.List()
+	agents, err := agent.List(searchDirs)
 	if err != nil {
 		return &ExitError{Code: 2, Err: err}
 	}
@@ -220,7 +230,7 @@ func runAllAgentsGC(cmd *cobra.Command) error {
 	for _, cfg := range memoryAgents {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "=== GC: %s ===\n", cfg.Name)
 
-		if err := runSingleAgentGC(cmd, cfg.Name); err != nil {
+		if err := runSingleAgentGC(cmd, cfg.Name, searchDirs); err != nil {
 			// Per-agent failure: print error, continue (Req 5.5)
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: gc failed for agent %q: %v\n", cfg.Name, err)
 			failCount++

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -52,6 +52,7 @@ calling the LLM provider, and printing the response.`,
 func init() {
 	runCmd.Flags().String("skill", "", "Override the agent's default skill path")
 	runCmd.Flags().String("workdir", "", "Override the working directory")
+	runCmd.Flags().String("agents-dir", "", "Additional agents directory to search before global config")
 	runCmd.Flags().String("model", "", "Override the model (provider/model-name format)")
 	runCmd.Flags().Int("timeout", 120, "Request timeout in seconds")
 	runCmd.Flags().Bool("dry-run", false, "Show resolved context without calling the LLM")
@@ -98,8 +99,20 @@ func truncateOutput(s string) string {
 func runAgent(cmd *cobra.Command, args []string) error {
 	agentName := args[0]
 
+	// Get the agents-dir flag early (before workdir resolution)
+	flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")
+
+	// Get current working directory for initial agent search
+	cwd, err := os.Getwd()
+	if err != nil {
+		return &ExitError{Code: 2, Err: fmt.Errorf("failed to get working directory: %w", err)}
+	}
+
+	// Build search directories using cwd as base (workdir not resolved yet)
+	searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)
+
 	// Step 1: Load agent config
-	cfg, err := agent.Load(agentName)
+	cfg, err := agent.Load(agentName, searchDirs)
 	if err != nil {
 		return &ExitError{Code: 2, Err: err}
 	}
@@ -472,7 +485,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			req.Messages = append(req.Messages, assistantMsg)
 
 			// Execute tool calls
-			results := executeToolCalls(ctx, resp.ToolCalls, cfg, globalCfg, registry, mcpRouter, depth, effectiveMaxDepth, parallel, verbose, cmd.ErrOrStderr(), workdir, tracker)
+			results := executeToolCalls(ctx, resp.ToolCalls, cfg, globalCfg, registry, mcpRouter, depth, effectiveMaxDepth, parallel, verbose, cmd.ErrOrStderr(), workdir, tracker, flagAgentsDir, workdir)
 			totalToolCalls += len(resp.ToolCalls)
 
 			if jsonOutput {
@@ -671,7 +684,7 @@ func printDryRun(cmd *cobra.Command, cfg *agent.AgentConfig, provName, modelName
 
 // executeToolCalls dispatches tool calls and returns results.
 // When parallel is true and there are multiple calls, they run concurrently.
-func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *agent.AgentConfig, globalCfg *config.GlobalConfig, registry *tool.Registry, mcpRouter *mcpclient.Router, depth, maxDepth int, parallel, verbose bool, stderr io.Writer, workdir string, budgetTracker *budget.BudgetTracker) []provider.ToolResult {
+func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *agent.AgentConfig, globalCfg *config.GlobalConfig, registry *tool.Registry, mcpRouter *mcpclient.Router, depth, maxDepth int, parallel, verbose bool, stderr io.Writer, workdir string, budgetTracker *budget.BudgetTracker, agentsDir string, agentsBase string) []provider.ToolResult {
 	results := make([]provider.ToolResult, len(toolCalls))
 
 	execOpts := tool.ExecuteOptions{
@@ -685,6 +698,8 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 		Verbose:       verbose,
 		Stderr:        stderr,
 		BudgetTracker: budgetTracker,
+		AgentsDir:     agentsDir,
+		AgentsBase:    agentsBase,
 	}
 
 	if len(toolCalls) == 1 || !parallel {

--- a/docs/plans/038_local_agent_directory_implement.md
+++ b/docs/plans/038_local_agent_directory_implement.md
@@ -1,0 +1,138 @@
+# 038 — Local/Per-Repo Agent Directory: Implementation Guide
+
+**Spec:** `docs/plans/038_local_agent_directory_spec.md`
+
+---
+
+## Section 1: Context Summary
+
+Axe currently loads all agent TOML configs exclusively from `$XDG_CONFIG_HOME/axe/agents/`. Issue #28 adds support for a local per-repo directory (`./axe/agents/`) so that agent configs can live alongside the code they operate on — useful for git hooks, CI pipelines, and team-shared configs checked into version control. The resolution order is: `--agents-dir` flag (highest) → `./axe/agents/` auto-discovered from the applicable working directory → global XDG config (fallback). Non-existent directories are silently skipped. All 7 call sites of `agent.Load()` and `agent.List()` must be updated. The `ExecuteOptions` struct in `internal/tool/tool.go` must carry the agents-dir value so sub-agent delegation respects the same resolution order using the parent's resolved workdir as the auto-discovery base.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Phase 1 — Core: `agent.Load` and `agent.List` accept ordered search dirs
+
+- [x] **1.1** `internal/agent/agent.go`: Extract private helper `loadFromPath(path string) (*AgentConfig, error)` that reads, TOML-decodes, and validates a single file path. Returns the existing error messages unchanged.
+
+- [x] **1.2** `internal/agent/agent.go`: Change `Load(name string)` signature to `Load(name string, searchDirs []string) (*AgentConfig, error)`. The function iterates `searchDirs` in order, calling `loadFromPath` for `filepath.Join(dir, name+".toml")`. Skips any dir where the file does not exist (`os.IsNotExist`). Falls back to the global XDG dir (`xdg.GetConfigDir()` + `/agents`) as the final entry. Returns `"agent config not found: {name}"` only if no dir yields the file.
+
+- [x] **1.3** `internal/agent/agent.go`: Change `List(searchDirs []string) ([]AgentConfig, error)` to read `.toml` files from all dirs in `searchDirs` plus the global XDG dir (appended last). Deduplicates by agent name — first occurrence wins (earlier dir = higher precedence). Invalid files are silently skipped (existing behavior). Returns a merged flat slice.
+
+- [x] **1.4** `internal/agent/agent_test.go`: `TestLoad_LocalDirTakesPrecedence` — agent with same name in local dir and global dir; local version is returned.
+
+- [x] **1.5** `internal/agent/agent_test.go`: `TestLoad_FallsBackToGlobal` — agent not in local dir; global version is returned.
+
+- [x] **1.6** `internal/agent/agent_test.go`: `TestLoad_NonExistentSearchDir_Skipped` — non-existent dir in `searchDirs` is silently skipped; global version returned.
+
+- [x] **1.7** `internal/agent/agent_test.go`: `TestLoad_EmptySearchDirs_UsesGlobal` — `searchDirs = nil` or `[]string{}` falls back to global only.
+
+- [x] **1.8** `internal/agent/agent_test.go`: `TestLoad_MultipleSearchDirs_FirstWins` — two local dirs both contain the agent; first dir's version is returned.
+
+- [x] **1.9** `internal/agent/agent_test.go`: `TestList_MergesLocalAndGlobal` — agents in local dir and global dir are merged into one list.
+
+- [x] **1.10** `internal/agent/agent_test.go`: `TestList_LocalWinsOnNameCollision` — same agent name in local and global; local version appears in result, global version does not.
+
+- [x] **1.11** `internal/agent/agent_test.go`: `TestList_NonExistentSearchDir_Skipped` — non-existent dir in `searchDirs` produces no error and no agents from that dir.
+
+- [x] **1.12** `internal/agent/agent_test.go`: `TestList_EmptySearchDirs_UsesGlobal` — `searchDirs = nil` returns only global agents (backward compat).
+
+- [x] **1.13** Run `go test ./internal/agent/...` — all tests pass.
+
+---
+
+### Phase 2 — Helper: build search dirs from flag + auto-discovery
+
+- [x] **2.1** `internal/agent/agent.go`: Add exported function `BuildSearchDirs(flagDir string, baseDir string) []string`. Builds the ordered search dirs list:
+  1. If `flagDir` is non-empty, append it.
+  2. Append `filepath.Join(baseDir, "axe", "agents")` (auto-discovery path).
+  Returns the slice (may be empty; global is always appended by `Load`/`List` themselves). Does NOT check existence — callers pass whatever they have; `Load`/`List` skip non-existent dirs.
+
+- [x] **2.2** `internal/agent/agent_test.go`: `TestBuildSearchDirs_FlagAndBase` — both flag and base provided; returns `[flagDir, baseDir/axe/agents]`.
+
+- [x] **2.3** `internal/agent/agent_test.go`: `TestBuildSearchDirs_NoFlag` — empty flag; returns `[baseDir/axe/agents]`.
+
+- [x] **2.4** `internal/agent/agent_test.go`: `TestBuildSearchDirs_EmptyFlag_EmptyBase` — both empty; returns `["axe/agents"]` (relative path from empty base is `filepath.Join("", "axe", "agents")`).
+
+- [x] **2.5** Run `go test ./internal/agent/...` — all tests pass.
+
+---
+
+### Phase 3 — `cmd/run.go`: wire `--agents-dir` flag
+
+- [x] **3.1** `cmd/run.go` `init()`: Add flag `runCmd.Flags().String("agents-dir", "", "Additional agents directory to search before global config")`.
+
+- [x] **3.2** `cmd/run.go` `runAgent()`: After resolving `workdir` (step 6, line ~132), read `flagAgentsDir, _ := cmd.Flags().GetString("agents-dir")` and build `searchDirs := agent.BuildSearchDirs(flagAgentsDir, workdir)`. Pass `searchDirs` to `agent.Load(agentName, searchDirs)` at line ~102.
+
+- [x] **3.3** `cmd/run.go` `executeToolCalls()`: Add `AgentsDir string` and `AgentsBase string` to the function signature (or thread via `ExecuteOptions` — see Phase 5). Pass `flagAgentsDir` and `workdir` through so sub-agents can use the same resolution.
+
+- [x] **3.4** `cmd/run.go`: Existing tests in `cmd/run_test.go` or `cmd/run_integration_test.go` must still pass unchanged (backward compat: no `--agents-dir` = same behavior as before).
+
+---
+
+### Phase 4 — `cmd/agents.go`: wire `--agents-dir` flag to all subcommands
+
+- [x] **4.1** `cmd/agents.go` `init()`: Add `agentsCmd.PersistentFlags().String("agents-dir", "", "Additional agents directory to search before global config")`. Persistent so all subcommands inherit it.
+
+- [x] **4.2** `cmd/agents.go` `agentsListCmd`: Read `flagAgentsDir` from the persistent flag. Get cwd via `os.Getwd()`. Build `searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)`. Pass to `agent.List(searchDirs)`.
+
+- [x] **4.3** `cmd/agents.go` `agentsShowCmd`: Same pattern — read flag, get cwd, build `searchDirs`, pass to `agent.Load(args[0], searchDirs)`.
+
+- [x] **4.4** `cmd/agents.go` `agentsInitCmd`: Determine write target:
+  1. If `flagAgentsDir` non-empty → use it.
+  2. Else if `filepath.Join(cwd, "axe", "agents")` exists → use it.
+  3. Else → use `filepath.Join(configDir, "agents")` (global).
+  Create the target directory with `os.MkdirAll(targetDir, 0755)`. Check for existing file before writing. Print the final path to stdout.
+
+- [x] **4.5** `cmd/agents.go` `agentsEditCmd`: Read flag, get cwd, build `searchDirs`, find the agent file path by iterating `searchDirs` + global dir (same order as `Load`). Open the found path in `$EDITOR`. Return error if not found.
+
+---
+
+### Phase 5 — `internal/tool/tool.go`: propagate agents-dir to sub-agents
+
+- [x] **5.1** `internal/tool/tool.go` `ExecuteOptions`: Add two fields:
+  ```go
+  AgentsDir  string // value of --agents-dir flag (may be empty)
+  AgentsBase string // parent agent's resolved workdir (for auto-discovery)
+  ```
+
+- [x] **5.2** `internal/tool/tool.go` `ExecuteCallAgent()`: After resolving the sub-agent's `workdir` (step 8, line ~146), build `searchDirs := agent.BuildSearchDirs(opts.AgentsDir, opts.AgentsBase)` and pass to `agent.Load(agentName, searchDirs)`.
+
+- [x] **5.3** `internal/tool/tool.go` `runConversationLoop()` (line ~395, `subOpts` construction): Propagate `AgentsDir` and `AgentsBase` from `opts` into `subOpts`. Use the sub-agent's resolved `workdir` as the new `AgentsBase` for the next level.
+
+- [x] **5.4** `cmd/run.go` `executeToolCalls()`: Populate `execOpts.AgentsDir = flagAgentsDir` and `execOpts.AgentsBase = workdir` when constructing `tool.ExecuteOptions` (line ~677).
+
+- [x] **5.5** `internal/tool/tool_test.go`: `TestExecuteCallAgent_LocalDirPropagated` — set `opts.AgentsBase` to a temp dir containing `axe/agents/sub-agent.toml`; verify the sub-agent is loaded from there rather than global. Use the existing mock server infrastructure.
+
+- [x] **5.6** Run `go test ./internal/tool/...` — all tests pass.
+
+---
+
+### Phase 6 — `cmd/gc.go`: wire `--agents-dir` flag
+
+- [x] **6.1** `cmd/gc.go` `init()`: Add `gcCmd.Flags().String("agents-dir", "", "Additional agents directory to search before global config")`.
+
+- [x] **6.2** `cmd/gc.go` `runGC()`: Read `flagAgentsDir`. Get cwd via `os.Getwd()`. Build `searchDirs := agent.BuildSearchDirs(flagAgentsDir, cwd)`. Pass to both `agent.Load()` (in `runSingleAgentGC`) and `agent.List()` (in `runAllAgentsGC`). Thread `searchDirs` through as a parameter to both functions.
+
+- [x] **6.3** `cmd/gc.go` `runSingleAgentGC(cmd, agentName string, searchDirs []string)`: Update signature to accept `searchDirs`. Pass to `agent.Load(agentName, searchDirs)`.
+
+- [x] **6.4** `cmd/gc.go` `runAllAgentsGC(cmd, searchDirs []string)`: Update signature to accept `searchDirs`. Pass to `agent.List(searchDirs)`. Pass `searchDirs` to each `runSingleAgentGC` call.
+
+- [x] **6.5** Run `go test ./cmd/...` — all tests pass.
+
+---
+
+### Phase 7 — Final validation
+
+- [ ] **7.1** Run `go build ./...` — no compilation errors.
+
+- [ ] **7.2** Run `go test ./...` — all tests pass.
+
+- [ ] **7.3** Run `go vet ./...` — no issues.
+
+- [ ] **7.4** Manual smoke: create `./axe/agents/local-test.toml` in a temp dir with a valid minimal config. Run `axe agents list` from that dir — `local-test` appears. Run `axe agents show local-test` — shows config. Run `axe run local-test` (with a mock or dry-run) — loads from local dir.
+
+- [ ] **7.5** Manual smoke: create the same agent name in both `./axe/agents/` and global config with different descriptions. Run `axe agents show <name>` — local version's description is shown.
+
+- [ ] **7.6** Manual smoke: run `axe agents list` from a dir with no `./axe/agents/` — output identical to current behavior.

--- a/docs/plans/038_local_agent_directory_spec.md
+++ b/docs/plans/038_local_agent_directory_spec.md
@@ -1,0 +1,148 @@
+# 038 — Local/Per-Repo Agent Directory
+
+**GitHub Issue:** [#28](https://github.com/jrswab/axe/issues/28)
+
+---
+
+## Section 1: Context & Constraints
+
+### Milestone
+
+Allow axe to load agent configs from a local directory (`./axe/agents/`) in addition to the global XDG config directory (`$XDG_CONFIG_HOME/axe/agents/`). Add an `--agents-dir` flag for explicit override.
+
+### Research Findings
+
+#### Current Agent Loading
+
+`agent.Load(name string)` resolves a single path:
+
+```
+$XDG_CONFIG_HOME/axe/agents/{name}.toml
+```
+
+`agent.List()` reads all `.toml` files from that same directory.
+
+Both functions are called from 7 sites:
+
+| Call Site | Function | Purpose |
+|---|---|---|
+| `cmd/run.go:102` | `agent.Load()` | Load agent for `axe run` |
+| `cmd/agents.go:27` | `agent.List()` | `axe agents list` |
+| `cmd/agents.go:53` | `agent.Load()` | `axe agents show` |
+| `cmd/agents.go:121` | manual path build | `axe agents init` |
+| `cmd/agents.go:163` | manual path build | `axe agents edit` |
+| `cmd/gc.go:67,200` | `agent.Load()`, `agent.List()` | `axe gc` |
+| `internal/tool/tool.go:134` | `agent.Load()` | `call_agent` sub-agent delegation |
+
+#### Decisions Made
+
+1. **Auto-discovery enabled.** If `./axe/agents/` exists relative to the working directory, it is automatically consulted before the global directory. No flag required.
+2. **`--agents-dir` flag available.** Explicit flag for custom paths. Takes highest precedence.
+3. **Local directory structure mirrors global.** `./axe/agents/*.toml` — not `./axe/*.toml`. Leaves room for `./axe/skills/` in the future.
+4. **Sub-agents follow the same rules.** `call_agent` uses the parent agent's resolved workdir as the base for `./axe/agents/` discovery.
+5. **`gc` follows the same rules.** Both `agent.Load()` and `agent.List()` calls in `gc` use the same resolution order.
+6. **`agents list` does not indicate source.** Output remains clean and pipeable — just names (and descriptions). No `(local)` / `(global)` markers.
+7. **`agents init` writes locally when `./axe/agents/` exists.** If `--agents-dir` is set, write there. Else if `./axe/agents/` exists in cwd, write there. Else write to global.
+
+#### Approaches Ruled Out
+
+- **Variadic `localDirs ...string` parameter on `Load`/`List`.** While discussed, the actual resolution logic (auto-discover + flag) belongs at the call site, not in the function signature. The function should accept a clear, ordered list of directories to search.
+- **Persistent flag on `agentsCmd` only.** The flag is also needed on `run` and `gc`, so it cannot live only on the agents parent command.
+- **`./axe/` without `agents/` subdirectory.** Ruled out to mirror global structure and leave room for future local skills.
+
+#### Constraints
+
+- **Resolution order is: `--agents-dir` > `./axe/agents/` (auto-discovered) > `$XDG_CONFIG_HOME/axe/agents/` (global).** First match wins. This follows the existing pattern: flags override TOML overrides defaults.
+- **Auto-discovery base directory:**
+  - For `axe run`: the resolved working directory (after `--workdir` / TOML `workdir` / cwd resolution).
+  - For `call_agent` (sub-agents): the parent agent's resolved working directory.
+  - For `axe agents list/show/init/edit`: the process's current working directory.
+  - For `axe gc`: the process's current working directory.
+- **Non-existent directories are silently skipped.** If `--agents-dir` points to a path that doesn't exist, or `./axe/agents/` doesn't exist, skip it and continue to the next directory in the resolution order. No error, no warning.
+- **The `--agents-dir` flag value is an absolute or relative path to a directory containing `.toml` files directly** (not a path that needs `/agents` appended). If the user passes `--agents-dir ./custom`, axe looks for `./custom/{name}.toml`.
+- **Backward compatibility.** All existing behavior is preserved when no local directory exists and no flag is passed. The global directory remains the final fallback.
+
+---
+
+## Section 2: Requirements
+
+### Requirement 1: Agent Resolution Order
+
+When loading an agent by name, the system must search directories in this order:
+
+1. The directory specified by `--agents-dir` (if the flag is provided and non-empty)
+2. `./axe/agents/` relative to the applicable working directory (auto-discovery)
+3. `$XDG_CONFIG_HOME/axe/agents/` (global fallback)
+
+The first directory containing `{name}.toml` wins. If no directory contains the file, return an error: `"agent config not found: {name}"`.
+
+### Requirement 2: Agent Listing Merges All Sources
+
+When listing agents, the system must read `.toml` files from all directories in the resolution order and merge results. If the same agent name appears in multiple directories, the version from the higher-precedence directory wins (earlier in the list). The merged list is returned as a single flat list with no source indicators.
+
+### Requirement 3: Auto-Discovery of `./axe/agents/`
+
+The system must automatically check for a `./axe/agents/` directory relative to the applicable base directory:
+
+- **`axe run`**: base = the resolved working directory (after `--workdir` / TOML `workdir` / cwd fallback)
+- **`call_agent` tool**: base = the parent agent's resolved working directory
+- **`axe agents list/show/init/edit`**: base = the process's current working directory (`os.Getwd()`)
+- **`axe gc`**: base = the process's current working directory
+
+If the directory does not exist, it is silently skipped. No error, no warning, no creation.
+
+### Requirement 4: `--agents-dir` Flag
+
+A `--agents-dir` flag must be available on:
+
+- `axe run`
+- `axe agents list`
+- `axe agents show`
+- `axe agents init`
+- `axe agents edit`
+- `axe gc`
+
+The flag accepts a path to a directory containing `.toml` agent files. The path may be absolute or relative (resolved from cwd). If the directory does not exist, it is silently skipped (same as auto-discovery).
+
+### Requirement 5: `agents init` Write Location
+
+When creating a new agent with `axe agents init`:
+
+1. If `--agents-dir` is provided → write to that directory
+2. Else if `./axe/agents/` exists in cwd → write there
+3. Else → write to `$XDG_CONFIG_HOME/axe/agents/` (global)
+
+The target directory must be created (with `0755` permissions) if it does not exist. If the agent file already exists at the resolved path, return an error: `"agent config already exists: {path}"`.
+
+### Requirement 6: `agents edit` Path Resolution
+
+When editing an agent with `axe agents edit`, the system must find the agent file using the same resolution order as `Load` (Requirement 1). The editor opens the file at the path where it was found. If the agent is not found in any directory, return an error.
+
+### Requirement 7: Sub-Agent Delegation
+
+The `call_agent` tool must pass the local directory resolution context to `agent.Load()`. The auto-discovery base is the parent agent's resolved working directory. If the parent agent was invoked with `--agents-dir`, that value must also propagate to sub-agent loading.
+
+### Requirement 8: Backward Compatibility
+
+When no `--agents-dir` flag is provided and no `./axe/agents/` directory exists in the applicable working directory, all behavior must be identical to the current implementation. No new directories are created. No new errors are produced. No output changes.
+
+### Edge Cases
+
+| Scenario | Expected Behavior |
+|---|---|
+| `--agents-dir` points to non-existent directory | Silently skip, continue to next source |
+| `./axe/agents/` does not exist | Silently skip, continue to global |
+| Agent exists in both local and global | Local version is used |
+| Agent exists only in global | Global version is used |
+| Agent exists in `--agents-dir` and `./axe/agents/` | `--agents-dir` version is used |
+| `agents list` with agents in both local and global | Merged list, local wins on name collision |
+| `agents init` with `--agents-dir` pointing to non-existent dir | Create the directory, then write the file |
+| `agents init` when agent exists in local but not global | Error: "agent config already exists: {local_path}" |
+| `agents init` when agent exists in global but `./axe/agents/` exists | Write to local (no collision in local dir) |
+| `agents edit` when agent exists in both local and global | Edit the local version (higher precedence) |
+| `--agents-dir ""` (empty string) | Treated as not provided; skip to auto-discovery |
+| `call_agent` with parent workdir `/project` | Auto-discovers `/project/axe/agents/` |
+| `axe run --workdir /other` | Auto-discovers `/other/axe/agents/` |
+| `./axe/agents/` is a symlink to a directory | Follow the symlink (standard OS behavior) |
+| `./axe/agents/` exists but is empty | No agents found there; fall through to global |
+| `./axe/agents/` contains invalid TOML files | Skip invalid files (existing behavior preserved) |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,6 +13,15 @@ import (
 	"github.com/jrswab/axe/internal/xdg"
 )
 
+// ValidationError represents an agent configuration validation failure.
+type ValidationError struct {
+	msg string
+}
+
+func (e *ValidationError) Error() string {
+	return e.msg
+}
+
 // MemoryConfig holds memory sub-configuration for an agent.
 type MemoryConfig struct {
 	Enabled    bool   `toml:"enabled"`
@@ -79,105 +88,95 @@ type AgentConfig struct {
 // without checking model.
 func Validate(cfg *AgentConfig) error {
 	if strings.TrimSpace(cfg.Name) == "" {
-		return errors.New("agent config missing required field: name")
+		return &ValidationError{msg: "agent config missing required field: name"}
 	}
 	if strings.TrimSpace(cfg.Model) == "" {
-		return errors.New("agent config missing required field: model")
+		return &ValidationError{msg: "agent config missing required field: model"}
 	}
 	if cfg.SubAgentsConf.MaxDepth < 0 {
-		return errors.New("sub_agents_config.max_depth must be non-negative")
+		return &ValidationError{msg: "sub_agents_config.max_depth must be non-negative"}
 	}
 	if cfg.SubAgentsConf.MaxDepth > 5 {
-		return errors.New("sub_agents_config.max_depth cannot exceed 5")
+		return &ValidationError{msg: "sub_agents_config.max_depth cannot exceed 5"}
 	}
 	if cfg.SubAgentsConf.Timeout < 0 {
-		return errors.New("sub_agents_config.timeout must be non-negative")
+		return &ValidationError{msg: "sub_agents_config.timeout must be non-negative"}
 	}
 	if cfg.Memory.LastN < 0 {
-		return errors.New("memory.last_n must be non-negative")
+		return &ValidationError{msg: "memory.last_n must be non-negative"}
 	}
 	if cfg.Memory.MaxEntries < 0 {
-		return errors.New("memory.max_entries must be non-negative")
+		return &ValidationError{msg: "memory.max_entries must be non-negative"}
 	}
 	validTools := toolname.ValidNames()
 	for _, name := range cfg.Tools {
 		if !validTools[name] {
-			return fmt.Errorf("unknown tool %q in tools config", name)
+			return &ValidationError{msg: fmt.Sprintf("unknown tool %q in tools config", name)}
 		}
 	}
 
 	seenMCPNames := make(map[string]struct{}, len(cfg.MCPServers))
 	for i, server := range cfg.MCPServers {
 		if strings.TrimSpace(server.Name) == "" {
-			return fmt.Errorf("mcp_servers[%d].name is required", i)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].name is required", i)}
 		}
 		if strings.TrimSpace(server.URL) == "" {
-			return fmt.Errorf("mcp_servers[%d].url is required", i)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].url is required", i)}
 		}
 		parsedURL, err := url.ParseRequestURI(strings.TrimSpace(server.URL))
 		if err != nil {
-			return fmt.Errorf("mcp_servers[%d].url is invalid: %v", i, err)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].url is invalid: %v", i, err)}
 		}
 		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			return fmt.Errorf("mcp_servers[%d].url must use http or https scheme, got %q", i, parsedURL.Scheme)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].url must use http or https scheme, got %q", i, parsedURL.Scheme)}
 		}
 		if parsedURL.Host == "" {
-			return fmt.Errorf("mcp_servers[%d].url must include a host", i)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].url must include a host", i)}
 		}
 		if server.Transport != "sse" && server.Transport != "streamable-http" {
-			return fmt.Errorf("mcp_servers[%d].transport must be one of: sse, streamable-http", i)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers[%d].transport must be one of: sse, streamable-http", i)}
 		}
 		if _, exists := seenMCPNames[server.Name]; exists {
-			return fmt.Errorf("mcp_servers names must be unique: %q", server.Name)
+			return &ValidationError{msg: fmt.Sprintf("mcp_servers names must be unique: %q", server.Name)}
 		}
 		seenMCPNames[server.Name] = struct{}{}
 	}
 
 	if cfg.Retry.MaxRetries < 0 {
-		return errors.New("retry.max_retries must be non-negative")
+		return &ValidationError{msg: "retry.max_retries must be non-negative"}
 	}
 	if cfg.Retry.Backoff != "" && cfg.Retry.Backoff != "exponential" && cfg.Retry.Backoff != "linear" && cfg.Retry.Backoff != "fixed" {
-		return errors.New("retry.backoff must be one of: exponential, linear, fixed")
+		return &ValidationError{msg: "retry.backoff must be one of: exponential, linear, fixed"}
 	}
 	if cfg.Retry.InitialDelayMs < 0 {
-		return errors.New("retry.initial_delay_ms must be non-negative")
+		return &ValidationError{msg: "retry.initial_delay_ms must be non-negative"}
 	}
 	if cfg.Retry.MaxDelayMs < 0 {
-		return errors.New("retry.max_delay_ms must be non-negative")
+		return &ValidationError{msg: "retry.max_delay_ms must be non-negative"}
 	}
 	if cfg.Retry.InitialDelayMs > 0 && cfg.Retry.MaxDelayMs > 0 && cfg.Retry.MaxDelayMs < cfg.Retry.InitialDelayMs {
-		return errors.New("retry.max_delay_ms must be >= retry.initial_delay_ms")
+		return &ValidationError{msg: "retry.max_delay_ms must be >= retry.initial_delay_ms"}
 	}
 
 	if cfg.Budget.MaxTokens < 0 {
-		return errors.New("budget.max_tokens must be non-negative")
+		return &ValidationError{msg: "budget.max_tokens must be non-negative"}
 	}
 
 	return nil
 }
 
-// Load reads and parses an agent TOML configuration file by name.
-// The name parameter is the agent name without the .toml extension.
-func Load(name string) (*AgentConfig, error) {
-	configDir, err := xdg.GetConfigDir()
+// loadFromPath reads and parses an agent TOML configuration file from a specific path.
+// It returns the raw read/parse/validate errors (without any wrapping) so the caller
+// can handle them appropriately.
+func loadFromPath(path string) (*AgentConfig, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	path := filepath.Join(configDir, "agents", name+".toml")
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, fmt.Errorf("agent config not found: %s", name)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read agent config %q: %w", name, err)
-	}
-
 	var cfg AgentConfig
 	if _, err := toml.Decode(string(data), &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse agent config %q: %w", name, err)
+		return nil, err
 	}
 
 	if err := Validate(&cfg); err != nil {
@@ -187,39 +186,109 @@ func Load(name string) (*AgentConfig, error) {
 	return &cfg, nil
 }
 
-// List returns all valid agent configurations from the agents directory.
-// Invalid files are silently skipped. If the agents directory does not exist,
-// an empty slice is returned.
-func List() ([]AgentConfig, error) {
+// Load reads and parses an agent TOML configuration file by name.
+// The name parameter is the agent name without the .toml extension.
+// searchDirs is a list of directories to search first, before falling back to the global XDG config dir.
+func Load(name string, searchDirs []string) (*AgentConfig, error) {
+	// Validate name: must be non-empty and must not contain path separators or traversal sequences
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("agent name must not be empty")
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return nil, fmt.Errorf("agent name %q must not contain path separators or traversal sequences", name)
+	}
+	for _, dir := range searchDirs {
+		path := filepath.Join(dir, name+".toml")
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue // file doesn't exist in this dir, try next
+			}
+			// File exists but failed to load (parse error, validation error, etc.)
+			// Check if it's a validation error - pass through unchanged
+			var valErr *ValidationError
+			if errors.As(err, &valErr) {
+				return nil, err
+			}
+			// Wrap other errors with context
+			return nil, fmt.Errorf("failed to parse agent config %q: %w", name, err)
+		}
+		return cfg, nil
+	}
+
+	// Fall back to global XDG config dir
 	configDir, err := xdg.GetConfigDir()
 	if err != nil {
 		return nil, err
 	}
-
-	agentsDir := filepath.Join(configDir, "agents")
-
-	entries, err := os.ReadDir(agentsDir)
+	path := filepath.Join(configDir, "agents", name+".toml")
+	cfg, err := loadFromPath(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return []AgentConfig{}, nil
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("agent config not found: %s", name)
 		}
+		var valErr *ValidationError
+		if errors.As(err, &valErr) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to parse agent config %q: %w", name, err)
+	}
+	return cfg, nil
+}
+
+// List returns all valid agent configurations from the agents directory.
+// Invalid files are silently skipped. If the agents directory does not exist,
+// an empty slice is returned.
+// searchDirs is a list of directories to search first, before falling back to the global XDG config dir.
+func List(searchDirs []string) ([]AgentConfig, error) {
+	seen := make(map[string]struct{})
+	var agents []AgentConfig
+
+	// Collect all directories to search: searchDirs first, then global XDG dir
+	var allDirs []string
+	allDirs = append(allDirs, searchDirs...)
+
+	configDir, err := xdg.GetConfigDir()
+	if err != nil {
 		return nil, err
 	}
+	allDirs = append(allDirs, filepath.Join(configDir, "agents"))
 
-	var agents []AgentConfig
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if !strings.HasSuffix(entry.Name(), ".toml") {
-			continue
-		}
-		name := strings.TrimSuffix(entry.Name(), ".toml")
-		cfg, err := Load(name)
+	// Process directories in order (earlier = higher precedence)
+	for _, agentsDir := range allDirs {
+		entries, err := os.ReadDir(agentsDir)
 		if err != nil {
-			continue // skip invalid files
+			// Silently skip non-existent directories
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
 		}
-		agents = append(agents, *cfg)
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if !strings.HasSuffix(entry.Name(), ".toml") {
+				continue
+			}
+			name := strings.TrimSuffix(entry.Name(), ".toml")
+
+			// Skip if we've already seen this agent name (first occurrence wins)
+			if _, exists := seen[name]; exists {
+				continue
+			}
+
+			// Try to load from this specific path
+			path := filepath.Join(agentsDir, entry.Name())
+			cfg, err := loadFromPath(path)
+			if err != nil {
+				continue // skip invalid files
+			}
+
+			seen[name] = struct{}{}
+			agents = append(agents, *cfg)
+		}
 	}
 
 	return agents, nil
@@ -285,6 +354,18 @@ model = "provider/model-name"
 # max_tokens = 0
 `
 	return tmpl, nil
+}
+
+// BuildSearchDirs builds the search directories slice from a flag value and base directory.
+// If flagDir is non-empty, it is appended as the first element.
+// The auto-discovery path (baseDir/axe/agents) is always appended.
+func BuildSearchDirs(flagDir string, baseDir string) []string {
+	var dirs []string
+	if flagDir != "" {
+		dirs = append(dirs, flagDir)
+	}
+	dirs = append(dirs, filepath.Join(baseDir, "axe", "agents"))
+	return dirs
 }
 
 // tomlDecode is a package-level wrapper for toml.Decode, used by tests.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -122,7 +122,7 @@ max_tokens = 4096
 `
 	writeAgentFile(t, agentsDir, "full-agent", tomlContent)
 
-	cfg, err := Load("full-agent")
+	cfg, err := Load("full-agent", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -174,7 +174,7 @@ model = "openai/gpt-4o"
 `
 	writeAgentFile(t, agentsDir, "minimal", tomlContent)
 
-	cfg, err := Load("minimal")
+	cfg, err := Load("minimal", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -220,7 +220,7 @@ model = "openai/gpt-4o"
 func TestLoad_MissingFile(t *testing.T) {
 	_ = setupAgentsDir(t)
 
-	_, err := Load("nonexistent")
+	_, err := Load("nonexistent", nil)
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -235,7 +235,7 @@ func TestLoad_MalformedTOML(t *testing.T) {
 
 	writeAgentFile(t, agentsDir, "bad", "this is not [valid toml =")
 
-	_, err := Load("bad")
+	_, err := Load("bad", nil)
 	if err == nil {
 		t.Fatal("expected error for malformed TOML, got nil")
 	}
@@ -249,7 +249,7 @@ func TestLoad_MissingName(t *testing.T) {
 
 	writeAgentFile(t, agentsDir, "noname", `model = "anthropic/claude-sonnet-4-20250514"`)
 
-	_, err := Load("noname")
+	_, err := Load("noname", nil)
 	if err == nil {
 		t.Fatal("expected validation error for missing name, got nil")
 	}
@@ -264,7 +264,7 @@ func TestLoad_MissingModel(t *testing.T) {
 
 	writeAgentFile(t, agentsDir, "nomodel", `name = "nomodel"`)
 
-	_, err := Load("nomodel")
+	_, err := Load("nomodel", nil)
 	if err == nil {
 		t.Fatal("expected validation error for missing model, got nil")
 	}
@@ -283,7 +283,7 @@ model = "anthropic/claude-sonnet-4-20250514"
 `
 	writeAgentFile(t, agentsDir, "wsname", tomlContent)
 
-	_, err := Load("wsname")
+	_, err := Load("wsname", nil)
 	if err == nil {
 		t.Fatal("expected validation error for whitespace name, got nil")
 	}
@@ -302,7 +302,7 @@ model = "   "
 `
 	writeAgentFile(t, agentsDir, "wsmodel", tomlContent)
 
-	_, err := Load("wsmodel")
+	_, err := Load("wsmodel", nil)
 	if err == nil {
 		t.Fatal("expected validation error for whitespace model, got nil")
 	}
@@ -317,7 +317,7 @@ model = "   "
 func TestList_EmptyDirectory(t *testing.T) {
 	_ = setupAgentsDir(t) // creates empty agents/
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestList_NoDirectory(t *testing.T) {
 		t.Fatalf("failed to create axe dir: %v", err)
 	}
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestList_MultipleAgents(t *testing.T) {
 	writeAgentFile(t, agentsDir, "alpha", `name = "alpha"`+"\n"+`model = "openai/gpt-4o"`)
 	writeAgentFile(t, agentsDir, "beta", `name = "beta"`+"\n"+`model = "anthropic/claude-sonnet-4-20250514"`)
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestList_SkipsInvalidFiles(t *testing.T) {
 	writeAgentFile(t, agentsDir, "good", `name = "good"`+"\n"+`model = "openai/gpt-4o"`)
 	writeAgentFile(t, agentsDir, "bad", "not valid toml [[[")
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestList_IgnoresNonTOML(t *testing.T) {
 		t.Fatalf("failed to write .md file: %v", err)
 	}
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -402,7 +402,7 @@ func TestList_IgnoresSubdirectories(t *testing.T) {
 		t.Fatalf("failed to create subdir: %v", err)
 	}
 
-	agents, err := List()
+	agents, err := List(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -428,7 +428,7 @@ timeout = 120
 `
 	writeAgentFile(t, agentsDir, "parent", tomlContent)
 
-	cfg, err := Load("parent")
+	cfg, err := Load("parent", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -454,7 +454,7 @@ sub_agents = ["helper"]
 `
 	writeAgentFile(t, agentsDir, "minimal-parent", tomlContent)
 
-	cfg, err := Load("minimal-parent")
+	cfg, err := Load("minimal-parent", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -547,7 +547,7 @@ max_entries = 50
 `
 	writeAgentFile(t, agentsDir, "mem-agent", tomlContent)
 
-	cfg, err := Load("mem-agent")
+	cfg, err := Load("mem-agent", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -575,7 +575,7 @@ model = "openai/gpt-4o"
 `
 	writeAgentFile(t, agentsDir, "no-mem", tomlContent)
 
-	cfg, err := Load("no-mem")
+	cfg, err := Load("no-mem", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -748,7 +748,7 @@ tools = ["read_file", "list_directory"]
 `
 	writeAgentFile(t, agentsDir, "tooled", tomlContent)
 
-	cfg, err := Load("tooled")
+	cfg, err := Load("tooled", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -773,7 +773,7 @@ model = "openai/gpt-4o"
 `
 	writeAgentFile(t, agentsDir, "no-tools", tomlContent)
 
-	cfg, err := Load("no-tools")
+	cfg, err := Load("no-tools", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -793,7 +793,7 @@ tools = []
 `
 	writeAgentFile(t, agentsDir, "empty-tools", tomlContent)
 
-	cfg, err := Load("empty-tools")
+	cfg, err := Load("empty-tools", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1145,7 +1145,7 @@ transport = "sse"
 `
 	writeAgentFile(t, agentsDir, "mcp-agent", tomlContent)
 
-	cfg, err := Load("mcp-agent")
+	cfg, err := Load("mcp-agent", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1185,7 +1185,7 @@ model = "openai/gpt-4o"
 `
 	writeAgentFile(t, agentsDir, "no-mcp", tomlContent)
 
-	cfg, err := Load("no-mcp")
+	cfg, err := Load("no-mcp", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1613,7 +1613,7 @@ max_tokens = 8000
 		t.Run(tc.name, func(t *testing.T) {
 			agentsDir := setupAgentsDir(t)
 			writeAgentFile(t, agentsDir, tc.agentName, tc.tomlContent)
-			cfg, err := Load(tc.agentName)
+			cfg, err := Load(tc.agentName, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1642,5 +1642,145 @@ func TestScaffold_IncludesBudgetConfig(t *testing.T) {
 				t.Errorf("scaffold output missing %q\nfull output:\n%s", tc.want, out)
 			}
 		})
+	}
+}
+
+// --- Phase 1 Multi-Directory Search Tests ---
+
+func TestLoad_LocalDirTakesPrecedence(t *testing.T) {
+	// Setup global XDG dir
+	globalDir := setupAgentsDir(t)
+	// Setup local dir
+	localDir := filepath.Join(t.TempDir(), "local")
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		t.Fatalf("failed to create local dir: %v", err)
+	}
+
+	// Write agent to global dir
+	writeAgentFile(t, globalDir, "myagent", `name = "myagent"`+"\n"+`model = "openai/gpt-4o"`+"\n"+`description = "global version"`)
+	// Write agent to local dir (different description)
+	localAgentPath := filepath.Join(localDir, "myagent.toml")
+	if err := os.WriteFile(localAgentPath, []byte(`name = "myagent"`+"\n"+`model = "openai/gpt-4o"`+"\n"+`description = "local version"`), 0644); err != nil {
+		t.Fatalf("failed to write local agent file: %v", err)
+	}
+
+	// Load with local dir first - should get local version
+	cfg, err := Load("myagent", []string{localDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Description != "local version" {
+		t.Errorf("expected local version, got %q", cfg.Description)
+	}
+}
+
+func TestLoad_FallsBackToGlobal(t *testing.T) {
+	// Setup global XDG dir
+	globalDir := setupAgentsDir(t)
+	// Setup local dir (but don't put the agent there)
+	localDir := filepath.Join(t.TempDir(), "local")
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		t.Fatalf("failed to create local dir: %v", err)
+	}
+
+	// Write agent only to global dir
+	writeAgentFile(t, globalDir, "myagent", `name = "myagent"`+"\n"+`model = "openai/gpt-4o"`)
+
+	// Load with local dir first - should fall back to global
+	cfg, err := Load("myagent", []string{localDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Name != "myagent" {
+		t.Errorf("expected name 'myagent', got %q", cfg.Name)
+	}
+}
+
+func TestLoad_NonExistentSearchDir_Skipped(t *testing.T) {
+	// Setup global XDG dir
+	globalDir := setupAgentsDir(t)
+	// Non-existent local dir
+	nonExistentDir := filepath.Join(t.TempDir(), "doesnotexist")
+
+	// Write agent only to global dir
+	writeAgentFile(t, globalDir, "myagent", `name = "myagent"`+"\n"+`model = "openai/gpt-4o"`)
+
+	// Load with non-existent dir first - should skip and use global
+	cfg, err := Load("myagent", []string{nonExistentDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Name != "myagent" {
+		t.Errorf("expected name 'myagent', got %q", cfg.Name)
+	}
+}
+
+func TestLoad_EmptyName_ReturnsError(t *testing.T) {
+	_ = setupAgentsDir(t)
+	_, err := Load("", nil)
+	if err == nil {
+		t.Fatal("expected error for empty name, got nil")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("got %q, want error containing 'must not be empty'", err.Error())
+	}
+}
+
+func TestLoad_PathTraversal_ReturnsError(t *testing.T) {
+	_ = setupAgentsDir(t)
+	cases := []string{"../foo", "foo/bar", "foo\\bar", ".."}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Load(name, nil)
+			if err == nil {
+				t.Fatalf("expected error for name %q, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "must not contain path separators") {
+				t.Errorf("got %q, want error containing 'must not contain path separators'", err.Error())
+			}
+		})
+	}
+}
+
+func TestBuildSearchDirs_FlagAndBase(t *testing.T) {
+	flagDir := "/custom/agents"
+	baseDir := "/project"
+	got := BuildSearchDirs(flagDir, baseDir)
+	want := []string{"/custom/agents", "/project/axe/agents"}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 dirs, got %d: %v", len(got), got)
+	}
+	if got[0] != want[0] {
+		t.Errorf("dir[0] = %q, want %q", got[0], want[0])
+	}
+	if got[1] != want[1] {
+		t.Errorf("dir[1] = %q, want %q", got[1], want[1])
+	}
+}
+
+func TestBuildSearchDirs_NoFlag(t *testing.T) {
+	flagDir := ""
+	baseDir := "/project"
+	got := BuildSearchDirs(flagDir, baseDir)
+	want := []string{"/project/axe/agents"}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 dir, got %d: %v", len(got), got)
+	}
+	if got[0] != want[0] {
+		t.Errorf("dir[0] = %q, want %q", got[0], want[0])
+	}
+}
+
+func TestBuildSearchDirs_EmptyFlag_EmptyBase(t *testing.T) {
+	flagDir := ""
+	baseDir := ""
+	got := BuildSearchDirs(flagDir, baseDir)
+	want := "axe/agents"
+	if len(got) != 1 {
+		t.Fatalf("expected 1 dir, got %d: %v", len(got), got)
+	}
+	// filepath.Join("", "axe", "agents") returns "axe/agents" on Unix
+	if got[0] != want {
+		t.Errorf("dir[0] = %q, want %q", got[0], want)
 	}
 }

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -36,6 +36,8 @@ type ExecuteOptions struct {
 	Verbose       bool
 	Stderr        io.Writer
 	BudgetTracker *budget.BudgetTracker
+	AgentsDir     string // value of --agents-dir flag (may be empty)
+	AgentsBase    string // parent agent's resolved workdir (for auto-discovery)
 }
 
 // CallAgentTool returns the call_agent tool definition for LLM tool calling.
@@ -130,8 +132,9 @@ func ExecuteCallAgent(ctx context.Context, call provider.ToolCall, opts ExecuteO
 
 	start := time.Now()
 
-	// Step 6: Load sub-agent config
-	cfg, err := agent.Load(agentName)
+	// Step 6: Load sub-agent config using parent's agents resolution context
+	searchDirs := agent.BuildSearchDirs(opts.AgentsDir, opts.AgentsBase)
+	cfg, err := agent.Load(agentName, searchDirs)
 	if err != nil {
 		return errorResult(call.ID, agentName, fmt.Sprintf("failed to load agent %q: %s", agentName, err), opts)
 	}
@@ -403,6 +406,8 @@ func runConversationLoop(ctx context.Context, prov provider.Provider, req *provi
 					Verbose:       opts.Verbose,
 					Stderr:        opts.Stderr,
 					BudgetTracker: opts.BudgetTracker,
+					AgentsDir:     opts.AgentsDir,
+					AgentsBase:    toolWorkdir, // sub-agent's workdir becomes the new base
 				}
 				results[i] = ExecuteCallAgent(ctx, tc, subOpts)
 			} else {

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -834,3 +834,112 @@ enabled = true
 		t.Errorf("expected no memory file at %s after error, but it exists", memPath)
 	}
 }
+
+// TestExecuteCallAgent_LocalDirPropagated verifies that when AgentsBase is set,
+// sub-agent configs are loaded from AgentsBase/axe/agents/ before falling back to global config.
+func TestExecuteCallAgent_LocalDirPropagated(t *testing.T) {
+	// Set up a temp XDG config dir (for fallback)
+	xdgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	xdgAgentsDir := filepath.Join(xdgDir, "axe", "agents")
+	if err := os.MkdirAll(xdgAgentsDir, 0755); err != nil {
+		t.Fatalf("failed to create XDG agents dir: %v", err)
+	}
+
+	// Set up a temp AgentsBase dir with a sub-agent in axe/agents/
+	agentsBaseDir := t.TempDir()
+	localAgentsDir := filepath.Join(agentsBaseDir, "axe", "agents")
+	if err := os.MkdirAll(localAgentsDir, 0755); err != nil {
+		t.Fatalf("failed to create local agents dir: %v", err)
+	}
+
+	// Start mock provider server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"id":    "msg_local",
+			"type":  "message",
+			"model": "claude-sonnet-4-20250514",
+			"role":  "assistant",
+			"content": []map[string]interface{}{
+				{"type": "text", "text": "Sub-agent result"},
+			},
+			"stop_reason": "end_turn",
+			"usage":       map[string]int{"input_tokens": 10, "output_tokens": 5},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Write a local-only agent in the local dir
+	writeToolTestAgent(t, localAgentsDir, "local-helper", `name = "local-helper"
+model = "anthropic/claude-sonnet-4-20250514"
+`)
+
+	// Write a global-only agent in XDG dir
+	writeToolTestAgent(t, xdgAgentsDir, "global-helper", `name = "global-helper"
+model = "anthropic/claude-sonnet-4-20250514"
+`)
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	// Test 1: With AgentsBase set, local agent should be found in local dir
+	call := provider.ToolCall{
+		ID:        "test-local-found",
+		Name:      CallAgentToolName,
+		Arguments: map[string]string{"agent": "local-helper", "task": "do something"},
+	}
+	opts := ExecuteOptions{
+		AllowedAgents: []string{"local-helper"},
+		MaxDepth:      3,
+		Depth:         0,
+		GlobalConfig:  &config.GlobalConfig{},
+		AgentsBase:    agentsBaseDir, // This should find local-helper in agentsBaseDir/axe/agents/
+	}
+	result := ExecuteCallAgent(context.Background(), call, opts)
+	if result.IsError {
+		t.Fatalf("expected IsError=false for local agent, got error: %s", result.Content)
+	}
+
+	// Test 2: With AgentsBase set, fallback to XDG still works for global-only agents
+	call2 := provider.ToolCall{
+		ID:        "test-global-fallback",
+		Name:      CallAgentToolName,
+		Arguments: map[string]string{"agent": "global-helper", "task": "do something"},
+	}
+	opts2 := ExecuteOptions{
+		AllowedAgents: []string{"global-helper"},
+		MaxDepth:      3,
+		Depth:         0,
+		GlobalConfig:  &config.GlobalConfig{},
+		AgentsBase:    agentsBaseDir, // Should fall back to XDG and find global-helper
+	}
+	result2 := ExecuteCallAgent(context.Background(), call2, opts2)
+	if result2.IsError {
+		t.Fatalf("expected IsError=false for global agent (fallback), got error: %s", result2.Content)
+	}
+
+	// Test 3: With AgentsBase set but NOT pointing to local dir, local agent should not be found
+	// (Using a different AgentsBase that doesn't have the agent)
+	otherBaseDir := t.TempDir()
+	call3 := provider.ToolCall{
+		ID:        "test-local-not-found",
+		Name:      CallAgentToolName,
+		Arguments: map[string]string{"agent": "local-helper", "task": "do something"},
+	}
+	opts3 := ExecuteOptions{
+		AllowedAgents: []string{"local-helper"},
+		MaxDepth:      3,
+		Depth:         0,
+		GlobalConfig:  &config.GlobalConfig{},
+		AgentsBase:    otherBaseDir, // This dir doesn't have local-helper, so XDG fallback should fail too
+	}
+	result3 := ExecuteCallAgent(context.Background(), call3, opts3)
+	if !result3.IsError {
+		t.Fatal("expected IsError=true for agent not found")
+	}
+	if !strings.Contains(result3.Content, "failed to load agent") {
+		t.Errorf("Content = %q, want to contain 'failed to load agent'", result3.Content)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This update adds local agent directory support, allowing agents to be discovered and loaded from a local directory (like `./axe/agents`) in addition to the global XDG config directory. A new `--agents-dir` CLI flag enables explicit specification of additional search paths. The implementation includes a precedence-based search mechanism with local directories taking priority, and refactored agent loading logic that validates agent names and handles multi-directory searches with global fallback.

## Changelog

### Added
- `--agents-dir` CLI flag for `agents`, `gc`, and `run` commands to specify additional agent search directories
- `ValidationError` type for structured agent configuration validation errors
- `BuildSearchDirs()` function to construct ordered search directory lists from flag and base directory
- Support for automatic detection and loading from local `./axe/agents` directory in current working directory
- Multi-directory agent search with first-match precedence and deduplication
- `AgentsDir` and `AgentsBase` fields to `ExecuteOptions` struct for propagating search context through tool execution
- Comprehensive test coverage for multi-directory agent search behavior, local directory detection, and search directory construction

### Changed
- `agent.Load()` now accepts `searchDirs []string` parameter to search multiple directories before global config fallback
- `agent.List()` now accepts `searchDirs []string` parameter to discover agents across multiple directories
- Agent configuration validation to return `ValidationError` type for all validation failures
- Config loading refactored with new `loadFromPath()` helper for raw read/parse/validate operations
- `agents init` command to prioritize `--agents-dir` flag, then local `./axe/agents`, then fall back to global XDG config
- `agents edit` command to search for agent configs across multiple directories
- `runSingleAgentGC()` and `runAllAgentsGC()` function signatures to accept and propagate `searchDirs`
- `executeToolCalls()` function signature to pass `agentsDir` and `agentsBase` for consistent sub-agent discovery
- Sub-agent execution in tools to inherit parent's search directory context for consistent agent resolution across nested invocations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->