### PR TITLE
ISS-56 - Fix Relative Artifact Dir Resolution

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -173,11 +173,21 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	// 3. TOML artifacts.enabled = true with no dir → auto-generate
 	// 4. None → inactive
 	if flagArtifactDir != "" {
-		artifactDir = flagArtifactDir
+		expanded, expandErr := resolve.ExpandPath(flagArtifactDir)
+		if expandErr != nil {
+			return &ExitError{Code: 2, Err: fmt.Errorf("failed to resolve --artifact-dir: %w", expandErr)}
+		}
+		if !filepath.IsAbs(expanded) {
+			expanded = filepath.Join(workdir, expanded)
+		}
+		artifactDir = expanded
 	} else if cfg.Artifacts.Enabled && cfg.Artifacts.Dir != "" {
-		expanded, expandErr := resolve.Workdir("", cfg.Artifacts.Dir)
+		expanded, expandErr := resolve.ExpandPath(cfg.Artifacts.Dir)
 		if expandErr != nil {
 			return &ExitError{Code: 2, Err: fmt.Errorf("failed to resolve artifacts.dir: %w", expandErr)}
+		}
+		if !filepath.IsAbs(expanded) {
+			expanded = filepath.Join(workdir, expanded)
 		}
 		artifactDir = expanded
 	} else if cfg.Artifacts.Enabled {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3121,6 +3121,168 @@ model = "anthropic/claude-sonnet-4-20250514"
 	}
 }
 
+func TestRun_ArtifactDirWorkdirResolution(t *testing.T) {
+	const agentName = "artifact-workdir-agent"
+	const baseToml = `name = "artifact-workdir-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+`
+
+	t.Run("relative TOML artifacts.dir resolves against --workdir", func(t *testing.T) {
+		resetRunCmd(t)
+		server := startMockAnthropicServer(t)
+		defer server.Close()
+
+		tmpWorkdir := t.TempDir()
+		toml := baseToml + `[artifacts]
+enabled = true
+dir = "output"
+`
+		setupRunTestAgent(t, agentName, toml)
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+
+		rootCmd.SetOut(new(bytes.Buffer))
+		rootCmd.SetErr(new(bytes.Buffer))
+		rootCmd.SetArgs([]string{"run", agentName, "--workdir", tmpWorkdir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wantDir := filepath.Join(tmpWorkdir, "output")
+		if _, statErr := os.Stat(wantDir); os.IsNotExist(statErr) {
+			t.Errorf("expected artifact directory %q to exist", wantDir)
+		}
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+	})
+
+	t.Run("absolute TOML artifacts.dir unaffected by --workdir", func(t *testing.T) {
+		resetRunCmd(t)
+		server := startMockAnthropicServer(t)
+		defer server.Close()
+
+		absoluteDir := t.TempDir()
+		otherWorkdir := t.TempDir()
+		toml := baseToml + `[artifacts]
+enabled = true
+dir = "` + absoluteDir + `"
+`
+		setupRunTestAgent(t, agentName, toml)
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+
+		rootCmd.SetOut(new(bytes.Buffer))
+		rootCmd.SetErr(new(bytes.Buffer))
+		rootCmd.SetArgs([]string{"run", agentName, "--workdir", otherWorkdir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, statErr := os.Stat(absoluteDir); os.IsNotExist(statErr) {
+			t.Errorf("expected artifact directory %q to exist", absoluteDir)
+		}
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+	})
+
+	t.Run("relative --artifact-dir flag resolves against --workdir", func(t *testing.T) {
+		resetRunCmd(t)
+		server := startMockAnthropicServer(t)
+		defer server.Close()
+
+		tmpWorkdir := t.TempDir()
+		setupRunTestAgent(t, agentName, baseToml)
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+
+		rootCmd.SetOut(new(bytes.Buffer))
+		rootCmd.SetErr(new(bytes.Buffer))
+		rootCmd.SetArgs([]string{"run", agentName, "--artifact-dir", "output", "--workdir", tmpWorkdir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wantDir := filepath.Join(tmpWorkdir, "output")
+		if _, statErr := os.Stat(wantDir); os.IsNotExist(statErr) {
+			t.Errorf("expected artifact directory %q to exist", wantDir)
+		}
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+	})
+
+	t.Run("absolute --artifact-dir flag unaffected by --workdir", func(t *testing.T) {
+		resetRunCmd(t)
+		server := startMockAnthropicServer(t)
+		defer server.Close()
+
+		absoluteDir := t.TempDir()
+		otherWorkdir := t.TempDir()
+		setupRunTestAgent(t, agentName, baseToml)
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+
+		rootCmd.SetOut(new(bytes.Buffer))
+		rootCmd.SetErr(new(bytes.Buffer))
+		rootCmd.SetArgs([]string{"run", agentName, "--artifact-dir", absoluteDir, "--workdir", otherWorkdir})
+
+		err := rootCmd.Execute()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, statErr := os.Stat(absoluteDir); os.IsNotExist(statErr) {
+			t.Errorf("expected artifact directory %q to exist", absoluteDir)
+		}
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+	})
+
+	t.Run("relative TOML artifacts.dir with no --workdir resolves against CWD", func(t *testing.T) {
+		resetRunCmd(t)
+		server := startMockAnthropicServer(t)
+		defer server.Close()
+
+		tmpCwdDir := t.TempDir()
+		toml := baseToml + `[artifacts]
+enabled = true
+dir = "output"
+`
+		setupRunTestAgent(t, agentName, toml)
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+		t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("failed to get cwd: %v", err)
+		}
+		if err := os.Chdir(tmpCwdDir); err != nil {
+			t.Fatalf("failed to chdir: %v", err)
+		}
+		defer func() { _ = os.Chdir(origDir) }()
+
+		rootCmd.SetOut(new(bytes.Buffer))
+		rootCmd.SetErr(new(bytes.Buffer))
+		rootCmd.SetArgs([]string{"run", agentName})
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wantDir := filepath.Join(tmpCwdDir, "output")
+		if _, statErr := os.Stat(wantDir); os.IsNotExist(statErr) {
+			t.Errorf("expected artifact directory %q to exist", wantDir)
+		}
+		_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+	})
+}
+
 func TestRun_ArtifactsJSON(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/docs/plans/044_artifact_dir_workdir_fix_implement.md
+++ b/docs/plans/044_artifact_dir_workdir_fix_implement.md
@@ -1,0 +1,124 @@
+# 044 — Artifact Dir Workdir Fix: Implementation Guide
+
+**Spec:** `docs/plans/044_artifact_dir_workdir_fix_spec.md`
+**Issue:** https://github.com/jrswab/axe/issues/56
+**Status:** Implement
+
+---
+
+## Section 1: Context Summary
+
+When `[artifacts] dir` in agent TOML is set to a relative path (e.g., `dir = "output"`), axe resolves it against the process CWD rather than the agent's resolved `--workdir`. In read-only CWD environments like AWS Lambda (`/var/task`), this causes a fatal `mkdir` error. The fix is confined to `cmd/run.go` lines 162–221 where the artifact directory resolution lives. The resolved `workdir` variable (line 157) is already available at that point but is never used when resolving artifact paths. The same issue affects the `--artifact-dir` flag, which is used raw without `~`/`$VAR` expansion or workdir joining. No changes to `internal/resolve`, `internal/agent`, or any other package are needed.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Task 1: Fix `--artifact-dir` flag resolution (expansion + workdir join)
+
+**Can be done in parallel with Task 2.**
+
+- [x] `cmd/run.go`: In the `runAgent()` function, replace the `--artifact-dir` flag branch (lines 175–176):
+
+  **Before:**
+  ```go
+  if flagArtifactDir != "" {
+      artifactDir = flagArtifactDir
+  }
+  ```
+
+  **After:** Pass `flagArtifactDir` through `resolve.Workdir("", flagArtifactDir)` for `~`/`$VAR` expansion, then join with `workdir` if the result is relative:
+  ```go
+  if flagArtifactDir != "" {
+      expanded, expandErr := resolve.Workdir("", flagArtifactDir)
+      if expandErr != nil {
+          return &ExitError{Code: 2, Err: fmt.Errorf("failed to resolve --artifact-dir: %w", expandErr)}
+      }
+      if !filepath.IsAbs(expanded) {
+          expanded = filepath.Join(workdir, expanded)
+      }
+      artifactDir = expanded
+  }
+  ```
+
+### Task 2: Fix TOML `artifacts.dir` resolution (workdir join for relative paths)
+
+**Can be done in parallel with Task 1.**
+
+- [x] `cmd/run.go`: In the `runAgent()` function, update the TOML `cfg.Artifacts.Dir` branch (lines 177–182). After the existing `resolve.Workdir("", cfg.Artifacts.Dir)` call, add a `filepath.IsAbs` check and join with `workdir` if relative:
+
+  **Before:**
+  ```go
+  } else if cfg.Artifacts.Enabled && cfg.Artifacts.Dir != "" {
+      expanded, expandErr := resolve.Workdir("", cfg.Artifacts.Dir)
+      if expandErr != nil {
+          return &ExitError{Code: 2, Err: fmt.Errorf("failed to resolve artifacts.dir: %w", expandErr)}
+      }
+      artifactDir = expanded
+  }
+  ```
+
+  **After:**
+  ```go
+  } else if cfg.Artifacts.Enabled && cfg.Artifacts.Dir != "" {
+      expanded, expandErr := resolve.Workdir("", cfg.Artifacts.Dir)
+      if expandErr != nil {
+          return &ExitError{Code: 2, Err: fmt.Errorf("failed to resolve artifacts.dir: %w", expandErr)}
+      }
+      if !filepath.IsAbs(expanded) {
+          expanded = filepath.Join(workdir, expanded)
+      }
+      artifactDir = expanded
+  }
+  ```
+
+### Task 3: Add tests for relative artifact dir resolution
+
+**Depends on Tasks 1 and 2 being complete.**
+
+- [x] `cmd/run_test.go`: Add a new table-driven test function `TestRun_ArtifactDirWorkdirResolution` near the existing `TestRun_ArtifactEnvVar` (after line 3122). Follow the same pattern: `resetRunCmd(t)`, `startMockAnthropicServer(t)`, `setupRunTestAgent(t, ...)`, set env vars, execute `rootCmd`, assert directory existence and path correctness.
+
+  **Required test cases (5 cases in one table):**
+
+  1. **`relative TOML artifacts.dir resolves against --workdir`**
+     - TOML: `[artifacts] enabled = true` with `dir = "output"`
+     - Args: `["run", "artifact-workdir-agent", "--workdir", <tmpWorkdir>]`
+     - Assert: directory `<tmpWorkdir>/output` exists on disk
+
+  2. **`absolute TOML artifacts.dir unaffected by --workdir`**
+     - TOML: `[artifacts] enabled = true` with `dir = "<absoluteTmpDir>"`
+     - Args: `["run", "artifact-workdir-agent", "--workdir", <otherTmpDir>]`
+     - Assert: directory `<absoluteTmpDir>` exists on disk (NOT `<otherTmpDir>/<absoluteTmpDir>`)
+
+  3. **`relative --artifact-dir flag resolves against --workdir`**
+     - TOML: no `[artifacts]` block
+     - Args: `["run", "artifact-workdir-agent", "--artifact-dir", "output", "--workdir", <tmpWorkdir>]`
+     - Assert: directory `<tmpWorkdir>/output` exists on disk
+
+  4. **`absolute --artifact-dir flag unaffected by --workdir`**
+     - TOML: no `[artifacts]` block
+     - Args: `["run", "artifact-workdir-agent", "--artifact-dir", <absoluteTmpDir>, "--workdir", <otherTmpDir>]`
+     - Assert: directory `<absoluteTmpDir>` exists on disk
+
+  5. **`relative TOML artifacts.dir with no --workdir resolves against CWD`**
+     - TOML: `[artifacts] enabled = true` with `dir = "output"`
+     - Args: `["run", "artifact-workdir-agent"]` (no `--workdir` flag)
+     - Before execute: `os.Chdir(<tmpCwdDir>)` and defer restore
+     - Assert: directory `<tmpCwdDir>/output` exists on disk
+
+  **Each test case must:**
+  - Use `t.TempDir()` for all temporary directories
+  - Use agent name `"artifact-workdir-agent"` with model `"anthropic/claude-sonnet-4-20250514"`
+  - Call `resetRunCmd(t)` at the start
+  - Set `ANTHROPIC_API_KEY` and `AXE_ANTHROPIC_BASE_URL` env vars
+  - Unset `AXE_ARTIFACT_DIR` before execute
+  - Assert the expected directory exists via `os.Stat`
+  - Clean up `AXE_ARTIFACT_DIR` after execute
+
+### Task 4: Run tests and verify no regressions
+
+**Depends on Task 3.**
+
+- [x] Run `go test ./cmd/... -run TestRun_Artifact -v` to verify all new and existing artifact tests pass.
+- [x] Run `go test ./cmd/... -count=1` to verify no regressions in the full `cmd` package test suite.
+- [x] Run `go vet ./...` and confirm no warnings.

--- a/docs/plans/044_artifact_dir_workdir_fix_spec.md
+++ b/docs/plans/044_artifact_dir_workdir_fix_spec.md
@@ -1,0 +1,157 @@
+# ISS-56 — Fix: Relative artifacts.dir Resolved Against --workdir, Not Process CWD
+
+**Milestone document:** N/A (standalone bug fix)
+**Issue:** https://github.com/jrswab/axe/issues/56
+**Status:** Spec
+
+---
+
+## Section 1: Context & Constraints
+
+### Codebase Structure Relevant to This Fix
+
+- **`cmd/run.go` — artifact directory resolution (lines 162–221):** The artifact directory is resolved in a three-way priority chain:
+  1. `--artifact-dir` flag (line 175–176): used raw, no expansion, no workdir join
+  2. TOML `cfg.Artifacts.Dir` (line 177–182): passed through `resolve.Workdir("", cfg.Artifacts.Dir)` for tilde/env expansion, but NOT joined with workdir if relative
+  3. Auto-generated XDG cache path (line 183–196): always absolute
+
+- **`cmd/run.go` — workdir resolution (lines 155–160):** `workdir` is resolved via `resolve.Workdir(flagWorkdir, cfg.Workdir)` before the artifact block. The resolved `workdir` variable is available but is never used when resolving `cfg.Artifacts.Dir`.
+
+- **`internal/resolve/resolve.go` — `Workdir` function (lines 45–62):** Performs only `~` and `$VAR` expansion via `ExpandPath`. A relative path like `"output"` passes through unchanged. It does NOT make paths absolute.
+
+- **`internal/resolve/resolve.go` — `ExpandPath` function (lines 16–40):** Handles `~/...` tilde expansion and `os.ExpandEnv` for `$VAR`/`${VAR}`. Does not resolve relative paths against any base directory.
+
+- **`internal/agent/agent.go` — `ArtifactsConfig` struct (lines 52–56):**
+  ```go
+  type ArtifactsConfig struct {
+      Enabled bool   `toml:"enabled"`
+      Dir     string `toml:"dir"`
+  }
+  ```
+
+- **`internal/agent/agent.go` — `Validate()` (lines 173–178):** Two existing validation rules for artifacts:
+  1. `artifacts.dir` set but `artifacts.enabled` is false → validation error
+  2. `artifacts.dir` contains `..` → validation error
+
+- **`cmd/run_test.go` — existing artifact tests (lines 3025–3083):** `TestRun_ArtifactFlagsExist` and `TestRun_ArtifactEnvVar` with three table-driven cases. No existing test covers relative path resolution against workdir.
+
+- **`os.MkdirAll(artifactDir, 0o755)` at line 200:** This is where the bug manifests. When `artifactDir` is a relative path like `"output"`, `os.MkdirAll` resolves it against the process CWD — not the agent's resolved workdir.
+
+### Decisions Already Made (from spec 042)
+
+1. **Resolution order for artifact directory:** flag > TOML dir > auto-generated. This order is preserved; only the path joining behavior changes.
+2. **`--artifact-dir` flag activates the system even without `enabled = true` in TOML.** This behavior is unchanged.
+3. **Persistent directories are never cleaned up.** This behavior is unchanged.
+4. **`~` and `$VAR` expansion applies to `artifacts.dir`.** This behavior is preserved; the fix adds workdir-relative joining on top of it.
+
+### Approaches Ruled Out
+
+- **Changing `resolve.Workdir` to accept a base directory:** `resolve.Workdir` is a general-purpose function used for the agent's own workdir resolution. Changing its signature would affect all callers. The fix belongs in `cmd/run.go` at the call site, not in `resolve`.
+- **Validating that `artifacts.dir` is absolute in `agent.Validate()`:** Would be a breaking change for users who intentionally use relative paths (e.g., `dir = "output"` to mean "output/ inside my workdir"). The correct behavior is to resolve relative paths against workdir, not reject them.
+- **Resolving `--artifact-dir` flag against workdir:** The flag is a direct user invocation argument. Users passing `--artifact-dir /tmp/my-dir` expect that exact path. However, for consistency, if the flag value is relative, it should also resolve against workdir (same rule as TOML). This is a secondary fix in the same change.
+
+### Constraints and Assumptions
+
+- **Backward compatibility:** Any user currently passing an absolute path for `artifacts.dir` (TOML or flag) must see zero behavior change. The `filepath.IsAbs` check ensures this.
+- **Workdir is always resolved before artifact dir.** The `workdir` variable at line 157 is always set (falls back to `os.Getwd()` if neither flag nor TOML is set). It is always available when the artifact block runs.
+- **The fix is purely in `cmd/run.go`.** No changes to `internal/resolve`, `internal/agent`, or any other package are required.
+- **Tests are in `cmd/run_test.go`.** New test cases are added to the existing `TestRun_ArtifactEnvVar` table or as a new table-driven test in the same file.
+
+### Open Questions Resolved
+
+- **Q: Should a relative `--artifact-dir` flag also resolve against workdir?** Yes. Consistency demands it. A user passing `--artifact-dir output` with `--workdir /tmp/abc` should get `/tmp/abc/output`, not `/var/task/output` (process CWD).
+- **Q: What if workdir itself is relative?** `resolve.Workdir` always returns an absolute path (it falls back to `os.Getwd()` which returns an absolute path). So `filepath.Join(workdir, expanded)` always produces an absolute path.
+
+---
+
+## Section 2: Requirements
+
+### 2.1 Behavior: Relative `artifacts.dir` in TOML
+
+When `cfg.Artifacts.Dir` is set to a relative path (after `~` and `$VAR` expansion), it must be resolved against the agent's resolved `workdir`.
+
+**Inputs:**
+- `cfg.Artifacts.Dir`: a non-empty string that, after expansion, is not an absolute path
+- `workdir`: the already-resolved working directory (always absolute)
+
+**Output:**
+- `artifactDir` is set to `filepath.Join(workdir, expanded)`
+
+**When `cfg.Artifacts.Dir` is already absolute after expansion:**
+- `artifactDir` is set to the expanded value unchanged. No workdir join.
+
+**When `cfg.Artifacts.Dir` is empty:**
+- This branch is not reached (guarded by `cfg.Artifacts.Dir != ""`). No change.
+
+### 2.2 Behavior: Relative `--artifact-dir` Flag
+
+When the `--artifact-dir` flag value is a relative path (after `~` and `$VAR` expansion), it must be resolved against the agent's resolved `workdir`.
+
+**Inputs:**
+- `flagArtifactDir`: a non-empty string that, after expansion, is not an absolute path
+- `workdir`: the already-resolved working directory (always absolute)
+
+**Output:**
+- `artifactDir` is set to `filepath.Join(workdir, expanded)`
+
+**When `flagArtifactDir` is already absolute after expansion:**
+- `artifactDir` is set to the expanded value unchanged. No workdir join.
+
+**When `flagArtifactDir` is empty:**
+- This branch is not reached (guarded by `flagArtifactDir != ""`). No change.
+
+**Note:** The `--artifact-dir` flag value must be passed through `resolve.Workdir("", flagArtifactDir)` (or equivalent `ExpandPath`) before the `filepath.IsAbs` check, so that `~` and `$VAR` in the flag value are expanded. Currently the flag value is used raw without expansion — this is a secondary bug fixed in the same change.
+
+### 2.3 Behavior: Auto-Generated Artifact Directory
+
+The auto-generated XDG cache path (`$XDG_CACHE_HOME/axe/artifacts/<run-id>/`) is always absolute. No change to this branch.
+
+### 2.4 Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `dir = "output"`, `--workdir /tmp/abc` | `artifactDir` = `/tmp/abc/output` |
+| `dir = "output"`, no `--workdir`, process CWD = `/app` | `artifactDir` = `/app/output` (workdir falls back to CWD) |
+| `dir = "/absolute/path"`, `--workdir /tmp/abc` | `artifactDir` = `/absolute/path` (absolute, no join) |
+| `dir = "~/artifacts"`, `--workdir /tmp/abc` | `~` expanded first → `/home/user/artifacts` (absolute after expansion, no join) |
+| `dir = "$OUTDIR"` where `OUTDIR=/tmp/out`, `--workdir /tmp/abc` | Expanded to `/tmp/out` (absolute after expansion, no join) |
+| `dir = "$OUTDIR"` where `OUTDIR=output`, `--workdir /tmp/abc` | Expanded to `output` (relative after expansion) → joined → `/tmp/abc/output` |
+| `--artifact-dir output`, `--workdir /tmp/abc` | `artifactDir` = `/tmp/abc/output` |
+| `--artifact-dir /absolute/path`, `--workdir /tmp/abc` | `artifactDir` = `/absolute/path` (absolute, no join) |
+| `--artifact-dir ~/artifacts`, `--workdir /tmp/abc` | `~` expanded → absolute → no join |
+| No `[artifacts]` config, no flag | Artifact system inactive. Zero behavior change. |
+| `artifacts.enabled = true`, no `dir`, no flag | Auto-generated path. No change. |
+| `dir` contains `..` | Rejected by existing `Validate()` before reaching resolution. No change needed here. |
+
+### 2.5 Tests
+
+New test cases must be added to `cmd/run_test.go` covering the scenarios in 2.4. The tests must use the existing table-driven pattern in `TestRun_ArtifactEnvVar` or a new parallel table-driven test.
+
+**Required test cases (can be implemented in parallel with each other):**
+
+1. **Relative TOML `artifacts.dir` resolves against `--workdir`:** Agent TOML has `[artifacts] enabled=true dir="output"`, invocation uses `--workdir <tmpdir>`. Assert that the artifact directory created is `<tmpdir>/output`.
+
+2. **Absolute TOML `artifacts.dir` is unaffected by `--workdir`:** Agent TOML has `[artifacts] enabled=true dir="<absolute-tmpdir>"`, invocation uses `--workdir <other-tmpdir>`. Assert that the artifact directory created is `<absolute-tmpdir>` (not joined with workdir).
+
+3. **Relative `--artifact-dir` flag resolves against `--workdir`:** No TOML artifacts config. Invocation uses `--artifact-dir output --workdir <tmpdir>`. Assert that the artifact directory created is `<tmpdir>/output`.
+
+4. **Absolute `--artifact-dir` flag is unaffected by `--workdir`:** No TOML artifacts config. Invocation uses `--artifact-dir <absolute-tmpdir> --workdir <other-tmpdir>`. Assert that the artifact directory created is `<absolute-tmpdir>`.
+
+5. **Relative TOML `artifacts.dir` with no `--workdir` flag resolves against process CWD:** Agent TOML has `[artifacts] enabled=true dir="output"`, no `--workdir` flag. Assert that the artifact directory created is `<process-CWD>/output`.
+
+Each test case must:
+- Use `t.TempDir()` for any temporary directories.
+- Assert the directory exists on disk after the run.
+- Assert `AXE_ARTIFACT_DIR` env var equals the expected resolved path.
+- Clean up after itself (temp dirs via `t.TempDir()` are auto-cleaned).
+
+### 2.6 No Changes Required
+
+The following are explicitly out of scope for this fix:
+
+- `internal/resolve/resolve.go` — no changes
+- `internal/agent/agent.go` — no changes (existing `..` validation already covers traversal)
+- `internal/tool/` — no changes
+- Any provider implementation — no changes
+- Documentation files — no changes
+- The `042_artifact_management_spec.md` spec document — no retroactive changes; this spec supersedes the path resolution behavior described there for relative paths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This update fixes artifact directory resolution to properly handle both relative and absolute paths in the `--artifact-dir` flag and `artifacts.dir` configuration option. Relative paths are now normalized by joining them with the resolved working directory, and environment variables are expanded in both sources. The changes include explicit error handling that returns a specific exit code (2) with context-aware error messages depending on whether the failure occurred in CLI flag or configuration file processing.

## Changelog

### Fixed
- Artifact directory resolution now properly expands environment variables and normalizes relative paths against `--workdir`
- Error handling for path expansion failures with context-specific messages for CLI flag (`--artifact-dir`) vs configuration file (`artifacts.dir`)

### Added
- Comprehensive test suite `TestRun_ArtifactDirWorkdirResolution` covering artifact directory resolution scenarios:
  - Relative `artifacts.dir` resolved under `--workdir`
  - Absolute `artifacts.dir` independent of `--workdir`
  - Relative `--artifact-dir` resolved under `--workdir`
  - Absolute `--artifact-dir` independent of `--workdir`
  - Fallback to current working directory when `--workdir` is omitted

### Changed
- Artifact directory path expansion now uses `resolve.ExpandPath` for consistent environment variable handling
- Non-absolute paths are joined with the resolved working directory instead of being used verbatim

<!-- end of auto-generated comment: release notes by coderabbit.ai -->