### PR TITLE
ISS-62 - Add Turn and Duration to Tool Call Details

### DIFF
--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -87,6 +87,9 @@ func maskJSONOutput(output string) string {
 			if _, hasOutput := entry["output"]; hasOutput {
 				entry["output"] = "{{TOOL_OUTPUT}}"
 			}
+			if _, hasDuration := entry["duration_ms"]; hasDuration {
+				entry["duration_ms"] = "{{TOOL_DURATION_MS}}"
+			}
 		}
 	}
 
@@ -422,6 +425,22 @@ func TestMaskJSONOutput(t *testing.T) {
 				// Should end with newline.
 				if !strings.HasSuffix(got, "\n") {
 					t.Errorf("expected trailing newline, got:\n%q", got)
+				}
+			},
+		},
+		{
+			name:  "masks tool_call_details duration_ms",
+			input: `{"model":"gpt-4o","duration_ms":1,"tool_call_details":[{"name":"read_file","input":{"path":"a.txt"},"output":"text","is_error":false,"turn":0,"duration_ms":42}]}` ,
+			check: func(t *testing.T, got string) {
+				if !strings.Contains(got, `"duration_ms": "{{TOOL_DURATION_MS}}"`) {
+					t.Errorf("expected tool_call_details duration_ms to be masked, got:\n%s", got)
+				}
+				// turn should NOT be masked - it should remain a number
+				if strings.Contains(got, `"turn": "{{`) {
+					t.Errorf("expected turn to NOT be masked, got:\n%s", got)
+				}
+				if !strings.Contains(got, `"turn": 0`) {
+					t.Errorf("expected turn to be preserved as number 0, got:\n%s", got)
 				}
 			},
 		},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,10 +37,17 @@ const maxConversationTurns = 50
 const maxToolOutputBytes = 1024
 
 type toolCallDetail struct {
-	Name    string            `json:"name"`
-	Input   map[string]string `json:"input"`
-	Output  string            `json:"output"`
-	IsError bool              `json:"is_error"`
+	Name       string            `json:"name"`
+	Input      map[string]string `json:"input"`
+	Output     string            `json:"output"`
+	IsError    bool              `json:"is_error"`
+	Turn       int               `json:"turn"`
+	DurationMs int64             `json:"duration_ms"`
+}
+
+type toolExecResult struct {
+	Result   provider.ToolResult
+	Duration time.Duration
 }
 
 var runCmd = &cobra.Command{
@@ -591,18 +598,24 @@ func runAgent(cmd *cobra.Command, args []string) error {
 					}
 
 					allToolCallDetails = append(allToolCallDetails, toolCallDetail{
-						Name:    tc.Name,
-						Input:   input,
-						Output:  truncateOutput(results[i].Content),
-						IsError: results[i].IsError,
+						Name:       tc.Name,
+						Input:      input,
+						Output:     truncateOutput(results[i].Result.Content),
+						IsError:    results[i].Result.IsError,
+						Turn:       turn,
+						DurationMs: results[i].Duration.Milliseconds(),
 					})
 				}
 			}
 
 			// Append tool result message
+			toolResults := make([]provider.ToolResult, len(results))
+			for i, r := range results {
+				toolResults[i] = r.Result
+			}
 			toolMsg := provider.Message{
 				Role:        "tool",
-				ToolResults: results,
+				ToolResults: toolResults,
 			}
 			req.Messages = append(req.Messages, toolMsg)
 		}
@@ -791,8 +804,8 @@ func printDryRun(cmd *cobra.Command, cfg *agent.AgentConfig, provName, modelName
 
 // executeToolCalls dispatches tool calls and returns results.
 // When parallel is true and there are multiple calls, they run concurrently.
-func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *agent.AgentConfig, globalCfg *config.GlobalConfig, registry *tool.Registry, mcpRouter *mcpclient.Router, depth, maxDepth int, parallel, verbose bool, stderr io.Writer, workdir string, budgetTracker *budget.BudgetTracker, agentsDir string, agentsBase string, artifactDir string, artifactTracker *artifact.Tracker) []provider.ToolResult {
-	results := make([]provider.ToolResult, len(toolCalls))
+func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *agent.AgentConfig, globalCfg *config.GlobalConfig, registry *tool.Registry, mcpRouter *mcpclient.Router, depth, maxDepth int, parallel, verbose bool, stderr io.Writer, workdir string, budgetTracker *budget.BudgetTracker, agentsDir string, agentsBase string, artifactDir string, artifactTracker *artifact.Tracker) []toolExecResult {
+	results := make([]toolExecResult, len(toolCalls))
 
 	execOpts := tool.ExecuteOptions{
 		AllowedAgents:   cfg.SubAgents,
@@ -815,23 +828,27 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 	if len(toolCalls) == 1 || !parallel {
 		// Sequential execution (also used for single call)
 		for i, tc := range toolCalls {
+			start := time.Now()
+			var r provider.ToolResult
 			if mcpRouter != nil && mcpRouter.Has(tc.Name) {
-				results[i] = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
 			} else if tc.Name == tool.CallAgentToolName {
-				results[i] = tool.ExecuteCallAgent(ctx, tc, execOpts)
+				r = tool.ExecuteCallAgent(ctx, tc, execOpts)
 			} else {
-				results[i] = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
 			}
+			results[i] = toolExecResult{Result: r, Duration: time.Since(start)}
 		}
 	} else {
 		// Parallel execution
 		type indexedResult struct {
 			index  int
-			result provider.ToolResult
+			result toolExecResult
 		}
 		ch := make(chan indexedResult, len(toolCalls))
 		for i, tc := range toolCalls {
 			go func(idx int, call provider.ToolCall) {
+				start := time.Now()
 				var res provider.ToolResult
 				if mcpRouter != nil && mcpRouter.Has(call.Name) {
 					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
@@ -840,7 +857,7 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 				} else {
 					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
 				}
-				ch <- indexedResult{index: idx, result: res}
+				ch <- indexedResult{index: idx, result: toolExecResult{Result: res, Duration: time.Since(start)}}
 			}(i, tc)
 		}
 		for range toolCalls {

--- a/cmd/run_integration_test.go
+++ b/cmd/run_integration_test.go
@@ -982,6 +982,14 @@ model = "anthropic/claude-sonnet-4-20250514"
 	if isError, ok := entry["is_error"].(bool); !ok || isError {
 		t.Fatalf("expected tool_call_details[0].is_error to be false, got %v", entry["is_error"])
 	}
+	// Assert turn is 0 (first and only tool call turn)
+	if turnVal, ok := entry["turn"].(float64); !ok || turnVal != 0 {
+		t.Fatalf("expected tool_call_details[0].turn to be 0, got %v", entry["turn"])
+	}
+	// Assert duration_ms is a non-negative number
+	if durationVal, ok := entry["duration_ms"].(float64); !ok || durationVal < 0 {
+		t.Fatalf("expected tool_call_details[0].duration_ms to be non-negative number, got %v", entry["duration_ms"])
+	}
 	if out, ok := entry["output"].(string); !ok || out == "" {
 		t.Fatalf("expected tool_call_details[0].output to be non-empty string, got %v", entry["output"])
 	}
@@ -1684,7 +1692,7 @@ tools = ["read_file", "list_directory", "run_command"]
 		if !ok {
 			t.Fatalf("expected tool_call_details[%d] to be object, got %T", i, raw)
 		}
-		for _, key := range []string{"name", "input", "output", "is_error"} {
+		for _, key := range []string{"name", "input", "output", "is_error", "turn", "duration_ms"} {
 			if _, ok := entry[key]; !ok {
 				t.Fatalf("expected tool_call_details[%d] to include key %q", i, key)
 			}
@@ -1694,6 +1702,14 @@ tools = ["read_file", "list_directory", "run_command"]
 		}
 		if isError, ok := entry["is_error"].(bool); !ok || isError {
 			t.Fatalf("expected tool_call_details[%d].is_error=false, got %v", i, entry["is_error"])
+		}
+		// Assert turn is a non-negative number (all 3 tool calls happen in turn 0 since they're sequential in one LLM response)
+		if turnVal, ok := entry["turn"].(float64); !ok || turnVal < 0 {
+			t.Fatalf("expected tool_call_details[%d].turn to be non-negative number, got %v", i, entry["turn"])
+		}
+		// Assert duration_ms is a non-negative number
+		if durationVal, ok := entry["duration_ms"].(float64); !ok || durationVal < 0 {
+			t.Fatalf("expected tool_call_details[%d].duration_ms to be non-negative number, got %v", i, entry["duration_ms"])
 		}
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3662,3 +3662,245 @@ func TestRun_TimeoutPrecedence(t *testing.T) {
 		})
 	}
 }
+
+// TestRun_ToolCallDetails_ParallelSameTurn tests that tool_call_details correctly
+// captures multiple parallel tool calls in the same turn with proper turn and duration values.
+func TestRun_ToolCallDetails_ParallelSameTurn(t *testing.T) {
+	resetRunCmd(t)
+
+	var mu sync.Mutex
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		currentCall := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if currentCall == 1 {
+			// First call: return two parallel tool calls (both list_directory)
+			_, _ = w.Write([]byte(`{
+				"id": "msg_1",
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "tc_1", "name": "list_directory", "input": {"path": "."}},
+					{"type": "tool_use", "id": "tc_2", "name": "list_directory", "input": {"path": "."}}
+				],
+				"model": "claude-sonnet-4-20250514",
+				"stop_reason": "tool_use",
+				"usage": {"input_tokens": 10, "output_tokens": 20}
+			}`))
+		} else {
+			// Second call: final text response
+			_, _ = w.Write([]byte(`{
+				"id": "msg_2",
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "text", "text": "done"}],
+				"model": "claude-sonnet-4-20250514",
+				"stop_reason": "end_turn",
+				"usage": {"input_tokens": 10, "output_tokens": 5}
+			}`))
+		}
+	}))
+	defer server.Close()
+
+	setupRunTestAgent(t, "parallel-tool-details", "name = \"parallel-tool-details\"\nmodel = \"anthropic/claude-sonnet-4-20250514\"\ntools = [\"list_directory\"]\n")
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "parallel-tool-details", "--json"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %q", err, buf.String())
+	}
+
+	// Assert 1: tool_call_details has exactly 2 entries
+	detailsRaw, ok := result["tool_call_details"]
+	if !ok {
+		t.Fatalf("expected tool_call_details field to be present")
+	}
+	details, ok := detailsRaw.([]interface{})
+	if !ok {
+		t.Fatalf("expected tool_call_details to be array, got %T", detailsRaw)
+	}
+	if len(details) != 2 {
+		t.Fatalf("expected tool_call_details length 2, got %d", len(details))
+	}
+
+	// Assert 2: Both entries have turn == 0 (same turn, parallel calls)
+	for i, raw := range details {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected tool_call_details[%d] to be object, got %T", i, raw)
+		}
+		turn, ok := entry["turn"].(float64)
+		if !ok {
+			t.Fatalf("expected tool_call_details[%d].turn to be number, got %T", i, entry["turn"])
+		}
+		if int(turn) != 0 {
+			t.Errorf("expected tool_call_details[%d].turn=0, got %v", i, turn)
+		}
+	}
+
+	// Assert 3: Each entry has its own duration_ms value (both non-negative numbers)
+	for i, raw := range details {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected tool_call_details[%d] to be object, got %T", i, raw)
+		}
+		durationMs, ok := entry["duration_ms"].(float64)
+		if !ok {
+			t.Fatalf("expected tool_call_details[%d].duration_ms to be number, got %T", i, entry["duration_ms"])
+		}
+		if durationMs < 0 {
+			t.Errorf("expected tool_call_details[%d].duration_ms >= 0, got %v", i, durationMs)
+		}
+	}
+}
+
+// TestRun_ToolCallDetails_TurnAndDuration tests that tool_call_details correctly captures
+// turn numbers and duration_ms across multiple tool call turns.
+func TestRun_ToolCallDetails_TurnAndDuration(t *testing.T) {
+	resetRunCmd(t)
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 0 {
+			callCount++
+			_, _ = w.Write([]byte(`{
+				"id": "msg_1",
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "tc_1", "name": "list_directory", "input": {"path": "."}}
+				],
+				"model": "claude-sonnet-4-20250514",
+				"stop_reason": "tool_use",
+				"usage": {"input_tokens": 10, "output_tokens": 20}
+			}`))
+			return
+		}
+		if callCount == 1 {
+			callCount++
+			_, _ = w.Write([]byte(`{
+				"id": "msg_2",
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "tc_2", "name": "list_directory", "input": {"path": "."}}
+				],
+				"model": "claude-sonnet-4-20250514",
+				"stop_reason": "tool_use",
+				"usage": {"input_tokens": 10, "output_tokens": 20}
+			}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"id": "msg_3",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "done"}],
+			"model": "claude-sonnet-4-20250514",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`))
+	}))
+	defer server.Close()
+
+	setupRunTestAgent(t, "turn-duration-agent", `name = "turn-duration-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+tools = ["list_directory"]
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "turn-duration-agent", "--json"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %q", err, buf.String())
+	}
+
+	detailsRaw, ok := result["tool_call_details"]
+	if !ok {
+		t.Fatalf("expected tool_call_details field to be present")
+	}
+	details, ok := detailsRaw.([]interface{})
+	if !ok {
+		t.Fatalf("expected tool_call_details to be array, got %T", detailsRaw)
+	}
+	if len(details) != 2 {
+		t.Fatalf("expected tool_call_details length 2, got %d", len(details))
+	}
+
+	// Check first entry
+	entry0, ok := details[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tool_call_details[0] to be object, got %T", details[0])
+	}
+	if turn, ok := entry0["turn"].(float64); !ok || turn != 0 {
+		t.Fatalf("expected tool_call_details[0].turn == 0, got %v", entry0["turn"])
+	}
+	if _, ok := entry0["duration_ms"]; !ok {
+		t.Fatalf("expected tool_call_details[0] to have duration_ms")
+	}
+	if _, ok := entry0["name"]; !ok {
+		t.Fatalf("expected tool_call_details[0] to have name")
+	}
+	if _, ok := entry0["input"]; !ok {
+		t.Fatalf("expected tool_call_details[0] to have input")
+	}
+	if _, ok := entry0["output"]; !ok {
+		t.Fatalf("expected tool_call_details[0] to have output")
+	}
+	if _, ok := entry0["is_error"]; !ok {
+		t.Fatalf("expected tool_call_details[0] to have is_error")
+	}
+
+	// Check second entry
+	entry1, ok := details[1].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected tool_call_details[1] to be object, got %T", details[1])
+	}
+	if turn, ok := entry1["turn"].(float64); !ok || turn != 1 {
+		t.Fatalf("expected tool_call_details[1].turn == 1, got %v", entry1["turn"])
+	}
+	if _, ok := entry1["duration_ms"]; !ok {
+		t.Fatalf("expected tool_call_details[1] to have duration_ms")
+	}
+	if _, ok := entry1["name"]; !ok {
+		t.Fatalf("expected tool_call_details[1] to have name")
+	}
+	if _, ok := entry1["input"]; !ok {
+		t.Fatalf("expected tool_call_details[1] to have input")
+	}
+	if _, ok := entry1["output"]; !ok {
+		t.Fatalf("expected tool_call_details[1] to have output")
+	}
+	if _, ok := entry1["is_error"]; !ok {
+		t.Fatalf("expected tool_call_details[1] to have is_error")
+	}
+}

--- a/cmd/testdata/golden/json/with_subagents.json
+++ b/cmd/testdata/golden/json/with_subagents.json
@@ -9,22 +9,26 @@
   "stop_reason": "end_turn",
   "tool_call_details": [
     {
+      "duration_ms": "{{TOOL_DURATION_MS}}",
       "input": {
         "agent": "basic",
         "task": "hello"
       },
       "is_error": false,
       "name": "call_agent",
-      "output": "{{TOOL_OUTPUT}}"
+      "output": "{{TOOL_OUTPUT}}",
+      "turn": 0
     },
     {
+      "duration_ms": "{{TOOL_DURATION_MS}}",
       "input": {
         "agent": "with_skill",
         "task": "hello"
       },
       "is_error": false,
       "name": "call_agent",
-      "output": "{{TOOL_OUTPUT}}"
+      "output": "{{TOOL_OUTPUT}}",
+      "turn": 0
     }
   ],
   "tool_calls": 2

--- a/cmd/testdata/golden/json/with_tools.json
+++ b/cmd/testdata/golden/json/with_tools.json
@@ -9,12 +9,14 @@
   "stop_reason": "stop",
   "tool_call_details": [
     {
+      "duration_ms": "{{TOOL_DURATION_MS}}",
       "input": {
         "path": "."
       },
       "is_error": false,
       "name": "list_directory",
-      "output": "{{TOOL_OUTPUT}}"
+      "output": "{{TOOL_OUTPUT}}",
+      "turn": 0
     }
   ],
   "tool_calls": 1

--- a/docs/plans/046_tool_call_trajectory_implement.md
+++ b/docs/plans/046_tool_call_trajectory_implement.md
@@ -1,0 +1,101 @@
+# 046 — Tool Call Trajectory in `--json` Output: Implementation Guide
+
+## Section 1: Context Summary
+
+**Spec:** `docs/plans/046_tool_call_trajectory_spec.md`
+
+The `--json` output envelope already captures tool call metadata in a `tool_call_details` array, but each entry lacks the conversation turn it occurred in and how long it took. This implementation adds `turn` (0-indexed int matching the conversation loop variable) and `duration_ms` (per-call wall-clock int) to every `toolCallDetail` entry. The existing `tool_calls` integer count, `output`, `is_error`, `name`, and `input` fields are untouched. Timing is measured at the dispatch layer inside `executeToolCalls`, not in the provider. The golden test sanitizer must be extended to mask `duration_ms` inside entries (non-deterministic) while leaving `turn` unmasked (deterministic).
+
+---
+
+## Section 2: Implementation Checklist
+
+### Task 1 — Add `Turn` and `DurationMs` fields to `toolCallDetail`
+
+- [x] `cmd/run.go`: Add `Turn int` (json tag `"turn"`) and `DurationMs int64` (json tag `"duration_ms"`) fields to the `toolCallDetail` struct (currently at lines 39–44).
+
+---
+
+### Task 2 — Introduce `toolExecResult` wrapper struct
+
+- [x] `cmd/run.go`: Define a new unexported struct `toolExecResult` immediately after `toolCallDetail`:
+  ```
+  type toolExecResult struct {
+      Result   provider.ToolResult
+      Duration time.Duration
+  }
+  ```
+  This bundles each dispatch result with its measured wall-clock duration, keeping timing data co-located with the result it describes.
+
+---
+
+### Task 3 — Change `executeToolCalls` return type to `[]toolExecResult`
+
+- [x] `cmd/run.go: executeToolCalls()`: Change the return type from `[]provider.ToolResult` to `[]toolExecResult`.
+- [x] `cmd/run.go: executeToolCalls()`: In the sequential path (the `if len(toolCalls) == 1 || !parallel` branch), wrap each dispatch call with `time.Now()` / `time.Since()` and store into `toolExecResult{Result: ..., Duration: ...}`.
+- [x] `cmd/run.go: executeToolCalls()`: In the parallel path (the goroutine branch), wrap each dispatch call inside the goroutine with `time.Now()` / `time.Since()` and send `toolExecResult{Result: ..., Duration: ...}` on the channel. Update the `indexedResult` struct to hold `toolExecResult` instead of `provider.ToolResult`.
+
+---
+
+### Task 4 — Update the conversation loop to use `[]toolExecResult`
+
+- [x] `cmd/run.go: runAgent()`: Update the call site of `executeToolCalls` (line ~583) to receive `[]toolExecResult` instead of `[]provider.ToolResult`.
+- [x] `cmd/run.go: runAgent()`: In the `tool_call_details` collection block (lines ~586–600), populate `Turn` from the loop variable `turn` and `DurationMs` from `results[i].Duration.Milliseconds()`. Access the result content and error flag via `results[i].Result.Content` and `results[i].Result.IsError`.
+- [x] `cmd/run.go: runAgent()`: In the tool message construction block (lines ~602–607), extract `[]provider.ToolResult` from the `[]toolExecResult` slice before building `provider.Message{Role: "tool", ToolResults: ...}`.
+
+---
+
+### Task 5 — Update `TestToolCallDetailJSON` for new fields
+
+- [x] `cmd/run_test.go: TestToolCallDetailJSON()`: Add `Turn: 0` and `DurationMs: 42` to the `toolCallDetail` literal. Extend the key-presence check to include `"turn"` and `"duration_ms"`. Assert `turn` marshals as a JSON number equal to `0` and `duration_ms` marshals as a JSON number equal to `42`.
+
+---
+
+### Task 6 — Add unit test for turn numbering across multiple conversation turns
+
+- [x] `cmd/run_test.go`: Add a new test `TestRun_ToolCallDetails_TurnAndDuration` that:
+  - Starts a mock Anthropic HTTP server that returns a tool-use response on the first call (one tool call), then a second tool-use response on the second call (one tool call), then a final text response on the third call.
+  - Runs `axe run <agent> --json` against the mock.
+  - Asserts `tool_call_details` has exactly 2 entries.
+  - Asserts `tool_call_details[0].turn == 0` and `tool_call_details[1].turn == 1`.
+  - Asserts both entries have a `duration_ms` key whose value is a non-negative number.
+  - Asserts existing fields (`name`, `input`, `output`, `is_error`) are still present on both entries.
+
+---
+
+### Task 7 — Add unit test for parallel tool calls sharing the same turn
+
+- [x] `cmd/run_test.go`: Add a new test `TestRun_ToolCallDetails_ParallelSameTurn` that:
+  - Starts a mock Anthropic HTTP server that returns two tool calls in a single response on the first call, then a final text response on the second call.
+  - Runs `axe run <agent> --json` against the mock.
+  - Asserts `tool_call_details` has exactly 2 entries.
+  - Asserts both entries have `turn == 0`.
+  - Asserts each entry has its own `duration_ms` value (both non-negative).
+
+---
+
+### Task 8 — Update integration test key assertions for `tool_call_details` entries
+
+- [x] `cmd/run_integration_test.go`: In every test that iterates `tool_call_details` entries and checks for keys (e.g., the loop at line ~1687 checking `[]string{"name", "input", "output", "is_error"}`), extend the key list to include `"turn"` and `"duration_ms"`.
+- [x] `cmd/run_integration_test.go`: In the multi-turn integration test (around line 1665), after verifying entry names, assert that entries from the first LLM turn have `turn == 0` and entries from the second LLM turn have `turn == 1`. Assert all `duration_ms` values are non-negative numbers.
+- [x] `cmd/run_integration_test.go`: In the `call_agent` integration test (around line 954), assert that the single `tool_call_details` entry has a `turn` key with value `0` and a `duration_ms` key with a non-negative value.
+
+---
+
+### Task 9 — Update golden test sanitizer to mask `duration_ms` inside entries
+
+- [x] `cmd/golden_test.go: maskJSONOutput()`: Inside the `tool_call_details` loop (lines 81–91), after masking `output`, add a check: if the entry has a `"duration_ms"` key, replace its value with the string `"{{TOOL_DURATION_MS}}"`. Do not mask `"turn"`.
+
+---
+
+### Task 10 — Update `TestMaskJSONOutput` for the new sanitizer behaviour
+
+- [x] `cmd/golden_test.go: TestMaskJSONOutput()`: Add a new table entry `"masks tool_call_details duration_ms"` whose input JSON includes a `tool_call_details` entry with a numeric `duration_ms` and a numeric `turn`. Assert the output contains `"duration_ms": "{{TOOL_DURATION_MS}}"` and that the `turn` value is preserved as a number (not replaced).
+
+---
+
+### Task 11 — Update any golden fixture files that contain `tool_call_details`
+
+- [x] `cmd/testdata/golden/`: For each golden file that contains a `tool_call_details` array, regenerate it by running `UPDATE_GOLDEN=1 go test ./cmd/...` after all code changes are complete. Verify the regenerated files contain `"turn"` (numeric) and `"duration_ms": "{{TOOL_DURATION_MS}}"` in each entry.
+
+---

--- a/docs/plans/046_tool_call_trajectory_spec.md
+++ b/docs/plans/046_tool_call_trajectory_spec.md
@@ -1,0 +1,160 @@
+---
+
+# 046 — Tool Call Trajectory in `--json` Output
+
+## Section 1: Context & Constraints
+
+### Milestone Source
+
+**GitHub Issue #62** — `feat: include tool call sequence in --json output`
+**Milestone:** 1.7.0
+**Labels:** enhancement, priority: medium
+
+### Codebase Patterns Relevant to This Milestone
+
+**JSON output envelope** (`cmd/run.go`):
+The `--json` flag produces a single JSON object on stdout. The envelope is built as `map[string]interface{}` and marshaled at the end of `runAgent`. The relevant existing fields:
+
+- `"tool_calls"` — `int`: total count of tool calls across all turns (already exists; must not be renamed or removed)
+- `"tool_call_details"` — `[]toolCallDetail`: flat array of per-call metadata (already exists; must be enhanced, not replaced)
+
+**`toolCallDetail` struct** (`cmd/run.go:39-44`):
+```go
+type toolCallDetail struct {
+    Name    string            `json:"name"`
+    Input   map[string]string `json:"input"`
+    Output  string            `json:"output"`
+    IsError bool              `json:"is_error"`
+}
+```
+
+**Conversation loop** (`cmd/run.go:531-608`):
+- Iterates `for turn := 0; turn < maxConversationTurns; turn++`
+- Each iteration: calls `prov.Send()`, checks for tool calls, calls `executeToolCalls()`, appends results to messages, loops
+- Tool call details are collected inside the loop at lines 586-600 (only when `jsonOutput` is true)
+- The loop variable `turn` is 0-indexed internally
+
+**`executeToolCalls` function** (`cmd/run.go:792-853`):
+- Returns `[]provider.ToolResult`
+- Supports both sequential (single call or `parallel=false`) and parallel (goroutines) execution paths
+- Does not currently measure per-call duration
+
+**Golden test sanitizer** (`cmd/golden_test.go:81-91`):
+- Masks `duration_ms` at the top-level envelope
+- Masks `output` inside each `tool_call_details` entry
+- Must be updated to also mask `duration_ms` inside each `tool_call_details` entry (non-deterministic)
+
+**No-tools path** (`cmd/run.go:~490-528`):
+- Handles agents with no tools configured; calls `Send()` once and exits without entering the conversation loop
+- `tool_call_details` is always `[]` on this path; no special handling required
+
+### Decisions Already Made
+
+1. **Enhance `tool_call_details`, do not add a new field.** Adding `turn` and `duration_ms` to existing entries is the least disruptive approach. The existing `"tool_calls"` integer count field is not renamed.
+2. **Keep the `output` field.** Backward compatibility is preserved. The output is already truncated to 1024 bytes.
+3. **`turn` is 0-indexed.** The `turn` value in each entry matches the internal loop variable directly (first LLM response with tool calls = `turn: 0`).
+4. **`duration_ms` is per-tool-call.** Measured from immediately before dispatch to immediately after, for each individual tool call. For parallel calls, each call is timed independently.
+
+### Approaches Ruled Out
+
+- **Renaming `"tool_calls"` integer to `"tool_call_count"`** — breaking change, rejected.
+- **Adding a separate `"tool_call_trajectory"` field** — redundant with `tool_call_details`, rejected.
+- **Removing the `output` field** — breaking change, rejected.
+- **1-indexed `turn`** — rejected in favor of 0-indexed to match the internal loop variable.
+- **Measuring duration at the provider level** — timing belongs at the dispatch layer in `cmd/run.go`, not in the provider interface.
+
+### Constraints
+
+- The `"tool_calls"` integer field and all other existing envelope fields must remain unchanged.
+- The `output` and `is_error` fields in `tool_call_details` entries must remain unchanged.
+- `duration_ms` inside `tool_call_details` entries is non-deterministic and must be masked in golden tests.
+- `turn` inside `tool_call_details` entries is deterministic and must NOT be masked in golden tests.
+- Both sequential and parallel tool execution paths must produce correct `duration_ms` values.
+- The no-tools path (no conversation loop) requires no changes.
+
+---
+
+## Section 2: Requirements
+
+### 2.1 Enhanced `tool_call_details` Entry Shape
+
+Each entry in the `tool_call_details` array must include two new fields in addition to the existing `name`, `input`, `output`, and `is_error`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `turn` | integer | The 0-indexed conversation turn in which this tool call was made. All tool calls from the same LLM response share the same `turn` value. |
+| `duration_ms` | integer | Wall-clock time in milliseconds from when the tool dispatch began to when it returned a result. |
+
+**Resulting entry shape:**
+```json
+{
+  "turn": 0,
+  "name": "read_file",
+  "input": { "path": "main.go" },
+  "output": "...",
+  "is_error": false,
+  "duration_ms": 42
+}
+```
+
+### 2.2 Turn Numbering
+
+- `turn` is 0-indexed: the first LLM response that produces tool calls has `turn: 0`, the second has `turn: 1`, and so on.
+- All tool calls produced by the same LLM response (including parallel calls) share the same `turn` value.
+- `turn` values are sequential integers with no gaps, incrementing by 1 for each LLM response that produces tool calls.
+- If the agent produces no tool calls at all, `tool_call_details` remains an empty array and no `turn` values are emitted.
+
+### 2.3 Duration Measurement
+
+- `duration_ms` measures the wall-clock time for a single tool call dispatch: from immediately before the dispatch call to immediately after it returns.
+- For parallel tool calls (multiple calls in the same turn), each call is timed independently. Their `duration_ms` values may overlap in real time but are each measured individually.
+- For sequential tool calls, each call is timed independently in sequence.
+- `duration_ms` must be a non-negative integer. A tool call that completes in under 1ms must report `0`.
+- `duration_ms` applies to all tool types: built-in tools, MCP tools, and `call_agent` sub-agent invocations.
+
+### 2.4 Backward Compatibility
+
+- The existing `"tool_calls"` integer field in the envelope is unchanged.
+- The existing `name`, `input`, `output`, and `is_error` fields in each `tool_call_details` entry are unchanged.
+- All other envelope fields are unchanged.
+- Consumers that do not read `turn` or `duration_ms` are unaffected.
+
+### 2.5 Non-JSON Path
+
+- When `--json` is not set, no timing or turn tracking occurs. The plain text output path is unchanged.
+
+### 2.6 Golden Test Sanitization
+
+- The golden test sanitizer must mask `duration_ms` inside each `tool_call_details` entry (replace with a placeholder, e.g., `"{{TOOL_DURATION_MS}}"`) because it is non-deterministic.
+- The `turn` field inside `tool_call_details` entries must NOT be masked; it is deterministic and its value must be verified.
+
+### 2.7 Edge Cases
+
+**Single tool call, single turn:**
+- `tool_call_details` has one entry with `turn: 0` and a non-negative `duration_ms`.
+
+**Multiple parallel tool calls in one turn:**
+- All entries share `turn: 0`. Each has its own independently measured `duration_ms`.
+
+**Multiple sequential turns:**
+- Turn 0 entries have `turn: 0`, turn 1 entries have `turn: 1`, etc.
+
+**Tool call that errors:**
+- `is_error: true`, `duration_ms` is still measured and reported (the duration of the failed call).
+
+**`call_agent` sub-agent invocation:**
+- Appears in `tool_call_details` with `name: "call_agent"`, `turn` and `duration_ms` populated like any other tool call. No additional sub-agent-specific fields are added.
+
+**MCP tool call:**
+- Appears in `tool_call_details` with the namespaced tool name (e.g., `"server-name.tool-name"`), `turn` and `duration_ms` populated like any other tool call.
+
+**Budget exceeded mid-loop:**
+- Any tool calls that were dispatched before the budget check still appear in `tool_call_details` with their `turn` and `duration_ms`.
+
+**Maximum turns reached (50):**
+- All tool calls from all turns that were dispatched appear in `tool_call_details` with correct `turn` values (0 through 49).
+
+**No tool calls (agent has no tools or LLM never calls tools):**
+- `tool_call_details` is `[]`. No `turn` or `duration_ms` values are emitted.
+
+---

--- a/docs/plans/ISS-40_smoke_test_agents_milestones.md
+++ b/docs/plans/ISS-40_smoke_test_agents_milestones.md
@@ -265,7 +265,7 @@ Status key: `[ ]` not started · `[-]` in progress · `[x]` done
 - [x] 043: Create smoke-test agent TOML files, skill file, and context file in `.github/smoke-agents/`
 - [ ] 044: Create `dry-run` CI job — validate `--dry-run` output for each agent type (no API keys required)
 - [ ] 045: Create `providers` CI job — verify Anthropic, OpenAI, and OpenCode connectivity with minimal prompts
-- [ ] 046: Create `tools` CI job — exercise all 7 built-in tools via OpenCode/minimax-m2.5
+- [x] 046: Create `tools` CI job — exercise all 7 built-in tools via OpenCode/minimax-m2.5
 - [ ] 047: Create `config-sections` CI job — verify TOML config parsing for basic, skill, memory, files, sub_agents, and params
 - [ ] 048: Create `piped-input` CI job — verify stdin piping works across multiple scenarios
 - [ ] 049: Assemble all jobs into `.github/workflows/smoke-test.yml` with proper secret injection and triggers


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enriches tool call metadata in the CLI's JSON output by adding two new fields to each `tool_call_details` entry: `turn` (a 0-indexed conversation turn indicator) and `duration_ms` (per-call wall-clock execution time). A new `toolExecResult` wrapper type is introduced to pair execution results with timing measurements, and the execution paths for both sequential and parallel tool calls are updated to use this wrapper. The conversation loop now populates turn values from its iteration variable. Golden test fixtures and sanitization logic are updated to account for the new fields.

## Changelog

### Added
- `turn` field to `tool_call_details` entries in JSON output (0-indexed conversation turn)
- `duration_ms` field to `tool_call_details` entries in JSON output (per-call wall-clock duration in milliseconds)
- `toolExecResult` wrapper type to capture both tool execution results and their timing information
- `TestRun_ToolCallDetails_TurnAndDuration` test to validate turn and duration tracking across multiple conversation turns
- `TestRun_ToolCallDetails_ParallelSameTurn` test to validate turn and duration tracking for parallel tool calls within a single turn
- Masking of non-deterministic `duration_ms` values in golden test output (replaced with `{{TOOL_DURATION_MS}}` placeholder)

### Changed
- `toolCallDetail` structure to include `turn` and `duration_ms` fields
- `executeToolCalls` function to return `[]toolExecResult` wrapper instead of plain `[]provider.ToolResult`, with separate timing measurement for sequential and parallel execution paths
- Conversation loop to extract and assign `turn` values based on loop iteration and to read execution timing from the `toolExecResult` wrapper
- Tool results processing to extract `Result` field from `toolExecResult` before assigning to request message
- Integration test assertions in `cmd/run_integration_test.go` to validate presence and type of new `turn` and `duration_ms` fields
- Golden test sanitizer to mask `duration_ms` values within `tool_call_details` entries
- Golden fixture files (`with_tools.json`, `with_subagents.json`) to include new `turn` and `duration_ms` fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Satisfies #62 