### PR TITLE
ISS-60: Add Top-Level Timeout to Agent TOML

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -99,13 +99,15 @@ var agentsShowCmd = &cobra.Command{
 		}
 		if len(cfg.SubAgents) > 0 {
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "Sub-Agents:", strings.Join(cfg.SubAgents, ", "))
-			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Max Depth:", cfg.SubAgentsConf.MaxDepth)
-			parallelDisplay := true // default
-			if cfg.SubAgentsConf.Parallel != nil {
-				parallelDisplay = *cfg.SubAgentsConf.Parallel
+			if cfg.SubAgentsConf.MaxDepth != 0 {
+				_, _ = fmt.Fprintf(w, "%-16s%d\n", "Max Depth:", cfg.SubAgentsConf.MaxDepth)
 			}
-			_, _ = fmt.Fprintf(w, "%-16s%v\n", "Parallel:", parallelDisplay)
-			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Sub-Agent Timeout:", cfg.SubAgentsConf.Timeout)
+			if cfg.SubAgentsConf.Parallel != nil {
+				_, _ = fmt.Fprintf(w, "%-16s%v\n", "Parallel:", *cfg.SubAgentsConf.Parallel)
+			}
+			if cfg.SubAgentsConf.Timeout != 0 {
+				_, _ = fmt.Fprintf(w, "%-16s%d\n", "Sub-Agent Timeout:", cfg.SubAgentsConf.Timeout)
+			}
 		}
 		if cfg.Memory.Enabled {
 			_, _ = fmt.Fprintf(w, "%-16s%v\n", "Memory Enabled:", cfg.Memory.Enabled)

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -91,6 +91,9 @@ var agentsShowCmd = &cobra.Command{
 		if cfg.Workdir != "" {
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "Workdir:", cfg.Workdir)
 		}
+		if cfg.Timeout > 0 {
+			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Timeout:", cfg.Timeout)
+		}
 		if len(cfg.Tools) > 0 {
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "Tools:", strings.Join(cfg.Tools, ", "))
 		}
@@ -102,7 +105,7 @@ var agentsShowCmd = &cobra.Command{
 				parallelDisplay = *cfg.SubAgentsConf.Parallel
 			}
 			_, _ = fmt.Fprintf(w, "%-16s%v\n", "Parallel:", parallelDisplay)
-			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Timeout:", cfg.SubAgentsConf.Timeout)
+			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Sub-Agent Timeout:", cfg.SubAgentsConf.Timeout)
 		}
 		if cfg.Memory.Enabled {
 			_, _ = fmt.Fprintf(w, "%-16s%v\n", "Memory Enabled:", cfg.Memory.Enabled)

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -260,7 +260,7 @@ timeout = 120
 		"4",
 		"Parallel:",
 		"true",
-		"Timeout:",
+		"Sub-Agent Timeout:",
 		"120",
 	}
 	for _, check := range checks {
@@ -640,12 +640,68 @@ model = "openai/gpt-4o"
 	}
 }
 
+// --- Top-level Timeout field tests (TDD red phase) ---
+
+func TestAgentsShow_TopLevelTimeout(t *testing.T) {
+	agentsDir := setupTestAgentsDir(t)
+
+	toml := `name = "timeout-test"
+model = "openai/gpt-4o"
+timeout = 300
+`
+	writeTestAgent(t, agentsDir, "timeout-test", toml)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"agents", "show", "timeout-test"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Timeout:") {
+		t.Errorf("show output missing 'Timeout:'\nfull output:\n%s", output)
+	}
+	if !strings.Contains(output, "300") {
+		t.Errorf("show output missing '300'\nfull output:\n%s", output)
+	}
+}
+
+func TestAgentsShow_TopLevelTimeoutOmittedWhenZero(t *testing.T) {
+	agentsDir := setupTestAgentsDir(t)
+
+	toml := `name = "no-timeout"
+model = "openai/gpt-4o"
+`
+	writeTestAgent(t, agentsDir, "no-timeout", toml)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"agents", "show", "no-timeout"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// Top-level Timeout field should NOT be shown when zero/default
+	if strings.Contains(output, "Timeout:") {
+		t.Errorf("show output should not contain 'Timeout:' when timeout is not set\nfull output:\n%s", output)
+	}
+}
+
 func TestAgentsShow_ToolsDisplayOrder(t *testing.T) {
 	agentsDir := setupTestAgentsDir(t)
 	writeTestAgent(t, agentsDir, "ordered", `name = "ordered"
 model = "openai/gpt-4o"
 tools = ["read_file"]
 workdir = "/tmp"
+timeout = 300
 sub_agents = ["helper"]
 `)
 
@@ -661,11 +717,15 @@ sub_agents = ["helper"]
 
 	output := buf.String()
 	workdirIdx := strings.Index(output, "Workdir:")
+	timeoutIdx := strings.Index(output, "Timeout:")
 	toolsIdx := strings.Index(output, "Tools:")
 	subAgentsIdx := strings.Index(output, "Sub-Agents:")
 
 	if workdirIdx < 0 {
 		t.Fatal("output missing 'Workdir:'")
+	}
+	if timeoutIdx < 0 {
+		t.Fatal("output missing 'Timeout:'")
 	}
 	if toolsIdx < 0 {
 		t.Fatal("output missing 'Tools:'")
@@ -674,8 +734,11 @@ sub_agents = ["helper"]
 		t.Fatal("output missing 'Sub-Agents:'")
 	}
 
-	if toolsIdx <= workdirIdx {
-		t.Errorf("Tools: (pos %d) should appear after Workdir: (pos %d)", toolsIdx, workdirIdx)
+	if timeoutIdx <= workdirIdx {
+		t.Errorf("Timeout: (pos %d) should appear after Workdir: (pos %d)", timeoutIdx, workdirIdx)
+	}
+	if toolsIdx <= timeoutIdx {
+		t.Errorf("Tools: (pos %d) should appear after Timeout: (pos %d)", toolsIdx, timeoutIdx)
 	}
 	if toolsIdx >= subAgentsIdx {
 		t.Errorf("Tools: (pos %d) should appear before Sub-Agents: (pos %d)", toolsIdx, subAgentsIdx)

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -640,58 +640,59 @@ model = "openai/gpt-4o"
 	}
 }
 
-// --- Top-level Timeout field tests (TDD red phase) ---
+// --- Top-level Timeout field tests ---
 
-func TestAgentsShow_TopLevelTimeout(t *testing.T) {
-	agentsDir := setupTestAgentsDir(t)
-
-	toml := `name = "timeout-test"
+func TestAgentsShow_TopLevelTimeout_Table(t *testing.T) {
+	tests := []struct {
+		name           string
+		toml           string
+		expectContains bool
+	}{
+		{
+			name: "timeout-test",
+			toml: `name = "timeout-test"
 model = "openai/gpt-4o"
 timeout = 300
-`
-	writeTestAgent(t, agentsDir, "timeout-test", toml)
-
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(new(bytes.Buffer))
-	rootCmd.SetArgs([]string{"agents", "show", "timeout-test"})
-
-	err := rootCmd.Execute()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	output := buf.String()
-	if !strings.Contains(output, "Timeout:") {
-		t.Errorf("show output missing 'Timeout:'\nfull output:\n%s", output)
-	}
-	if !strings.Contains(output, "300") {
-		t.Errorf("show output missing '300'\nfull output:\n%s", output)
-	}
-}
-
-func TestAgentsShow_TopLevelTimeoutOmittedWhenZero(t *testing.T) {
-	agentsDir := setupTestAgentsDir(t)
-
-	toml := `name = "no-timeout"
+`,
+			expectContains: true,
+		},
+		{
+			name: "no-timeout",
+			toml: `name = "no-timeout"
 model = "openai/gpt-4o"
-`
-	writeTestAgent(t, agentsDir, "no-timeout", toml)
-
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(new(bytes.Buffer))
-	rootCmd.SetArgs([]string{"agents", "show", "no-timeout"})
-
-	err := rootCmd.Execute()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+`,
+			expectContains: false,
+		},
 	}
 
-	output := buf.String()
-	// Top-level Timeout field should NOT be shown when zero/default
-	if strings.Contains(output, "Timeout:") {
-		t.Errorf("show output should not contain 'Timeout:' when timeout is not set\nfull output:\n%s", output)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agentsDir := setupTestAgentsDir(t)
+			writeTestAgent(t, agentsDir, tc.name, tc.toml)
+
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(new(bytes.Buffer))
+			rootCmd.SetArgs([]string{"agents", "show", tc.name})
+
+			err := rootCmd.Execute()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			output := buf.String()
+			hasTimeout := strings.Contains(output, "Timeout:")
+			if hasTimeout != tc.expectContains {
+				if tc.expectContains {
+					t.Errorf("show output missing 'Timeout:'\nfull output:\n%s", output)
+				} else {
+					t.Errorf("show output should not contain 'Timeout:' when timeout is not set\nfull output:\n%s", output)
+				}
+			}
+			if tc.expectContains && !strings.Contains(output, "300") {
+				t.Errorf("show output missing '300'\nfull output:\n%s", output)
+			}
+		})
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -295,7 +295,13 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Flags
-	timeout, _ := cmd.Flags().GetInt("timeout")
+	timeout := 120
+	if cfg.Timeout > 0 {
+		timeout = cfg.Timeout
+	}
+	if cmd.Flags().Changed("timeout") {
+		timeout, _ = cmd.Flags().GetInt("timeout")
+	}
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonOutput, _ := cmd.Flags().GetBool("json")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3579,123 +3579,86 @@ enabled = true
 
 // --- TOML Timeout Tests ---
 
-func TestRun_TomlTimeoutUsedWhenFlagAbsent(t *testing.T) {
-	resetRunCmd(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(3 * time.Second)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{
-			"id": "msg_test",
-			"type": "message",
-			"role": "assistant",
-			"content": [{"type": "text", "text": "Hello from mock"}],
-			"model": "claude-sonnet-4-20250514",
-			"stop_reason": "end_turn",
-			"usage": {"input_tokens": 10, "output_tokens": 5}
-		}`))
-	}))
-	defer server.Close()
+func TestRun_TimeoutPrecedence(t *testing.T) {
+	// The mock server sleeps for 2 seconds so that a timeout=1 will fire
+	// but a timeout=120 (or 300) will succeed.
+	const serverSleep = 2 * time.Second
 
-	setupRunTestAgent(t, "toml-timeout-agent", `name = "toml-timeout-agent"
-model = "anthropic/claude-sonnet-4-20250514"
-timeout = 1
-`)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
-
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	// Do NOT pass --timeout flag - TOML value should be used
-	rootCmd.SetArgs([]string{"run", "toml-timeout-agent"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for timeout, got nil")
+	tests := []struct {
+		name           string
+		tomlTimeout    int
+		flagTimeout    string // empty string means flag is not passed
+		expectExitCode int    // 0 = success, 3 = timeout
+	}{
+		{
+			name:           "toml timeout used when flag absent",
+			tomlTimeout:    1,
+			flagTimeout:    "",
+			expectExitCode: 3,
+		},
+		{
+			name:           "flag timeout overrides toml timeout",
+			tomlTimeout:    300,
+			flagTimeout:    "1",
+			expectExitCode: 3,
+		},
+		{
+			name:           "flag timeout default value overrides toml",
+			tomlTimeout:    1,
+			flagTimeout:    "120",
+			expectExitCode: 0,
+		},
 	}
 
-	var exitErr *ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T: %v", err, err)
-	}
-	if exitErr.Code != 3 {
-		t.Errorf("expected exit code 3 (timeout), got %d", exitErr.Code)
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetRunCmd(t)
 
-func TestRun_FlagTimeoutOverridesTomlTimeout(t *testing.T) {
-	resetRunCmd(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(3 * time.Second)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{
-			"id": "msg_test",
-			"type": "message",
-			"role": "assistant",
-			"content": [{"type": "text", "text": "Hello from mock"}],
-			"model": "claude-sonnet-4-20250514",
-			"stop_reason": "end_turn",
-			"usage": {"input_tokens": 10, "output_tokens": 5}
-		}`))
-	}))
-	defer server.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(serverSleep)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"Hello from mock"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
+			}))
+			defer server.Close()
 
-	setupRunTestAgent(t, "flag-timeout-agent", `name = "flag-timeout-agent"
-model = "anthropic/claude-sonnet-4-20250514"
-timeout = 300
-`)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+			agentName := fmt.Sprintf("timeout-precedence-%s", strings.ReplaceAll(tc.name, " ", "-"))
+			tomlContent := fmt.Sprintf("name = %q\nmodel = \"anthropic/claude-sonnet-4-20250514\"\ntimeout = %d\n", agentName, tc.tomlTimeout)
+			setupRunTestAgent(t, agentName, tomlContent)
 
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	// Pass --timeout 1 to override TOML value of 300
-	rootCmd.SetArgs([]string{"run", "flag-timeout-agent", "--timeout", "1"})
+			t.Setenv("ANTHROPIC_API_KEY", "test-key")
+			t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
 
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for timeout, got nil")
-	}
+			buf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(errBuf)
 
-	var exitErr *ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T: %v", err, err)
-	}
-	if exitErr.Code != 3 {
-		t.Errorf("expected exit code 3 (timeout), got %d", exitErr.Code)
-	}
-}
+			args := []string{"run", agentName}
+			if tc.flagTimeout != "" {
+				args = append(args, "--timeout", tc.flagTimeout)
+			}
+			rootCmd.SetArgs(args)
 
-func TestRun_FlagTimeoutDefaultValueOverridesToml(t *testing.T) {
-	resetRunCmd(t)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"Hello from mock"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
-	}))
-	defer server.Close()
+			err := rootCmd.Execute()
 
-	setupRunTestAgent(t, "flag-default-timeout-agent", `name = "flag-default-timeout-agent"
-model = "anthropic/claude-sonnet-4-20250514"
-timeout = 1
-`)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+			if tc.expectExitCode == 0 {
+				if err != nil {
+					t.Fatalf("expected success (no timeout), got error: %v", err)
+				}
+				return
+			}
 
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	// Pass --timeout 120 explicitly to override TOML value of 1
-	rootCmd.SetArgs([]string{"run", "flag-default-timeout-agent", "--timeout", "120"})
-
-	err := rootCmd.Execute()
-	if err != nil {
-		t.Fatalf("expected success (no timeout), got error: %v", err)
+			if err == nil {
+				t.Fatal("expected error for timeout, got nil")
+			}
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected ExitError, got %T: %v", err, err)
+			}
+			if exitErr.Code != tc.expectExitCode {
+				t.Errorf("expected exit code %d (timeout), got %d", tc.expectExitCode, exitErr.Code)
+			}
+		})
 	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -25,7 +25,7 @@ func resetRunCmd(t *testing.T) {
 	_ = runCmd.Flags().Set("workdir", "")
 	_ = runCmd.Flags().Set("agents-dir", "")
 	_ = runCmd.Flags().Set("model", "")
-	_ = runCmd.Flags().Set("timeout", "120")
+	// Don't preset timeout - let it use default so Changed() detection works
 	_ = runCmd.Flags().Set("dry-run", "false")
 	_ = runCmd.Flags().Set("verbose", "false")
 	_ = runCmd.Flags().Set("json", "false")
@@ -33,6 +33,10 @@ func resetRunCmd(t *testing.T) {
 	_ = runCmd.Flags().Set("prompt", "")
 	_ = runCmd.Flags().Set("artifact-dir", "")
 	_ = runCmd.Flags().Set("keep-artifacts", "false")
+	// Reset the Changed state for timeout flag so TOML timeout values can be used
+	if f := runCmd.Flags().Lookup("timeout"); f != nil {
+		f.Changed = false
+	}
 	rootCmd.SetIn(os.Stdin)
 }
 
@@ -3571,4 +3575,127 @@ enabled = true
 
 	// Clean up env var
 	_ = os.Unsetenv("AXE_ARTIFACT_DIR")
+}
+
+// --- TOML Timeout Tests ---
+
+func TestRun_TomlTimeoutUsedWhenFlagAbsent(t *testing.T) {
+	resetRunCmd(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"id": "msg_test",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "Hello from mock"}],
+			"model": "claude-sonnet-4-20250514",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`))
+	}))
+	defer server.Close()
+
+	setupRunTestAgent(t, "toml-timeout-agent", `name = "toml-timeout-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+timeout = 1
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	// Do NOT pass --timeout flag - TOML value should be used
+	rootCmd.SetArgs([]string{"run", "toml-timeout-agent"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for timeout, got nil")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != 3 {
+		t.Errorf("expected exit code 3 (timeout), got %d", exitErr.Code)
+	}
+}
+
+func TestRun_FlagTimeoutOverridesTomlTimeout(t *testing.T) {
+	resetRunCmd(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{
+			"id": "msg_test",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "Hello from mock"}],
+			"model": "claude-sonnet-4-20250514",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`))
+	}))
+	defer server.Close()
+
+	setupRunTestAgent(t, "flag-timeout-agent", `name = "flag-timeout-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+timeout = 300
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	// Pass --timeout 1 to override TOML value of 300
+	rootCmd.SetArgs([]string{"run", "flag-timeout-agent", "--timeout", "1"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for timeout, got nil")
+	}
+
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != 3 {
+		t.Errorf("expected exit code 3 (timeout), got %d", exitErr.Code)
+	}
+}
+
+func TestRun_FlagTimeoutDefaultValueOverridesToml(t *testing.T) {
+	resetRunCmd(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"Hello from mock"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`))
+	}))
+	defer server.Close()
+
+	setupRunTestAgent(t, "flag-default-timeout-agent", `name = "flag-default-timeout-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+timeout = 1
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	// Pass --timeout 120 explicitly to override TOML value of 1
+	rootCmd.SetArgs([]string{"run", "flag-default-timeout-agent", "--timeout", "120"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected success (no timeout), got error: %v", err)
+	}
 }

--- a/docs/plans/045_agent_run_timeout_config_implement.md
+++ b/docs/plans/045_agent_run_timeout_config_implement.md
@@ -1,0 +1,129 @@
+---
+
+# 045 — Agent Run Timeout Configuration: Implementation Guide
+
+## Section 1: Context Summary
+
+**Spec:** `045_agent_run_timeout_config_spec.md`
+
+Issue #60 reports that `sub_agents_config.timeout` has no effect on the main agent run — it only controls sub-agent delegation timeouts. The fix is a new top-level `timeout` field in `AgentConfig` that sets the default run timeout per-agent in TOML. Resolution order is: explicit `--timeout` flag > TOML `timeout` field > hard default of 120 seconds. Cobra's `cmd.Flags().Changed("timeout")` distinguishes an explicit user-supplied flag from the flag sitting at its default value. The `--timeout` flag default (120) and `sub_agents_config.timeout` behavior are both unchanged.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Task 1 — Add `Timeout` field to `AgentConfig`
+
+- [x] `internal/agent/agent.go`: Add `Timeout int \`toml:"timeout"\`` as a top-level field on the `AgentConfig` struct, after the `Workdir` field and before `Tools`.
+
+---
+
+### Task 2 — Validate the new field
+
+- [x] `internal/agent/agent.go`: `Validate()` — add a guard immediately after the existing `SubAgentsConf.Timeout` validation block:
+  ```
+  if cfg.Timeout < 0 {
+      return &ValidationError{msg: "timeout must be non-negative"}
+  }
+  ```
+
+---
+
+### Task 3 — Update the scaffold template
+
+- [x] `internal/agent/agent.go`: `Scaffold()` — add `# timeout = 120` as a commented line near the top of the template, after `# workdir = ""` and before the `# sub_agents = []` line.
+
+---
+
+### Task 4 — Resolve effective timeout in `runAgent`
+
+- [x] `cmd/run.go`: `runAgent()` — replace the single-line flag read at line ~298:
+  ```go
+  timeout, _ := cmd.Flags().GetInt("timeout")
+  ```
+  with a three-step resolution block:
+  ```go
+  timeout := 120
+  if cfg.Timeout > 0 {
+      timeout = cfg.Timeout
+  }
+  if cmd.Flags().Changed("timeout") {
+      timeout, _ = cmd.Flags().GetInt("timeout")
+  }
+  ```
+  The `timeout` variable is already used downstream at lines ~323 (dry-run call) and ~326 (context creation) — no further changes to those call sites are needed.
+
+---
+
+### Task 5 — Display `Timeout` in `agents show`
+
+- [x] `cmd/agents.go`: inside the `showCmd` `RunE` closure — add a conditional display block for the new top-level field, placed after the `Workdir` block (around line ~93) and before the `Tools` block:
+  ```go
+  if cfg.Timeout > 0 {
+      _, _ = fmt.Fprintf(w, "%-16s%d\n", "Timeout:", cfg.Timeout)
+  }
+  ```
+
+---
+
+### Task 6 — Test: `AgentConfig` parsing of new field
+
+- [x] `internal/agent/agent_test.go`: add `TestLoad_TopLevelTimeout` — write a TOML with `timeout = 300`, load it, assert `cfg.Timeout == 300`.
+
+---
+
+### Task 7 — Test: `Validate()` rejects negative timeout
+
+- [x] `internal/agent/agent_test.go`: add `TestValidate_TopLevelTimeoutNegative` — construct `AgentConfig{Name: "x", Model: "p/m", Timeout: -1}`, call `Validate()`, assert error message equals `"timeout must be non-negative"`.
+
+---
+
+### Task 8 — Test: `Validate()` accepts zero and positive timeout
+
+- [x] `internal/agent/agent_test.go`: add `TestValidate_TopLevelTimeoutZeroAndPositive` — table-driven test with `timeout = 0` and `timeout = 300`, assert `Validate()` returns nil for both.
+
+---
+
+### Task 9 — Test: `Scaffold()` contains new commented line
+
+- [x] `internal/agent/agent_test.go`: extend `TestScaffold_IncludesSubAgentsConfig` (or add `TestScaffold_IncludesTopLevelTimeout`) — assert scaffold output contains `"# timeout = 120"` as a top-level line (distinct from the one inside `# [sub_agents_config]`).
+
+---
+
+### Task 10 — Test: TOML timeout used when flag not explicitly set
+
+- [x] `cmd/run_test.go`: add `TestRun_TomlTimeoutUsedWhenFlagAbsent` — set up a slow mock server (sleeps >1s), configure agent TOML with `timeout = 1`, do **not** pass `--timeout` flag, assert the run returns a timeout `ExitError` with code 3. This proves the TOML value was applied.
+
+---
+
+### Task 11 — Test: explicit `--timeout` flag overrides TOML timeout
+
+- [x] `cmd/run_test.go`: add `TestRun_FlagTimeoutOverridesTomlTimeout` — set up a slow mock server (sleeps >1s), configure agent TOML with `timeout = 300`, pass `--timeout 1` explicitly, assert the run returns a timeout `ExitError` with code 3. This proves the flag wins over the TOML value.
+
+---
+
+### Task 12 — Test: `--timeout` flag equal to default still overrides TOML
+
+- [x] `cmd/run_test.go`: add `TestRun_FlagTimeoutDefaultValueOverridesToml` — set up a mock server that responds immediately with a valid LLM response, configure agent TOML with `timeout = 1`, pass `--timeout 120` explicitly, assert the run **succeeds** (no timeout error). This proves that an explicit `--timeout 120` wins over `timeout = 1` in TOML.
+
+---
+
+### Task 13 — Test: `agents show` displays `Timeout` when non-zero
+
+- [x] `cmd/agents_test.go`: add `TestAgentsShow_TopLevelTimeout` — write an agent TOML with `timeout = 300` (no `sub_agents`), run `agents show`, assert output contains `"Timeout:"` and `"300"`.
+
+---
+
+### Task 14 — Test: `agents show` omits `Timeout` when zero
+
+- [x] `cmd/agents_test.go`: add `TestAgentsShow_TopLevelTimeoutOmittedWhenZero` — write an agent TOML with no `timeout` field, run `agents show`, assert output does **not** contain `"Timeout:"` (the top-level one; sub-agents section is absent too).
+
+---
+
+### Task 15 — Verify golden files remain correct
+
+- [x] `cmd/testdata/golden/dry-run/`: confirm all six golden files still show `Timeout:  120s` — no edits needed since the fixture agents in `cmd/testdata/agents/` do not set the new top-level `timeout` field. Run `go test ./cmd/... -run TestGolden` to confirm.
+
+---
+
+*End of implementation guide.*

--- a/docs/plans/045_agent_run_timeout_config_spec.md
+++ b/docs/plans/045_agent_run_timeout_config_spec.md
@@ -1,0 +1,168 @@
+---
+
+# 045 — Agent Run Timeout Configuration
+
+## Section 1: Context & Constraints
+
+### Milestone Entry
+
+**Issue #60:** Allow configuring the `run` timeout in agent TOML config, in addition to the `--timeout` CLI flag.
+
+- The `--timeout` flag must still override the TOML value when explicitly provided by the user.
+- Setting `sub_agents_config.timeout` currently has no effect on the main agent run timeout — only on sub-agent delegation timeouts.
+
+### Research Findings
+
+#### Codebase Structure
+
+- **`internal/agent/agent.go`** — Defines `AgentConfig` (the TOML struct), `SubAgentsConfig`, and `Validate()`. All top-level agent fields live here.
+- **`cmd/run.go`** — Main entry point for `axe run`. Reads the `--timeout` flag (default: 120), creates a `context.WithTimeout` for the entire agent execution, and passes `cfg.SubAgentsConf.Timeout` to sub-agent execution options.
+- **`cmd/agents.go`** — `agents show` command; displays agent config fields.
+- **`internal/tool/tool.go`** — Sub-agent execution; uses `ExecuteOptions.Timeout` (sourced from `cfg.SubAgentsConf.Timeout`) to create a per-sub-agent timeout context.
+- **`cmd/testdata/golden/dry-run/`** — Golden files for dry-run output. All currently show `Timeout:  120s` on line 5.
+- **`cmd/testdata/agents/`** — Fixture agent TOML files used in golden tests.
+
+#### Decisions Already Made
+
+- **Top-level `timeout` field** (not reuse of `sub_agents_config.timeout`) is the chosen approach. The run timeout is not sub-agent-specific; it controls the entire agent execution. Reusing `sub_agents_config.timeout` would be semantically incorrect.
+- **Resolution order:** `--timeout` flag (when explicitly set by user) > TOML `timeout` field > default (120 seconds). This is consistent with how other flag/TOML overrides work in the codebase (e.g., `--model`, `--workdir`).
+- **Cobra's `cmd.Flags().Changed("timeout")`** is the correct mechanism to distinguish "user explicitly passed `--timeout`" from "flag is at its default value of 120". This is the standard cobra pattern; no other mechanism is needed.
+
+#### Approaches Ruled Out
+
+- **Reusing `sub_agents_config.timeout`** for the main run: ruled out — semantically wrong; `sub_agents_config` controls sub-agent delegation only.
+- **Removing the `--timeout` flag default**: ruled out — would be a breaking change.
+- **Changing `sub_agents_config.timeout` behavior**: ruled out — its existing behavior (sub-agent delegation timeout) is correct and must not change.
+
+#### Constraints
+
+- The `--timeout` flag default remains 120 seconds. Backward compatibility must be preserved.
+- `sub_agents_config.timeout` behavior is unchanged.
+- The new `timeout` field is top-level in `AgentConfig`, not nested.
+- Zero (`0`) means "not set" for the TOML field — the default (120s) applies. Negative values are invalid.
+- The `--timeout` flag (when explicitly passed) always wins, regardless of the TOML value.
+- All existing tests must continue to pass.
+- Golden files must be updated to reflect any output changes.
+
+#### Open Questions Resolved
+
+- **What value means "not configured" in TOML?** Zero (`0`). TOML omits the field or sets it to `0` to mean "use default". This is consistent with other optional integer fields in `AgentConfig` (e.g., `params.max_tokens`, `budget.max_tokens`).
+- **What is the default timeout?** 120 seconds — unchanged from the current `--timeout` flag default.
+- **Does the new field appear in `agents show` output?** Yes, when non-zero.
+- **Does the new field appear in dry-run output?** Yes — the dry-run `Timeout:` line already shows the effective timeout; it will now reflect the TOML value when the flag is not explicitly set.
+- **Does the new field appear in verbose stderr output?** Yes — the verbose `Timeout:` line will reflect the effective timeout.
+- **Does the scaffold template include the new field?** Yes, as a commented-out example.
+
+---
+
+## Section 2: Requirements
+
+### 2.1 New TOML Field: `timeout`
+
+A new optional integer field `timeout` must be added at the top level of the agent TOML configuration.
+
+- Field name: `timeout`
+- Type: integer (seconds)
+- Default when absent or zero: 120 seconds (the existing default)
+- Valid range: 0 (not set) or any positive integer
+- Negative values are invalid and must be rejected at validation time with the error message: `"timeout must be non-negative"`
+
+Example TOML:
+```toml
+name = "my-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+timeout = 300
+```
+
+### 2.2 Timeout Resolution Order
+
+The effective timeout for the main agent run must be resolved in the following order (highest precedence first):
+
+1. **`--timeout` flag** — only when the user explicitly passes it on the command line (i.e., the flag was changed from its default)
+2. **TOML `timeout` field** — when non-zero and the flag was not explicitly set
+3. **Default: 120 seconds** — when neither the flag was explicitly set nor the TOML field is non-zero
+
+The `--timeout` flag default value (120) must not be treated as an explicit user override. Only a user-supplied `--timeout` value takes precedence over the TOML field.
+
+### 2.3 Validation
+
+The `timeout` field must be validated as part of the existing `Validate()` function:
+
+- If `timeout < 0`: return a `ValidationError` with message `"timeout must be non-negative"`
+- If `timeout == 0`: valid (means "not set"; default applies)
+- If `timeout > 0`: valid
+
+### 2.4 Scaffold Template
+
+The scaffold template (used by `axe agents init`) must include the new field as a commented-out example:
+
+```toml
+# timeout = 120
+```
+
+This line must appear near the top of the template, in the vicinity of other top-level fields (before section headers like `[sub_agents_config]`).
+
+### 2.5 Display: `agents show`
+
+The `agents show` command must display the `timeout` field when it is non-zero:
+
+```
+Timeout:        300
+```
+
+The field must only be shown when `cfg.Timeout > 0` (i.e., not shown when using the default).
+
+### 2.6 Display: Dry-Run Output
+
+The dry-run output line `Timeout:  <N>s` must reflect the **effective timeout** (after resolution per §2.2). No structural change to the dry-run format is required.
+
+### 2.7 Display: Verbose Stderr
+
+The verbose stderr line `Timeout:  <N>s` must reflect the **effective timeout** (after resolution per §2.2). No structural change to the verbose output format is required.
+
+### 2.8 Golden File Updates
+
+All golden files that contain `Timeout:  120s` must remain correct. Since the fixture agent TOML files do not set the new top-level `timeout` field, the effective timeout for those agents remains 120s and the golden files do not need content changes.
+
+If a new golden file is added for a fixture agent that sets `timeout`, it must show the TOML-configured value.
+
+### 2.9 No Change to Sub-Agent Timeout
+
+`sub_agents_config.timeout` behavior is unchanged. It continues to control only the timeout applied to individual sub-agent delegations, not the main agent run.
+
+### 2.10 Edge Cases
+
+| Scenario | Expected Behavior |
+|---|---|
+| TOML `timeout` absent or `0`, no `--timeout` flag | Effective timeout = 120s |
+| TOML `timeout = 300`, no `--timeout` flag | Effective timeout = 300s |
+| TOML `timeout = 300`, `--timeout 60` explicitly passed | Effective timeout = 60s (flag wins) |
+| TOML `timeout` absent, `--timeout 60` explicitly passed | Effective timeout = 60s |
+| TOML `timeout = -1` | Validation error: `"timeout must be non-negative"` |
+| TOML `timeout = 0` | Valid; treated as "not set"; effective timeout = 120s |
+| TOML `timeout = 300`, `--timeout 120` explicitly passed | Effective timeout = 120s (flag wins, even though it equals the default) |
+
+### 2.11 Test Coverage
+
+The following test scenarios must be covered:
+
+**`internal/agent/agent_test.go`:**
+- Parsing a TOML with `timeout = 300` populates `cfg.Timeout = 300`
+- `Validate()` rejects `timeout = -1` with message `"timeout must be non-negative"`
+- `Validate()` accepts `timeout = 0`
+- `Validate()` accepts `timeout = 300`
+- `Scaffold()` output contains `# timeout = 120`
+
+**`cmd/run_test.go`:**
+- TOML `timeout = 300` with no `--timeout` flag → effective timeout is 300s (context deadline reflects 300s)
+- `--timeout 60` explicitly passed with TOML `timeout = 300` → effective timeout is 60s (flag wins)
+- No TOML timeout, no `--timeout` flag → effective timeout is 120s (default)
+- `--timeout 120` explicitly passed with TOML `timeout = 300` → effective timeout is 120s (flag wins even when equal to default)
+
+**`cmd/agents_test.go`:**
+- `agents show` displays `Timeout:` line when `cfg.Timeout > 0`
+- `agents show` does not display `Timeout:` line when `cfg.Timeout == 0`
+
+---
+
+*End of spec.*

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -79,6 +79,7 @@ type AgentConfig struct {
 	Skill         string            `toml:"skill"`
 	Files         []string          `toml:"files"`
 	Workdir       string            `toml:"workdir"`
+	Timeout       int               `toml:"timeout"`
 	Tools         []string          `toml:"tools"`
 	AllowedHosts  []string          `toml:"allowed_hosts"`
 	MCPServers    []MCPServerConfig `toml:"mcp_servers"`
@@ -109,6 +110,9 @@ func Validate(cfg *AgentConfig) error {
 	}
 	if cfg.SubAgentsConf.Timeout < 0 {
 		return &ValidationError{msg: "sub_agents_config.timeout must be non-negative"}
+	}
+	if cfg.Timeout < 0 {
+		return &ValidationError{msg: "timeout must be non-negative"}
 	}
 	if cfg.Memory.LastN < 0 {
 		return &ValidationError{msg: "memory.last_n must be non-negative"}
@@ -329,6 +333,9 @@ model = "provider/model-name"
 
 # Working directory (optional)
 # workdir = ""
+
+# Run timeout in seconds (optional, default: 120)
+# timeout = 120
 
 # Tools this agent can use (optional)
 # Valid: list_directory, read_file, write_file, edit_file, run_command, url_fetch, web_search

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1645,7 +1645,77 @@ func TestScaffold_IncludesBudgetConfig(t *testing.T) {
 	}
 }
 
-// --- Artifacts Config tests ---
+// --- TopLevel Timeout Tests ---
+
+func TestLoad_TopLevelTimeout(t *testing.T) {
+	agentsDir := setupAgentsDir(t)
+
+	tomlContent := `
+name = "timeout-agent"
+model = "openai/gpt-4o"
+timeout = 300
+`
+	writeAgentFile(t, agentsDir, "timeout-agent", tomlContent)
+
+	cfg, err := Load("timeout-agent", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Timeout != 300 {
+		t.Errorf("Timeout = %d, want 300", cfg.Timeout)
+	}
+}
+
+func TestValidate_TopLevelTimeoutNegative(t *testing.T) {
+	cfg := &AgentConfig{
+		Name:    "x",
+		Model:   "p/m",
+		Timeout: -1,
+	}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for timeout=-1, got nil")
+	}
+	want := "timeout must be non-negative"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidate_TopLevelTimeoutZeroAndPositive(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout int
+	}{
+		{name: "zero", timeout: 0},
+		{name: "positive", timeout: 300},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &AgentConfig{
+				Name:    "x",
+				Model:   "p/m",
+				Timeout: tc.timeout,
+			}
+			err := Validate(cfg)
+			if err != nil {
+				t.Fatalf("expected no error for timeout=%d, got %v", tc.timeout, err)
+			}
+		})
+	}
+}
+
+func TestScaffold_IncludesTopLevelTimeout(t *testing.T) {
+	out, err := Scaffold("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "# timeout = 120") {
+		t.Errorf("scaffold output missing '# timeout = 120'\nfull output:\n%s", out)
+	}
+}
 
 func TestValidate_Artifacts(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a top-level `timeout` configuration field to agent TOML files, allowing users to specify a default timeout at the agent level. It implements proper timeout precedence where the TOML configuration baseline can be overridden by explicit CLI flags. The changes also refine the CLI output to display timeout-related fields only when they have meaningful values and clarify the distinction between top-level and sub-agent timeouts.

## Changelog

### Added
- Top-level `timeout` configuration field to `AgentConfig` TOML (with 120-second baseline)
- Display of top-level `Timeout` field in `agents show` output when configured
- Table-driven test `TestRun_TimeoutPrecedence` for timeout precedence validation across TOML and CLI flag scenarios
- Table-driven test `TestAgentsShow_TopLevelTimeout_Table` for top-level timeout display coverage
- Four new test cases for top-level timeout parsing, validation, and scaffold output

### Changed
- Timeout precedence order: TOML `timeout` is now the baseline, overridable by explicit `--timeout` CLI flag
- Sub-agent timeout field label from `Timeout:` to `Sub-Agent Timeout:` for clarity
- Conditional output of timeout-related fields to display only when they contain meaningful values
- Agent TOML scaffold template to document the optional `timeout` configuration

### Fixed
- Omit zero-valued fields (`MaxDepth`, `Parallel`, `Sub-Agent Timeout`) from output when `[sub_agents_config]` block is absent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Satisfies https://github.com/jrswab/axe/issues/60