### PR TITLE
ISS-40 - Add Smoke-Test CI Workflow

### DIFF
--- a/.github/smoke-agents/cfg-subagents.toml
+++ b/.github/smoke-agents/cfg-subagents.toml
@@ -1,6 +1,7 @@
 name = "cfg-subagents"
 model = "opencode/minimax-m2.5"
 description = "Smoke test: sub_agents config section"
+system_prompt = "You must always call the cfg-sub-child sub-agent immediately. Do not ask for clarification. Call the sub-agent with the task 'respond' and report its exact reply."
 sub_agents = ["cfg-sub-child"]
 
 [sub_agents_config]

--- a/.github/smoke-agents/provider-anthropic.toml
+++ b/.github/smoke-agents/provider-anthropic.toml
@@ -1,3 +1,3 @@
 name = "provider-anthropic"
-model = "anthropic/claude-3-5-haiku-20241022"
+model = "anthropic/claude-haiku-4-5"
 description = "Smoke test: Anthropic provider connectivity"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-files --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q -- "--- Files ---" || { echo "FAIL: '--- Files ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q -- "--- Files" || { echo "FAIL: '--- Files' not found"; exit 1; }
         echo "$OUTPUT" | grep -q "smoke-context.txt" || { echo "FAIL: 'smoke-context.txt' not found in files section"; exit 1; }
 
   providers:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -121,16 +121,16 @@ jobs:
 
     - name: tool-write-file
       run: |
-        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-write-file -p "Write the text 'smoke-write-ok' to the file /tmp/smoke-write-test.txt")
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-write-file -p "Write the text 'smoke-write-ok' to the file smoke-write-test.txt")
         echo "$OUTPUT"
-        grep -q "smoke-write-ok" /tmp/smoke-write-test.txt || { echo "FAIL: write file content not found"; exit 1; }
+        grep -q "smoke-write-ok" smoke-write-test.txt || { echo "FAIL: write file content not found"; exit 1; }
 
     - name: tool-edit-file
       run: |
-        echo "original-content" > /tmp/smoke-edit-test.txt
-        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-edit-file -p "Edit the file /tmp/smoke-edit-test.txt: replace 'original-content' with 'edited-content'")
+        echo "original-content" > smoke-edit-test.txt
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-edit-file -p "Edit the file smoke-edit-test.txt: replace 'original-content' with 'edited-content'")
         echo "$OUTPUT"
-        grep -q "edited-content" /tmp/smoke-edit-test.txt || { echo "FAIL: edited content not found"; exit 1; }
+        grep -q "edited-content" smoke-edit-test.txt || { echo "FAIL: edited content not found"; exit 1; }
 
     - name: tool-run-cmd
       run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -31,31 +31,32 @@ jobs:
       run: |
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-tools --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q "--- Tools ---" || { echo "FAIL: '--- Tools ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q -- "--- Tools ---" || { echo "FAIL: '--- Tools ---' not found"; exit 1; }
         echo "$OUTPUT" | grep -q "read_file" || { echo "FAIL: 'read_file' not found in tools section"; exit 1; }
 
     - name: dry-skill
       run: |
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-skill --skill "$(pwd)/.github/smoke-agents/skills/smoke-skill/SKILL.md" --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q "--- Skill ---" || { echo "FAIL: '--- Skill ---' not found"; exit 1; }
-        echo "$OUTPUT" | grep -A1 "--- Skill ---" | grep -q "(none)" && { echo "FAIL: skill section is '(none)'"; exit 1; } || true
+        echo "$OUTPUT" | grep -q -- "--- Skill ---" || { echo "FAIL: '--- Skill ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -A1 -- "--- Skill ---" | grep -q "(none)" && { echo "FAIL: skill section is '(none)'"; exit 1; } || true
 
     - name: dry-memory
       run: |
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-memory --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q -- "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
 
     - name: dry-files
       run: |
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-files --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q "--- Files ---" || { echo "FAIL: '--- Files ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q -- "--- Files ---" || { echo "FAIL: '--- Files ---' not found"; exit 1; }
         echo "$OUTPUT" | grep -q "smoke-context.txt" || { echo "FAIL: 'smoke-context.txt' not found in files section"; exit 1; }
 
   providers:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -91,6 +92,7 @@ jobs:
 
   tools:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
@@ -150,6 +152,7 @@ jobs:
 
   config-sections:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
     steps:
@@ -180,7 +183,7 @@ jobs:
         ./axe run --agents-dir .github/smoke-agents cfg-memory -p "Remember this: memory-smoke-test"
         OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-memory --dry-run -p "ping")
         echo "$OUTPUT"
-        echo "$OUTPUT" | grep -q "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q -- "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
         echo "$OUTPUT" | grep -q "memory-smoke-test" || { echo "FAIL: memory entry not found in dry-run output"; exit 1; }
 
     - name: cfg-files
@@ -203,6 +206,7 @@ jobs:
 
   piped-input:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
     steps:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -194,7 +194,7 @@ jobs:
 
     - name: cfg-subagents
       run: |
-        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-subagents -p "Delegate to your sub-agent and report what it says.")
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-subagents -p "Call your sub-agent now.")
         echo "$OUTPUT"
         echo "$OUTPUT" | grep -q "sub-agent-ok" || { echo "FAIL: 'sub-agent-ok' not found"; exit 1; }
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,229 @@
+# .github/workflows/smoke-test.yml
+name: Smoke Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+
+jobs:
+
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Build axe
+      run: go build -o axe .
+
+    - name: dry-basic
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-basic --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "=== Dry Run ===" || { echo "FAIL: '=== Dry Run ===' not found"; exit 1; }
+
+    - name: dry-tools
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-tools --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "--- Tools ---" || { echo "FAIL: '--- Tools ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q "read_file" || { echo "FAIL: 'read_file' not found in tools section"; exit 1; }
+
+    - name: dry-skill
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-skill --skill "$(pwd)/.github/smoke-agents/skills/smoke-skill/SKILL.md" --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "--- Skill ---" || { echo "FAIL: '--- Skill ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -A1 "--- Skill ---" | grep -q "(none)" && { echo "FAIL: skill section is '(none)'"; exit 1; } || true
+
+    - name: dry-memory
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-memory --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
+
+    - name: dry-files
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents dry-files --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "--- Files ---" || { echo "FAIL: '--- Files ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q "smoke-context.txt" || { echo "FAIL: 'smoke-context.txt' not found in files section"; exit 1; }
+
+  providers:
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Build axe
+      run: go build -o axe .
+
+    - name: provider-anthropic
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents provider-anthropic -p "Reply with only the word: pong")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+    - name: provider-openai
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents provider-openai -p "Reply with only the word: pong")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+    - name: provider-opencode
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents provider-opencode -p "Reply with only the word: pong")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+  tools:
+    runs-on: ubuntu-latest
+    env:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Build axe
+      run: go build -o axe .
+
+    - name: tool-list-dir
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-list-dir -p "List the files in the current directory and tell me what you see.")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+    - name: tool-read-file
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-read-file -p "Read the file .github/smoke-agents/smoke-context.txt and tell me its contents.")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "smoke-context-loaded" || { echo "FAIL: 'smoke-context-loaded' not found"; exit 1; }
+
+    - name: tool-write-file
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-write-file -p "Write the text 'smoke-write-ok' to the file /tmp/smoke-write-test.txt")
+        echo "$OUTPUT"
+        grep -q "smoke-write-ok" /tmp/smoke-write-test.txt || { echo "FAIL: write file content not found"; exit 1; }
+
+    - name: tool-edit-file
+      run: |
+        echo "original-content" > /tmp/smoke-edit-test.txt
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-edit-file -p "Edit the file /tmp/smoke-edit-test.txt: replace 'original-content' with 'edited-content'")
+        echo "$OUTPUT"
+        grep -q "edited-content" /tmp/smoke-edit-test.txt || { echo "FAIL: edited content not found"; exit 1; }
+
+    - name: tool-run-cmd
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-run-cmd -p "Run the shell command: echo hello-smoke")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "hello-smoke" || { echo "FAIL: 'hello-smoke' not found"; exit 1; }
+
+    - name: tool-url-fetch
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-url-fetch -p "Fetch the URL https://example.com and tell me the page title.")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "Example Domain" || { echo "FAIL: 'Example Domain' not found"; exit 1; }
+
+    - name: tool-web-search
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents tool-web-search -p "Search the web for 'axe cli golang' and summarize what you find.")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+  config-sections:
+    runs-on: ubuntu-latest
+    env:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Build axe
+      run: go build -o axe .
+
+    - name: cfg-basic
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-basic -p "Reply with only the word: pong")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+    - name: cfg-skill
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-skill --skill "$(pwd)/.github/smoke-agents/skills/smoke-skill/SKILL.md" -p "Follow your instructions.")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "smoke-skill-loaded" || { echo "FAIL: 'smoke-skill-loaded' not found"; exit 1; }
+
+    - name: cfg-memory
+      run: |
+        ./axe run --agents-dir .github/smoke-agents cfg-memory -p "Remember this: memory-smoke-test"
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-memory --dry-run -p "ping")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "--- Memory ---" || { echo "FAIL: '--- Memory ---' not found"; exit 1; }
+        echo "$OUTPUT" | grep -q "memory-smoke-test" || { echo "FAIL: memory entry not found in dry-run output"; exit 1; }
+
+    - name: cfg-files
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-files -p "What does the context file say?")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "smoke-context-loaded" || { echo "FAIL: 'smoke-context-loaded' not found"; exit 1; }
+
+    - name: cfg-subagents
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-subagents -p "Delegate to your sub-agent and report what it says.")
+        echo "$OUTPUT"
+        echo "$OUTPUT" | grep -q "sub-agent-ok" || { echo "FAIL: 'sub-agent-ok' not found"; exit 1; }
+
+    - name: cfg-params
+      run: |
+        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-params -p "Reply with only the word: pong")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+  piped-input:
+    runs-on: ubuntu-latest
+    env:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: Build axe
+      run: go build -o axe .
+
+    - name: pipe-basic
+      run: |
+        OUTPUT=$(echo "pipe-smoke-input" | ./axe run --agents-dir .github/smoke-agents pipe-basic)
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
+
+    - name: pipe-with-prompt
+      run: |
+        OUTPUT=$(echo "context: pipe-smoke-context" | ./axe run --agents-dir .github/smoke-agents pipe-basic -p "Repeat back the context you were given.")
+        echo "$OUTPUT"
+        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Adds a new "Smoke Tests" GitHub Actions workflow to build the Go CLI and run a suite of lightweight end-to-end smoke tests (dry-run, providers, tools, config sections, piped input). Introduces a stricter smoke-agent configuration that forces a parent agent to immediately invoke a sub-agent. Also updates the Anthropic provider smoke-agent to use a newer model identifier.

## Changelog
### Added
- `.github/workflows/smoke-test.yml` — new GitHub Actions workflow that builds the Go CLI (Go 1.24) and runs smoke-test jobs:
  - dry-run: validates dry-mode output sections and markers (=== Dry Run ===, --- Tools ---, --- Skill ---, --- Memory ---, --- Files) and verifies sentinel items (e.g., skill not "(none)", smoke-context.txt).
  - providers: runs provider agents (Anthropic, OpenAI, OpenCode) with API keys from secrets and asserts non-empty responses. Runs only for trusted PRs or push events.
  - tools: exercises tool agents (list/read/write/edit files, run command, URL fetch, web search) and checks for expected markers and side effects (smoke-context-loaded, smoke-write-test.txt, edited content, hello-smoke, Example Domain).
  - config-sections: executes config-driven agents and validates outputs/markers (smoke-skill-loaded, memory-smoke-test, sub-agent-ok, smoke-context-loaded), including a memory dry-run check.
  - piped-input: verifies stdin piping behavior for agents (pipe-basic) with and without an explicit prompt.

### Changed
- `.github/smoke-agents/cfg-subagents.toml` — added a system_prompt forcing the parent agent to immediately call the `cfg-sub-child` sub-agent with task `'respond'` and to report its exact reply (no clarification questions).
- `.github/smoke-agents/provider-anthropic.toml` — updated Anthropic model identifier from `anthropic/claude-3-5-haiku-20241022` to `anthropic/claude-haiku-4-5`.

## Other
- No exported or public code declarations changed; this PR adds CI workflow files and updates smoke-agent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->