### PR TITLE
feat: implement initial AxeClient for remote agent execution

### DIFF
--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// AxeClient handles communication with the Axe agent service.
+type AxeClient struct {
+	BaseURL string
+	APIKey  string
+}
+
+func (c *AxeClient) ExecuteAgent(agentID string, input map[string]interface{}) (map[string]interface{}, error) {
+	url := c.BaseURL + "/v1/agents/" + agentID + "/execute"
+	data, _ := json.Marshal(input)
+	
+	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req.Header.Set("Authorization", "Bearer " + c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result, nil
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Introduces initial `AxeClient` implementation in `pkg/client` for programmatic remote agent execution. The client supports API-key authentication and uses only the Go standard library, providing a lightweight, dependency-free solution for triggering and managing Axe agents.

## Changelog
### Added
- `AxeClient` type with `BaseURL` and `APIKey` fields for remote agent communication
- `ExecuteAgent` method to trigger remote agent execution with input parameters via POST requests to the `/v1/agents/{agentID}/execute` endpoint
- Bearer token authentication using API key in request headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->