### PR TITLE
ISS-59 - Enable Response Streaming

### DIFF
--- a/.github/smoke-agents/cfg-params.toml
+++ b/.github/smoke-agents/cfg-params.toml
@@ -1,7 +1,0 @@
-name = "cfg-params"
-model = "opencode/minimax-m2.5"
-description = "Smoke test: params config section"
-
-[params]
-temperature = 0.5
-max_tokens = 100

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -198,12 +198,6 @@ jobs:
         echo "$OUTPUT"
         echo "$OUTPUT" | grep -q "sub-agent-ok" || { echo "FAIL: 'sub-agent-ok' not found"; exit 1; }
 
-    - name: cfg-params
-      run: |
-        OUTPUT=$(./axe run --agents-dir .github/smoke-agents cfg-params -p "Reply with only the word: pong")
-        echo "$OUTPUT"
-        [ -n "$OUTPUT" ] || { echo "FAIL: empty output"; exit 1; }
-
   piped-input:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -318,7 +318,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("stream") {
 		streamEnabled, _ = cmd.Flags().GetBool("stream")
 	}
-	_ = streamEnabled
+
 
 	// Resolve effective budget
 	flagMaxTokens, _ := cmd.Flags().GetInt("max-tokens")
@@ -383,6 +383,13 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		Stderr:         cmd.ErrOrStderr(),
 	})
 	prov = retryProv
+
+	// Resolve whether streaming is actually usable.
+	// RetryProvider always satisfies StreamProvider but may wrap a non-streaming
+	// inner provider, so check SupportsStream().
+	if streamEnabled && !retryProv.SupportsStream() {
+		streamEnabled = false
+	}
 
 	// Step 16: Build request
 	req := &provider.Request{
@@ -510,10 +517,37 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	var totalToolCalls int
 	var allToolCallDetails []toolCallDetail
 	var budgetExceeded bool
+	var streamedText bool
 
 	if len(req.Tools) == 0 {
-		// Single-shot: no tools, no conversation loop (identical to M4)
-		resp, err = prov.Send(ctx, req)
+		// Single-shot: no tools, no conversation loop
+		if streamEnabled {
+			if sp, ok := prov.(provider.StreamProvider); ok {
+				stream, streamErr := sp.SendStream(ctx, req)
+				if streamErr != nil {
+					durationMs := time.Since(start).Milliseconds()
+					if verbose {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Duration: %dms\n", durationMs)
+					}
+					return mapProviderError(streamErr)
+				}
+				var textWriter io.Writer
+				if !jsonOutput {
+					textWriter = cmd.OutOrStdout()
+				}
+				resp, err = drainEventStream(stream, textWriter)
+				if err != nil {
+					return mapProviderError(err)
+				}
+				if !jsonOutput {
+					streamedText = true
+				}
+			} else {
+				resp, err = prov.Send(ctx, req)
+			}
+		} else {
+			resp, err = prov.Send(ctx, req)
+		}
 		if err != nil {
 			durationMs := time.Since(start).Milliseconds()
 			if verbose {
@@ -555,10 +589,44 @@ func runAgent(cmd *cobra.Command, args []string) error {
 						pendingToolCalls += len(m.ToolResults)
 					}
 				}
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] Sending request (%d messages, %d tool calls pending)\n", turn+1, len(req.Messages), pendingToolCalls)
+				if streamEnabled {
+					if _, ok := prov.(provider.StreamProvider); ok {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] Streaming request (%d messages)\n", turn+1, len(req.Messages))
+					} else {
+						_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] Sending request (%d messages, %d tool calls pending)\n", turn+1, len(req.Messages), pendingToolCalls)
+					}
+				} else {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] Sending request (%d messages, %d tool calls pending)\n", turn+1, len(req.Messages), pendingToolCalls)
+				}
 			}
 
-			resp, err = prov.Send(ctx, req)
+			if streamEnabled {
+				if sp, ok := prov.(provider.StreamProvider); ok {
+					stream, streamErr := sp.SendStream(ctx, req)
+					if streamErr != nil {
+						durationMs := time.Since(start).Milliseconds()
+						if verbose {
+							_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Duration: %dms\n", durationMs)
+						}
+						return mapProviderError(streamErr)
+					}
+					var textWriter io.Writer
+					if !jsonOutput {
+						textWriter = cmd.OutOrStdout()
+					}
+					resp, err = drainEventStream(stream, textWriter)
+					if err != nil {
+						return mapProviderError(err)
+					}
+					if !jsonOutput && resp.Content != "" {
+						streamedText = true
+					}
+				} else {
+					resp, err = prov.Send(ctx, req)
+				}
+			} else {
+				resp, err = prov.Send(ctx, req)
+			}
 			if err != nil {
 				durationMs := time.Since(start).Milliseconds()
 				if verbose {
@@ -572,7 +640,13 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			tracker.Add(resp.InputTokens, resp.OutputTokens)
 
 			if verbose {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] Received response: %s (%d tool calls)\n", turn+1, resp.StopReason, len(resp.ToolCalls))
+				label := "Received response"
+				if streamEnabled {
+					if _, ok := prov.(provider.StreamProvider); ok {
+						label = "Stream complete"
+					}
+				}
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "[turn %d] %s: %s (%d tool calls)\n", turn+1, label, resp.StopReason, len(resp.ToolCalls))
 			}
 
 			// No tool calls: conversation is done
@@ -692,8 +766,8 @@ func runAgent(cmd *cobra.Command, args []string) error {
 			return &ExitError{Code: 1, Err: fmt.Errorf("failed to marshal JSON output: %w", err)}
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
-	} else {
-		// Step 20: Default output
+	} else if !streamedText {
+		// Step 20: Default output (skip if text was already streamed to stdout)
 		_, _ = fmt.Fprint(cmd.OutOrStdout(), resp.Content)
 	}
 
@@ -907,6 +981,83 @@ func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.
 		return provider.ToolResult{CallID: tc.ID, Content: dispatchErr.Error(), IsError: true}
 	}
 	return result
+}
+
+// drainEventStream consumes all events from a stream and constructs a Response.
+// If w is non-nil, text events are written to it incrementally.
+func drainEventStream(stream *provider.EventStream, w io.Writer) (*provider.Response, error) {
+	defer func() { _ = stream.Close() }()
+
+	var content strings.Builder
+	var toolCalls []provider.ToolCall
+	var inputTokens, outputTokens int
+	var stopReason string
+
+	type pendingCall struct {
+		id   string
+		name string
+		args strings.Builder
+	}
+	pending := make(map[string]*pendingCall)
+
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch ev.Type {
+		case provider.StreamEventText:
+			content.WriteString(ev.Text)
+			if w != nil {
+				_, _ = io.WriteString(w, ev.Text)
+			}
+
+		case provider.StreamEventToolStart:
+			pending[ev.ToolCallID] = &pendingCall{id: ev.ToolCallID, name: ev.ToolName}
+
+		case provider.StreamEventToolDelta:
+			if pc, ok := pending[ev.ToolCallID]; ok {
+				pc.args.WriteString(ev.ToolInput)
+			}
+
+		case provider.StreamEventToolEnd:
+			if pc, ok := pending[ev.ToolCallID]; ok {
+				args := make(map[string]string)
+				raw := pc.args.String()
+				if raw != "" {
+					var parsed map[string]interface{}
+					if jsonErr := json.Unmarshal([]byte(raw), &parsed); jsonErr == nil {
+						for k, v := range parsed {
+							args[k] = fmt.Sprintf("%v", v)
+						}
+					}
+				}
+				toolCalls = append(toolCalls, provider.ToolCall{
+					ID:        pc.id,
+					Name:      pc.name,
+					Arguments: args,
+				})
+				delete(pending, ev.ToolCallID)
+			}
+
+		case provider.StreamEventDone:
+			inputTokens = ev.InputTokens
+			outputTokens = ev.OutputTokens
+			stopReason = ev.StopReason
+		}
+	}
+
+	return &provider.Response{
+		Content:      content.String(),
+		ToolCalls:    toolCalls,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		StopReason:   stopReason,
+	}, nil
 }
 
 // mapProviderError converts a provider error to an ExitError with the correct exit code.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,6 +78,7 @@ func init() {
 	runCmd.Flags().Int("max-tokens", 0, "Maximum total tokens (input+output) for the entire run (0 = unlimited)")
 	runCmd.Flags().String("artifact-dir", "", "Override or set the artifact directory (activates artifact system)")
 	runCmd.Flags().Bool("keep-artifacts", false, "Preserve auto-generated artifact directories after the run")
+	runCmd.Flags().Bool("stream", false, "Enable streaming responses from the LLM provider")
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -313,6 +314,12 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 
+	streamEnabled := cfg.Stream
+	if cmd.Flags().Changed("stream") {
+		streamEnabled, _ = cmd.Flags().GetBool("stream")
+	}
+	_ = streamEnabled
+
 	// Resolve effective budget
 	flagMaxTokens, _ := cmd.Flags().GetInt("max-tokens")
 	effectiveMaxTokens := cfg.Budget.MaxTokens
@@ -333,7 +340,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 	// Step 11b: Dry-run mode
 	if dryRun {
-		return printDryRun(cmd, cfg, provName, modelName, workdir, timeout, systemPrompt, skillContent, files, userMessage, memoryEntries, effectiveMaxTokens)
+		return printDryRun(cmd, cfg, provName, modelName, workdir, timeout, streamEnabled, systemPrompt, skillContent, files, userMessage, memoryEntries, effectiveMaxTokens)
 	}
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(timeout)*time.Second)
@@ -710,7 +717,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printDryRun(cmd *cobra.Command, cfg *agent.AgentConfig, provName, modelName, workdir string, timeout int, systemPrompt, skillContent string, files []resolve.FileContent, userMessage string, memoryEntries string, maxTokens int) error {
+func printDryRun(cmd *cobra.Command, cfg *agent.AgentConfig, provName, modelName, workdir string, timeout int, streamEnabled bool, systemPrompt, skillContent string, files []resolve.FileContent, userMessage string, memoryEntries string, maxTokens int) error {
 	out := cmd.OutOrStdout()
 
 	_, _ = fmt.Fprintln(out, "=== Dry Run ===")
@@ -720,6 +727,11 @@ func printDryRun(cmd *cobra.Command, cfg *agent.AgentConfig, provName, modelName
 	_, _ = fmt.Fprintf(out, "Timeout:  %ds\n", timeout)
 	_, _ = fmt.Fprintf(out, "Params:   temperature=%g, max_tokens=%d\n", cfg.Params.Temperature, cfg.Params.MaxTokens)
 	_, _ = fmt.Fprintf(out, "Budget:   %d tokens (0 = unlimited)\n", maxTokens)
+	streamVal := "no"
+	if streamEnabled {
+		streamVal = "yes"
+	}
+	_, _ = fmt.Fprintf(out, "Stream:   %s\n", streamVal)
 
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, "--- System Prompt ---")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1017,7 +1017,11 @@ func drainEventStream(stream *provider.EventStream, w io.Writer) (*provider.Resp
 			}
 
 		case provider.StreamEventToolStart:
-			pending[ev.ToolCallID] = &pendingCall{id: ev.ToolCallID, name: ev.ToolName}
+			pc := &pendingCall{id: ev.ToolCallID, name: ev.ToolName}
+			if ev.ToolInput != "" {
+				pc.args.WriteString(ev.ToolInput)
+			}
+			pending[ev.ToolCallID] = pc
 
 		case provider.StreamEventToolDelta:
 			if pc, ok := pending[ev.ToolCallID]; ok {

--- a/cmd/run_stream_test.go
+++ b/cmd/run_stream_test.go
@@ -109,6 +109,30 @@ func TestDrainEventStream_ToolCalls(t *testing.T) {
 	}
 }
 
+func TestDrainEventStream_ToolCallsFromStartInput(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventToolStart, ToolCallID: "ollama_0", ToolName: "read_file", ToolInput: `{"path":"main.go"}`},
+		{Type: provider.StreamEventToolEnd, ToolCallID: "ollama_0"},
+		{Type: provider.StreamEventDone, StopReason: "tool_calls"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("got %d tool calls, want 1", len(resp.ToolCalls))
+	}
+
+	tc := resp.ToolCalls[0]
+	if tc.ID != "ollama_0" || tc.Name != "read_file" {
+		t.Errorf("tool call: ID=%q Name=%q", tc.ID, tc.Name)
+	}
+	if tc.Arguments["path"] != "main.go" {
+		t.Errorf("tool call args = %v, want path=main.go", tc.Arguments)
+	}
+}
+
 func TestDrainEventStream_TextAndToolCalls(t *testing.T) {
 	stream := makeStream([]provider.StreamEvent{
 		{Type: provider.StreamEventText, Text: "Let me help."},

--- a/cmd/run_stream_test.go
+++ b/cmd/run_stream_test.go
@@ -1,0 +1,380 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jrswab/axe/internal/provider"
+	"github.com/jrswab/axe/internal/testutil"
+)
+
+// nopCloser is a no-op io.Closer for test EventStreams.
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
+
+// makeStream creates an EventStream from a slice of events.
+// After all events are consumed, it returns io.EOF.
+func makeStream(events []provider.StreamEvent) *provider.EventStream {
+	i := 0
+	return provider.NewEventStream(nopCloser{}, func() (provider.StreamEvent, error) {
+		if i >= len(events) {
+			return provider.StreamEvent{}, io.EOF
+		}
+		ev := events[i]
+		i++
+		return ev, nil
+	})
+}
+
+// errStream creates an EventStream that emits the given events,
+// then returns the specified error.
+func errStream(events []provider.StreamEvent, err error) *provider.EventStream {
+	i := 0
+	return provider.NewEventStream(nopCloser{}, func() (provider.StreamEvent, error) {
+		if i >= len(events) {
+			return provider.StreamEvent{}, err
+		}
+		ev := events[i]
+		i++
+		return ev, nil
+	})
+}
+
+func TestDrainEventStream_TextOnly(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "Hello "},
+		{Type: provider.StreamEventText, Text: "world"},
+		{Type: provider.StreamEventDone, InputTokens: 10, OutputTokens: 5, StopReason: "end_turn"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Hello world" {
+		t.Errorf("Content = %q, want %q", resp.Content, "Hello world")
+	}
+	if resp.InputTokens != 10 {
+		t.Errorf("InputTokens = %d, want 10", resp.InputTokens)
+	}
+	if resp.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", resp.OutputTokens)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want %q", resp.StopReason, "end_turn")
+	}
+}
+
+func TestDrainEventStream_ToolCalls(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventToolStart, ToolCallID: "call_1", ToolName: "read_file"},
+		{Type: provider.StreamEventToolDelta, ToolCallID: "call_1", ToolInput: `{"path":`},
+		{Type: provider.StreamEventToolDelta, ToolCallID: "call_1", ToolInput: `"foo.txt"}`},
+		{Type: provider.StreamEventToolEnd, ToolCallID: "call_1"},
+		{Type: provider.StreamEventToolStart, ToolCallID: "call_2", ToolName: "list_directory"},
+		{Type: provider.StreamEventToolDelta, ToolCallID: "call_2", ToolInput: `{"path":"."}`},
+		{Type: provider.StreamEventToolEnd, ToolCallID: "call_2"},
+		{Type: provider.StreamEventDone, StopReason: "tool_calls"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.ToolCalls) != 2 {
+		t.Fatalf("got %d tool calls, want 2", len(resp.ToolCalls))
+	}
+
+	tc1 := resp.ToolCalls[0]
+	if tc1.ID != "call_1" || tc1.Name != "read_file" {
+		t.Errorf("tool call 0: ID=%q Name=%q", tc1.ID, tc1.Name)
+	}
+	if tc1.Arguments["path"] != "foo.txt" {
+		t.Errorf("tool call 0 args = %v, want path=foo.txt", tc1.Arguments)
+	}
+
+	tc2 := resp.ToolCalls[1]
+	if tc2.ID != "call_2" || tc2.Name != "list_directory" {
+		t.Errorf("tool call 1: ID=%q Name=%q", tc2.ID, tc2.Name)
+	}
+	if tc2.Arguments["path"] != "." {
+		t.Errorf("tool call 1 args = %v, want path=.", tc2.Arguments)
+	}
+}
+
+func TestDrainEventStream_TextAndToolCalls(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "Let me help."},
+		{Type: provider.StreamEventToolStart, ToolCallID: "call_1", ToolName: "read_file"},
+		{Type: provider.StreamEventToolDelta, ToolCallID: "call_1", ToolInput: `{"path":"a.go"}`},
+		{Type: provider.StreamEventToolEnd, ToolCallID: "call_1"},
+		{Type: provider.StreamEventDone, StopReason: "tool_calls", InputTokens: 20, OutputTokens: 15},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Let me help." {
+		t.Errorf("Content = %q, want %q", resp.Content, "Let me help.")
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("got %d tool calls, want 1", len(resp.ToolCalls))
+	}
+}
+
+func TestDrainEventStream_IncrementalWrite(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "one"},
+		{Type: provider.StreamEventText, Text: "two"},
+		{Type: provider.StreamEventText, Text: "three"},
+		{Type: provider.StreamEventDone, StopReason: "end_turn"},
+	})
+
+	var buf bytes.Buffer
+	resp, err := drainEventStream(stream, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "onetwothree" {
+		t.Errorf("writer got %q, want %q", buf.String(), "onetwothree")
+	}
+	if resp.Content != "onetwothree" {
+		t.Errorf("Content = %q, want %q", resp.Content, "onetwothree")
+	}
+}
+
+func TestDrainEventStream_NilWriter(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "buffered"},
+		{Type: provider.StreamEventDone, StopReason: "end_turn"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "buffered" {
+		t.Errorf("Content = %q, want %q", resp.Content, "buffered")
+	}
+}
+
+func TestDrainEventStream_MidStreamError(t *testing.T) {
+	testErr := errors.New("connection reset")
+	stream := errStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "partial"},
+		{Type: provider.StreamEventText, Text: " data"},
+	}, testErr)
+
+	_, err := drainEventStream(stream, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, testErr) {
+		t.Errorf("got error %v, want %v", err, testErr)
+	}
+}
+
+func TestDrainEventStream_EmptyStream(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventDone, StopReason: "end_turn", InputTokens: 3, OutputTokens: 1},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "" {
+		t.Errorf("Content = %q, want empty", resp.Content)
+	}
+	if resp.ToolCalls != nil {
+		t.Errorf("ToolCalls = %v, want nil", resp.ToolCalls)
+	}
+	if resp.InputTokens != 3 {
+		t.Errorf("InputTokens = %d, want 3", resp.InputTokens)
+	}
+}
+
+func TestDrainEventStream_EOFWithoutDone(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventText, Text: "hello"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Errorf("Content = %q, want %q", resp.Content, "hello")
+	}
+	if resp.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0", resp.InputTokens)
+	}
+	if resp.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0", resp.OutputTokens)
+	}
+	if resp.StopReason != "" {
+		t.Errorf("StopReason = %q, want empty", resp.StopReason)
+	}
+}
+
+// --- Integration Tests ---
+
+func TestIntegration_Streaming_SingleShot_OpenAI(t *testing.T) {
+	resetRunCmd(t)
+
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.OpenAIStreamResponse("Hello streamed", 10, 5),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	writeAgentConfig(t, configDir, "stream-single", `name = "stream-single"
+model = "openai/gpt-4o"
+`)
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AXE_OPENAI_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "stream-single", "--stream"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	output := buf.String()
+	if output != "Hello streamed" {
+		t.Errorf("expected stdout %q, got %q", "Hello streamed", output)
+	}
+}
+
+func TestIntegration_Streaming_JSON_Buffers(t *testing.T) {
+	resetRunCmd(t)
+
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.OpenAIStreamResponse("buffered text", 10, 5),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	writeAgentConfig(t, configDir, "stream-json", `name = "stream-json"
+model = "openai/gpt-4o"
+`)
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AXE_OPENAI_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "stream-json", "--stream", "--json"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	output := buf.String()
+	var envelope map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(output)), &envelope); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %s", jsonErr, output)
+	}
+
+	content, _ := envelope["content"].(string)
+	if content != "buffered text" {
+		t.Errorf("JSON content = %q, want %q", content, "buffered text")
+	}
+}
+
+func TestIntegration_Streaming_FallbackNonStreamProvider(t *testing.T) {
+	resetRunCmd(t)
+
+	// Anthropic provider does not implement StreamProvider, so --stream should fall back to Send()
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicResponse("Fallback works"),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	writeAgentConfig(t, configDir, "stream-fallback", `name = "stream-fallback"
+model = "anthropic/claude-sonnet-4-20250514"
+`)
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "stream-fallback", "--stream"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	output := buf.String()
+	if output != "Fallback works" {
+		t.Errorf("expected stdout %q, got %q", "Fallback works", output)
+	}
+}
+
+func TestIntegration_Streaming_WithTools(t *testing.T) {
+	resetRunCmd(t)
+
+	// First response: tool call via streaming
+	// Second response: final text (non-streaming is fine since loop checks each turn)
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.OpenAIStreamToolCallResponse("", []testutil.MockToolCall{
+			{ID: "call_1", Name: "list_directory", Input: map[string]string{"path": "."}},
+		}, 10, 15),
+		testutil.OpenAIStreamResponse("Done listing", 5, 3),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	workdir := t.TempDir()
+	// Create a file so list_directory has something to find
+	if err := os.WriteFile(workdir+"/test.txt", []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAgentConfig(t, configDir, "stream-tools", fmt.Sprintf(`name = "stream-tools"
+model = "openai/gpt-4o"
+tools = ["list_directory"]
+workdir = %q
+`, workdir))
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AXE_OPENAI_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "stream-tools", "--stream"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Done listing") {
+		t.Errorf("expected stdout to contain %q, got %q", "Done listing", output)
+	}
+
+	if mock.RequestCount() != 2 {
+		t.Errorf("expected 2 requests (tool call + final), got %d", mock.RequestCount())
+	}
+}

--- a/cmd/run_stream_test.go
+++ b/cmd/run_stream_test.go
@@ -297,16 +297,15 @@ model = "openai/gpt-4o"
 	}
 }
 
-func TestIntegration_Streaming_FallbackNonStreamProvider(t *testing.T) {
+func TestIntegration_Streaming_SingleShot_Anthropic(t *testing.T) {
 	resetRunCmd(t)
 
-	// Anthropic provider does not implement StreamProvider, so --stream should fall back to Send()
 	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
-		testutil.AnthropicResponse("Fallback works"),
+		testutil.AnthropicStreamResponse("Fallback works", 10, 5),
 	})
 
 	configDir, _ := testutil.SetupXDGDirs(t)
-	writeAgentConfig(t, configDir, "stream-fallback", `name = "stream-fallback"
+	writeAgentConfig(t, configDir, "stream-anthropic", `name = "stream-anthropic"
 model = "anthropic/claude-sonnet-4-20250514"
 `)
 
@@ -317,7 +316,7 @@ model = "anthropic/claude-sonnet-4-20250514"
 	errBuf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"run", "stream-fallback", "--stream"})
+	rootCmd.SetArgs([]string{"run", "stream-anthropic", "--stream"})
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -33,8 +33,12 @@ func resetRunCmd(t *testing.T) {
 	_ = runCmd.Flags().Set("prompt", "")
 	_ = runCmd.Flags().Set("artifact-dir", "")
 	_ = runCmd.Flags().Set("keep-artifacts", "false")
+	_ = runCmd.Flags().Set("stream", "false")
 	// Reset the Changed state for timeout flag so TOML timeout values can be used
 	if f := runCmd.Flags().Lookup("timeout"); f != nil {
+		f.Changed = false
+	}
+	if f := runCmd.Flags().Lookup("stream"); f != nil {
 		f.Changed = false
 	}
 	rootCmd.SetIn(os.Stdin)

--- a/cmd/testdata/golden/dry-run/basic.txt
+++ b/cmd/testdata/golden/dry-run/basic.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/cmd/testdata/golden/dry-run/with_files.txt
+++ b/cmd/testdata/golden/dry-run/with_files.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/cmd/testdata/golden/dry-run/with_memory.txt
+++ b/cmd/testdata/golden/dry-run/with_memory.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/cmd/testdata/golden/dry-run/with_skill.txt
+++ b/cmd/testdata/golden/dry-run/with_skill.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/cmd/testdata/golden/dry-run/with_subagents.txt
+++ b/cmd/testdata/golden/dry-run/with_subagents.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/cmd/testdata/golden/dry-run/with_tools.txt
+++ b/cmd/testdata/golden/dry-run/with_tools.txt
@@ -5,6 +5,7 @@ Workdir:  {{WORKDIR}}
 Timeout:  120s
 Params:   temperature=0, max_tokens=0
 Budget:   0 tokens (0 = unlimited)
+Stream:   no
 
 --- System Prompt ---
 

--- a/docs/plans/ISS-59_m1_core_types_sse_parser_spec.md
+++ b/docs/plans/ISS-59_m1_core_types_sse_parser_spec.md
@@ -1,0 +1,206 @@
+# ISS-59 M1 — Core Types, SSE Parser, Config Plumbing
+
+Milestones: [ISS-59_streaming_milestones.md](ISS-59_streaming_milestones.md)
+
+## Section 1: Context & Constraints
+
+### Codebase Structure
+
+- **Provider interface** (`internal/provider/provider.go`): All 7 providers
+  implement `Provider` with a single `Send(ctx, *Request) (*Response, error)`
+  method. The new streaming interface must coexist without breaking existing
+  providers.
+
+- **RetryProvider** (`internal/provider/retry.go`): Wraps `Provider.Send()`.
+  Must also implement `StreamProvider` by delegating to the inner provider
+  without retry logic. This aligns with the project rule: "Do not add internal
+  LLM retries for provider errors."
+
+- **Agent TOML** (`internal/agent/agent.go`): Agent config is loaded via
+  `agent.Load()` and validated via `agent.Validate()`. New fields must be
+  added to the `AgentConfig` struct and validated.
+
+- **CLI flags** (`cmd/run.go`): Flags are registered in `init()` and read
+  in `runAgent()`. Resolution order: flags > TOML > defaults.
+
+- **Go version**: 1.25 (per `go.mod`). `iter.Seq2` is available but the
+  `EventStream` struct with `Next()/Close()` was chosen for explicit
+  resource cleanup (HTTP response body) without relying on iterator
+  semantics.
+
+### Decisions Already Made
+
+- `--stream` flag name (explicit opt-in, no TTY auto-detection).
+- `stream = true/false` in agent TOML at top level.
+- `EventStream` with `Next()/Close()` pattern (like `sql.Rows`).
+- `StreamProvider` is an optional interface — providers that don't support
+  streaming simply don't implement it.
+- Sub-agents never stream (only top-level agent).
+- `--stream --json` streams from provider to Axe but buffers output.
+- Bedrock streaming deferred to separate issue.
+
+### Approaches Ruled Out
+
+- **Changing `Send()` to internally stream**: Invisible to callers, breaks
+  the explicit opt-in principle. The streaming transport should be a
+  conscious choice, not hidden behavior.
+- **`iter.Seq2` return type**: Requires careful cleanup semantics when the
+  caller breaks out of iteration. `Next()/Close()` with `defer` is safer
+  and more idiomatic for resource-holding types.
+- **Channel-based streaming**: Requires goroutine management and has leak
+  risks if the receiver stops consuming.
+- **TTY auto-detection for streaming default**: Users pipe Axe output in
+  CI/lambda/scripts. Auto-detecting would change behavior unexpectedly.
+
+### Constraints
+
+- SSE parser must handle: multi-line `data:` fields, empty events,
+  `event:` type fields, `[DONE]` sentinel (OpenAI), comment lines
+  (lines starting with `:`).
+- SSE parser is a shared utility — Anthropic, OpenAI, Gemini, and MiniMax
+  all use SSE (with different event payloads). The parser handles the
+  wire format; each provider maps parsed events to `StreamEvent`.
+- `EventStream.Close()` must close the underlying HTTP response body.
+  Callers must always call `Close()` (via `defer`).
+- `StreamEvent.Type` values must cover: text deltas, tool call lifecycle
+  (start/delta/end), and a terminal "done" event with usage + stop reason.
+
+## Section 2: Requirements
+
+### 2.1 StreamEvent Type
+
+A struct representing a single event from a streaming LLM response.
+
+**Fields:**
+
+| Field          | Type   | Populated When           | Description                                  |
+| -------------- | ------ | ------------------------ | -------------------------------------------- |
+| `Type`         | string | Always                   | One of the event type constants below        |
+| `Text`         | string | `Type == "text"`         | Text content delta                           |
+| `ToolCallID`   | string | `Type` is tool-related   | Provider-assigned tool call ID               |
+| `ToolName`     | string | `Type == "tool_start"`   | Name of the tool being called                |
+| `ToolInput`    | string | `Type == "tool_delta"`   | JSON fragment of tool input                  |
+| `InputTokens`  | int    | `Type == "done"`         | Total input tokens for the request           |
+| `OutputTokens` | int    | `Type == "done"`         | Total output tokens for the request          |
+| `StopReason`   | string | `Type == "done"`         | Why the model stopped (e.g. "end_turn")      |
+
+**Event type constants** (exported string constants):
+
+| Constant             | Value          | Meaning                                     |
+| -------------------- | -------------- | ------------------------------------------- |
+| `StreamEventText`    | `"text"`       | Text content delta                          |
+| `StreamEventToolStart` | `"tool_start"` | A new tool call began (ID + name)          |
+| `StreamEventToolDelta` | `"tool_delta"` | Tool input JSON fragment                   |
+| `StreamEventToolEnd` | `"tool_end"`   | Tool call input is complete                 |
+| `StreamEventDone`    | `"done"`       | Stream finished; usage + stop reason set    |
+
+### 2.2 EventStream Type
+
+A struct that wraps a streaming HTTP response and yields `StreamEvent`
+values one at a time.
+
+**Methods:**
+
+- `Next() (StreamEvent, error)` — Returns the next event. Returns
+  `io.EOF` when the stream is complete (after the "done" event has been
+  returned). Returns a `ProviderError` on mid-stream failures.
+- `Close() error` — Closes the underlying HTTP response body. Must be
+  safe to call multiple times. Must be called by the caller (via `defer`)
+  regardless of whether `Next()` returned `io.EOF` or an error.
+
+**Edge cases:**
+
+- If the HTTP connection drops mid-stream, `Next()` returns a
+  `ProviderError` with `ErrCategoryServer`.
+- If context is cancelled, `Next()` returns a `ProviderError` with
+  `ErrCategoryTimeout`.
+- `Close()` after `Close()` is a no-op (no error).
+- `Next()` after `Close()` returns `io.EOF`.
+
+### 2.3 StreamProvider Interface
+
+```
+StreamProvider interface {
+    Provider
+    SendStream(ctx context.Context, req *Request) (*EventStream, error)
+}
+```
+
+- Embeds `Provider` so every `StreamProvider` is also a `Provider`.
+- `SendStream()` returns an error for connection/setup failures (before
+  any events). Mid-stream errors come through `EventStream.Next()`.
+- Providers that don't support streaming simply don't implement this
+  interface. The conversation loop (M3) will type-assert to check.
+
+### 2.4 RetryProvider StreamProvider Support
+
+`RetryProvider` must implement `StreamProvider` if its inner provider does:
+
+- Type-assert the inner provider to `StreamProvider`.
+- If the inner provider is a `StreamProvider`, delegate `SendStream()`
+  directly — no retry wrapping.
+- If the inner provider is not a `StreamProvider`, `RetryProvider` does
+  not implement `StreamProvider` (the type assertion in the conversation
+  loop will fail gracefully and fall back to `Send()`).
+
+### 2.5 SSE Parser
+
+A shared utility for parsing Server-Sent Events from an `io.Reader`.
+
+**Input**: An `io.Reader` (the HTTP response body).
+
+**Output**: Parsed SSE events, each containing:
+- `Event` (string) — the `event:` field value, empty if not present
+- `Data` (string) — the concatenated `data:` field values (joined by `\n`
+  for multi-line data)
+
+**Behavior:**
+
+- Events are delimited by blank lines (`\n\n`).
+- Lines starting with `:` are comments — skip them.
+- `event: <value>` sets the event type for the current event.
+- `data: <value>` appends to the data buffer for the current event.
+  Multiple `data:` lines within one event are joined with `\n`.
+- `id:` and `retry:` fields are ignored (not needed for LLM streaming).
+- A `data:` line with value `[DONE]` must be passed through as-is (the
+  provider-specific code decides how to handle it).
+- The parser reads until the reader returns `io.EOF` or an error.
+- The space after the colon in field names is optional per the SSE spec
+  (i.e. `data:hello` and `data: hello` are equivalent — strip one
+  leading space from the value if present).
+
+**Interface**: A struct with a `Next() (SSEEvent, error)` method that
+returns `io.EOF` when the reader is exhausted. This mirrors the
+`EventStream` pattern and allows the caller to pull events in a loop.
+
+### 2.6 TOML Config: `stream` Field
+
+Add a `stream` boolean field to `AgentConfig`:
+
+- **Default**: `false` (current buffered behavior).
+- **Validation**: None required (boolean with a sensible default).
+- **Behavior**: When `true`, the conversation loop (M3) will attempt to
+  use `SendStream()` if the provider supports it.
+
+### 2.7 CLI Flag: `--stream`
+
+Add a `--stream` boolean flag to the `run` command:
+
+- **Default**: `false`.
+- **Resolution order**: `--stream` flag overrides TOML `stream` field.
+- **Mutual exclusivity**: `--stream` and `--json` are NOT mutually
+  exclusive. When both are set, streaming is used on the wire but output
+  is buffered into the JSON envelope.
+- **Dry-run**: When `--dry-run` is set, the resolved `stream` value
+  should be displayed in the dry-run output.
+
+### Parallelism
+
+The following can be implemented in parallel (no dependencies between them):
+
+- **2.1 + 2.2 + 2.3** (StreamEvent, EventStream, StreamProvider) — these
+  are type definitions in `provider.go`
+- **2.5** (SSE parser) — standalone package, no dependency on provider types
+- **2.4** (RetryProvider) depends on 2.3 (StreamProvider interface)
+- **2.6 + 2.7** (TOML + CLI flag) can be done in parallel with all of the
+  above

--- a/docs/plans/ISS-59_m1_implement.md
+++ b/docs/plans/ISS-59_m1_implement.md
@@ -1,0 +1,73 @@
+# ISS-59 M1 — Implementation Guide: Core Types, SSE Parser, Config Plumbing
+
+Spec: [ISS-59_m1_core_types_sse_parser_spec.md](ISS-59_m1_core_types_sse_parser_spec.md)
+
+## Section 1: Context Summary
+
+Axe agents calling LLM providers through nginx proxies with 60-second idle timeouts get killed before long responses complete. Streaming keeps bytes flowing to prevent idle disconnects. M1 lays the foundation: event types, an SSE wire-format parser, a `StreamProvider` interface, `RetryProvider` passthrough, and the `--stream` / TOML `stream` config plumbing. No provider implementations or conversation-loop changes — those are M2–M5. All decisions (explicit `--stream` opt-in, `EventStream` with `Next()/Close()`, no retry wrapping for streams, sub-agents never stream, Bedrock deferred) are settled in the spec and must not be re-evaluated.
+
+## Section 2: Implementation Checklist
+
+### Stream Types (internal/provider/stream.go — new file)
+
+These three tasks have no dependencies on each other or on other groups and can be implemented together.
+
+- [x] Define exported string constants `StreamEventText`, `StreamEventToolStart`, `StreamEventToolDelta`, `StreamEventToolEnd`, `StreamEventDone` in `internal/provider/stream.go`
+- [x] Define `StreamEvent` struct with fields: `Type string`, `Text string`, `ToolCallID string`, `ToolName string`, `ToolInput string`, `InputTokens int`, `OutputTokens int`, `StopReason string` in `internal/provider/stream.go`
+- [x] Define `EventStream` struct with an `io.Closer` field (HTTP response body), a `nextFunc func() (StreamEvent, error)` field, and a `closed bool` field. Implement `Next() (StreamEvent, error)` (returns `io.EOF` after close or after done event), `Close() error` (idempotent, closes underlying body) in `internal/provider/stream.go`
+- [x] Define `StreamProvider` interface embedding `Provider` with method `SendStream(ctx context.Context, req *Request) (*EventStream, error)` in `internal/provider/stream.go`
+- [x] **Test:** `internal/provider/stream_test.go` — Table-driven tests for `EventStream`: `Next()` returns events in order then `io.EOF`; `Close()` is idempotent (double-close returns nil); `Next()` after `Close()` returns `io.EOF`. Use a real `EventStream` with a pipe-backed `io.ReadCloser` and a `nextFunc` that reads from it — no mocks.
+
+### SSE Parser (internal/provider/sse.go — new file)
+
+No dependency on stream types. Can be implemented in parallel with stream types and config plumbing.
+
+- [x] Define `SSEEvent` struct with `Event string` and `Data string` fields in `internal/provider/sse.go`
+- [x] Define `SSEParser` struct wrapping a `bufio.Scanner` (line-by-line) in `internal/provider/sse.go`
+- [x] Implement `NewSSEParser(r io.Reader) *SSEParser` in `internal/provider/sse.go`
+- [x] Implement `SSEParser.Next() (SSEEvent, error)` in `internal/provider/sse.go` — reads lines until a blank line (event boundary). Handles: `data:` lines (concatenate with `\n`), `event:` lines, comment lines (`:` prefix — skip), optional space after colon, `id:` and `retry:` ignored, `[DONE]` passed through as data. Returns `io.EOF` when reader is exhausted.
+- [x] **Test:** `internal/provider/sse_test.go` — Table-driven tests covering: single data event, multi-line data (joined with `\n`), event type field, comment lines skipped, `[DONE]` sentinel passed through, space-after-colon stripping (`data:hello` vs `data: hello`), empty events between blank lines, `id:`/`retry:` fields ignored, `io.EOF` after last event. Feed real `strings.Reader` content into `NewSSEParser`.
+
+### RetryProvider StreamProvider Delegation (internal/provider/retry.go)
+
+Depends on `StreamProvider` interface from stream types.
+
+- [x] Add method `SendStream(ctx context.Context, req *Request) (*EventStream, error)` on `*RetryProvider` in `internal/provider/retry.go`: type-assert `r.inner` to `StreamProvider`; if yes, delegate directly (no retry wrapping); if no, return a `ProviderError` with `ErrCategoryBadRequest` and message indicating the inner provider does not support streaming.
+- [x] **Test:** `internal/provider/retry_test.go` — Two cases: (1) inner provider implements `StreamProvider` → `RetryProvider` delegates `SendStream()` and returns the stream; (2) inner provider does NOT implement `StreamProvider` → `SendStream()` returns error. Use minimal concrete test types (a struct implementing `Provider` only, and one implementing both `Provider` + `StreamProvider`) — not mocks.
+
+### TOML Config (internal/agent/agent.go)
+
+No dependency on any of the above. Can be implemented in parallel.
+
+- [x] Add `Stream bool` field with TOML tag `toml:"stream"` to `AgentConfig` struct in `internal/agent/agent.go`
+- [x] **Test:** `internal/agent/agent_test.go` — Verify `stream = true` in TOML round-trips through `Load()` correctly; verify default is `false` when field is omitted. Use a real temp TOML file, not mocks.
+
+### CLI Flag and Dry-Run (cmd/run.go)
+
+No dependency on any of the above. Can be implemented in parallel.
+
+- [x] Register `--stream` boolean flag (default `false`) in `cmd/run.go: init()`
+- [x] Read the flag in `cmd/run.go: runAgent()` and resolve against `cfg.Stream` (flag overrides TOML). Store as a local `streamEnabled` variable. No behavior change yet — just resolve and pass to dry-run.
+- [x] Add `Stream: yes/no` line to `cmd/run.go: printDryRun()` output showing the resolved value
+- [x] **Test:** `cmd/run_test.go` or `cmd/golden_test.go` — Verify `--dry-run --stream` shows `Stream: yes` in output; verify `--dry-run` without `--stream` shows `Stream: no`. Use the golden-file pattern if one already exists for dry-run, otherwise a standard command execution test.
+
+### Scaffold Update (internal/agent/agent.go)
+
+- [x] Add commented-out `# stream = false` line to `Scaffold()` template in `internal/agent/agent.go: Scaffold()`, placed near other top-level fields (after `timeout`)
+
+## Parallelism
+
+The following groups have **zero dependencies** between them and should be implemented concurrently:
+
+| Group | Tasks |
+|-------|-------|
+| **A** | Stream types + tests (`stream.go`, `stream_test.go`) |
+| **B** | SSE parser + tests (`sse.go`, `sse_test.go`) |
+| **C** | TOML `Stream` field + test |
+| **D** | CLI `--stream` flag + dry-run + test |
+
+**Sequential after A completes:**
+- RetryProvider `SendStream` delegation + tests (depends on `StreamProvider` interface from Group A)
+
+**Sequential after C completes:**
+- Scaffold update (trivial, touches same file)

--- a/docs/plans/ISS-59_m2_implement.md
+++ b/docs/plans/ISS-59_m2_implement.md
@@ -1,0 +1,42 @@
+# ISS-59 M2 — OpenAI Provider Streaming: Implementation Guide
+
+Spec: [ISS-59_m2_openai_streaming_spec.md](ISS-59_m2_openai_streaming_spec.md)
+
+## Section 1: Context Summary
+
+The OpenAI provider needs a `SendStream()` method so that Axe can keep nginx connections alive during long-running LLM calls and (in M3) print tokens as they arrive. The M1 milestone already landed the `StreamEvent`, `EventStream`, `StreamProvider`, and `SSEParser` primitives. This milestone wires them together: the OpenAI provider sends `stream: true` in the request, parses the SSE response using `SSEParser`, tracks tool call fragments by index, and maps each chunk to the appropriate `StreamEvent` — all without modifying existing buffered behavior or retry logic.
+
+## Section 2: Implementation Checklist
+
+All tasks are sequential — each depends on the one before it.
+
+### Task 1: Add streaming chunk deserialization types
+
+- [x] `internal/provider/openai.go`: Add unexported structs for the streaming wire format: `openaiStreamChunk` (with `Model`, `Choices []openaiStreamChoice`, `Usage *openaiStreamUsage`), `openaiStreamChoice` (with `Index`, `Delta openaiStreamDelta`, `FinishReason *string`), `openaiStreamDelta` (with `Content *string`, `Role string`, `ToolCalls []openaiStreamToolCall`), `openaiStreamToolCall` (with `Index int`, `ID string`, `Type string`, `Function *openaiStreamToolCallFunction`), `openaiStreamToolCallFunction` (with `Name string`, `Arguments string`), and `openaiStreamUsage` (with `PromptTokens int`, `CompletionTokens int`). All fields use `json` tags. These are separate from the existing `openaiResponse` type.
+
+### Task 2: Extend the request struct for streaming fields
+
+- [x] `internal/provider/openai.go`: Add `Stream bool` and `StreamOptions *openaiStreamOptions` fields (with `json:"stream,omitempty"` and `json:"stream_options,omitempty"` tags) to the existing `openaiRequest` struct. Add an unexported `openaiStreamOptions` struct with `IncludeUsage bool` (`json:"include_usage"`). Existing `Send()` behavior is unchanged because `Stream` defaults to `false` and is omitted from the JSON.
+- [x] `internal/provider/openai_test.go`: Add a test `TestOpenAI_Send_DoesNotSetStreamField` — use an `httptest.Server` that captures the request body, call `Send()`, and assert the JSON body does NOT contain a `"stream"` key.
+
+### Task 3: Implement `SendStream()` on `OpenAI`
+
+- [x] `internal/provider/openai.go`: Add method `func (o *OpenAI) SendStream(ctx context.Context, req *Request) (*EventStream, error)`. Build the request body identically to `Send()` (reuse `convertToOpenAIMessages`, `convertToOpenAITools`, same temperature/max_tokens logic) but set `Stream: true` and `StreamOptions: &openaiStreamOptions{IncludeUsage: true}`. POST to `o.baseURL + "/chat/completions"` with the same headers. On context cancellation before response, return `ProviderError{Category: ErrCategoryTimeout}`. On non-2xx status, read the body, close it, and return via `handleErrorResponse()`. On 2xx, construct and return `NewEventStream(httpResp.Body, nextFunc)` where `nextFunc` is a closure (implemented in Task 4).
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_RequestFormat` — use `httptest.Server` that captures the request body and responds with a minimal valid SSE stream (`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\ndata: [DONE]\n\n`). Assert: method is POST, path is `/chat/completions`, `Authorization` header is `Bearer {key}`, body JSON contains `"stream": true` and `"stream_options": {"include_usage": true}`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_ErrorResponse` — server returns 401 with JSON error body. Assert `SendStream()` returns a `ProviderError` with `ErrCategoryAuth`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_ContextCancelled` — server delays 2s, context has 50ms timeout. Assert `SendStream()` returns `ProviderError` with `ErrCategoryTimeout`.
+
+### Task 4: Implement the `nextFunc` closure (SSE-to-StreamEvent mapping)
+
+- [x] `internal/provider/openai.go`: Implement the `nextFunc` closure inside `SendStream()`. It creates an `SSEParser` from the response body. The closure maintains: a `toolCalls map[int]struct{id, name string}` for index tracking, a `finishReason string` for the stop reason, and a `gotUsage bool` flag. On each call: (1) call `parser.Next()` to get the next `SSEEvent`; (2) if the parser returns an error, check `ctx.Err()` — if context is done, return `ProviderError{ErrCategoryTimeout}`, else return `ProviderError{ErrCategoryServer}` wrapping the read error; (3) if `sseEvent.Data == "[DONE]"`, emit `StreamEventDone` with stored `finishReason` and zero tokens if `!gotUsage`, else return `io.EOF`; (4) JSON-unmarshal `sseEvent.Data` into `openaiStreamChunk` — on parse failure return `ProviderError{ErrCategoryServer}`; (5) if `len(chunk.Choices) == 0` and `chunk.Usage != nil`, set `gotUsage = true`, return `StreamEvent{Type: StreamEventDone, InputTokens, OutputTokens, StopReason: finishReason}`; (6) if `len(chunk.Choices) == 0`, loop back to step 1; (7) process `choices[0]`: if `delta.Content` is non-nil and non-empty, return `StreamEvent{Type: StreamEventText, Text: *delta.Content}`; if `delta.ToolCalls` is non-empty, process the first entry — if `ID` is present, store in `toolCalls` map and return `StreamEventToolStart`, else look up ID by index and return `StreamEventToolDelta`; if `FinishReason` is non-nil and `== "tool_calls"`, emit `StreamEventToolEnd` for each tracked tool call (by ascending index), store finish reason, loop back; if `FinishReason` is non-nil (any other value), store it, loop back; otherwise loop back.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_TextDeltas` — server sends 3 text delta chunks + finish + usage + `[DONE]`. Call `SendStream()`, then call `Next()` repeatedly. Assert: 3 `StreamEventText` events with correct text, then `StreamEventDone` with correct tokens and `StopReason: "stop"`, then `io.EOF`. Defer `stream.Close()`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_ToolCall` — server sends: tool_start chunk (index 0, id "call_1", name "read_file"), 2 tool_delta chunks (index 0, arguments fragments), finish chunk (finish_reason "tool_calls"), usage chunk, `[DONE]`. Assert event sequence: `StreamEventToolStart` (ID "call_1", Name "read_file"), 2x `StreamEventToolDelta` (ID "call_1", correct fragments), `StreamEventToolEnd` (ID "call_1"), `StreamEventDone`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_MultipleToolCalls` — server sends: tool_start for index 0 ("call_a", "read_file"), tool_start for index 1 ("call_b", "write_file"), delta for index 0, delta for index 1, finish "tool_calls", usage, `[DONE]`. Assert: two `StreamEventToolStart` events, two `StreamEventToolDelta` events with correct IDs, two `StreamEventToolEnd` events (index 0 then 1), then `StreamEventDone`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_EmptyContent` — server sends a chunk with `"content": ""` followed by a chunk with `"content": "hello"`, finish, usage, `[DONE]`. Assert only one `StreamEventText` event (the empty one is skipped).
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_NoUsageChunk` — server sends text delta, finish "stop", `[DONE]` (no usage chunk). Assert: `StreamEventText`, `StreamEventDone` with `InputTokens: 0`, `OutputTokens: 0`, `StopReason: "stop"`, then `io.EOF`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_MalformedJSON` — server sends `data: {not json}\n\n`. Assert `Next()` returns a `ProviderError` with `ErrCategoryServer`.
+- [x] `internal/provider/openai_test.go`: Add test `TestOpenAI_SendStream_FinishReasonLength` — server sends text delta, finish with `"length"`, usage, `[DONE]`. Assert `StreamEventDone` has `StopReason: "length"`.
+
+### Task 5: Verify `RetryProvider` delegation
+
+- [x] `internal/provider/retry_test.go`: Add test `TestRetryProvider_SendStream_DelegatesToOpenAI` — create a real `OpenAI` pointed at an `httptest.Server` serving a minimal SSE stream, wrap in `NewRetry()`, call `SendStream()`. Assert: returns an `EventStream`, first `Next()` yields expected event, `Close()` succeeds. This validates the full `RetryProvider` → `OpenAI` → `SSEParser` → `EventStream` chain.

--- a/docs/plans/ISS-59_m2_openai_streaming_spec.md
+++ b/docs/plans/ISS-59_m2_openai_streaming_spec.md
@@ -1,0 +1,265 @@
+# ISS-59 M2 — OpenAI Provider Streaming
+
+Milestones: [ISS-59_streaming_milestones.md](ISS-59_streaming_milestones.md)
+
+## Section 1: Context & Constraints
+
+### Codebase Structure
+
+- **OpenAI provider** (`internal/provider/openai.go`): Implements `Provider`
+  with `Send()`. Uses `http.Client` to POST to `/chat/completions`. Existing
+  request-building helpers (`convertToOpenAIMessages`,
+  `convertToOpenAITools`) and error handling (`handleErrorResponse`,
+  `mapStatusToCategory`) are reusable.
+
+- **M1 types** (`internal/provider/stream.go`): `StreamEvent`,
+  `EventStream`, and `StreamProvider` interface are already defined.
+  `NewEventStream(body, nextFunc)` is the constructor. `EventStream` manages
+  close-once semantics and mutex-protected `Next()`.
+
+- **SSE parser** (`internal/provider/sse.go`): `NewSSEParser(io.Reader)`
+  returns a parser with `Next() (SSEEvent, error)`. Returns `io.EOF` when
+  the reader is exhausted. Each `SSEEvent` has `Event` (type) and `Data`
+  (payload) fields.
+
+- **RetryProvider** (`internal/provider/retry.go`): Already implements
+  `SendStream()` by delegating to the inner provider without retries. No
+  changes needed for M2.
+
+### Decisions Already Made
+
+- `StreamProvider` is an optional interface — `OpenAI` will implement it by
+  adding `SendStream()`.
+- `EventStream` with `Next()/Close()` is the streaming primitive.
+- The SSE parser handles wire-level parsing; the provider maps parsed events
+  to `StreamEvent` values.
+- No retry wrapping for streaming (handled by `RetryProvider` in M1).
+
+### Approaches Ruled Out
+
+- **Reusing `Send()` internally**: `SendStream()` must return an
+  `EventStream` immediately with the HTTP body open. It cannot read the
+  full body like `Send()` does.
+- **Goroutine + channel bridge**: The `EventStream.Next()` pull model
+  already matches the SSE parser's pull model. No goroutine needed.
+- **Parsing `usage` from `stream_options`**: OpenAI supports
+  `stream_options: {include_usage: true}` which sends a final chunk with
+  usage data. This is the correct approach — usage is not available in
+  individual delta chunks.
+
+### Constraints
+
+- **OpenAI streaming wire format**: When `stream: true` is set in the
+  request body, the response is `text/event-stream` (SSE). Each SSE event
+  has `data:` containing a JSON chunk. The final event is `data: [DONE]`.
+
+- **Chunk JSON structure** (text delta):
+  ```json
+  {
+    "model": "gpt-4o",
+    "choices": [{
+      "index": 0,
+      "delta": {"content": "Hello"},
+      "finish_reason": null
+    }]
+  }
+  ```
+
+- **Chunk JSON structure** (tool call):
+  ```json
+  {
+    "choices": [{
+      "delta": {
+        "tool_calls": [{
+          "index": 0,
+          "id": "call_abc",
+          "type": "function",
+          "function": {"name": "read_file", "arguments": ""}
+        }]
+      },
+      "finish_reason": null
+    }]
+  }
+  ```
+  Subsequent chunks for the same tool call omit `id`, `type`, and
+  `function.name` — only `index` and `function.arguments` (fragment) are
+  present.
+
+- **Chunk JSON structure** (finish):
+  ```json
+  {
+    "choices": [{
+      "delta": {},
+      "finish_reason": "stop"
+    }]
+  }
+  ```
+
+- **Usage chunk** (when `stream_options.include_usage` is set):
+  ```json
+  {
+    "choices": [],
+    "usage": {
+      "prompt_tokens": 10,
+      "completion_tokens": 5
+    }
+  }
+  ```
+  This arrives as a separate chunk after the `finish_reason` chunk and
+  before `[DONE]`.
+
+- **Tool call accumulation**: A single tool call is split across many
+  chunks. The first chunk for a tool call (identified by `index`) carries
+  `id` and `function.name`. Subsequent chunks carry `function.arguments`
+  fragments. The `finish_reason` of `"tool_calls"` signals all tool calls
+  are complete.
+
+- **Error responses**: If the API returns an HTTP error status (4xx/5xx),
+  the response is NOT SSE — it's a JSON error body, identical to the
+  non-streaming case. Mid-stream errors manifest as the connection dropping
+  (the SSE parser returns a read error).
+
+## Section 2: Requirements
+
+### 2.1 `SendStream()` Method on `OpenAI`
+
+`OpenAI` must implement the `StreamProvider` interface by adding a
+`SendStream(ctx context.Context, req *Request) (*EventStream, error)` method.
+
+**Request construction:**
+
+- Build the request body identically to `Send()` (same message conversion,
+  tool conversion, temperature/max_tokens handling).
+- Set `"stream": true` in the JSON request body.
+- Set `"stream_options": {"include_usage": true}` in the JSON request body
+  so that usage data is included in the final chunk.
+- Send to the same endpoint: `{baseURL}/chat/completions`.
+- Use the same headers: `Authorization: Bearer {apiKey}`,
+  `Content-Type: application/json`.
+
+**Response handling:**
+
+- If the HTTP status is not 2xx, read the full body and return a
+  `ProviderError` using the existing `handleErrorResponse()` logic. Close
+  the body before returning.
+- If the HTTP status is 2xx, do NOT read or close the body. Wrap it in
+  an `EventStream` using `NewEventStream()` and return immediately.
+
+**Context cancellation:**
+
+- If the context is cancelled before the HTTP request completes, return a
+  `ProviderError` with `ErrCategoryTimeout` (same as `Send()`).
+
+### 2.2 SSE-to-StreamEvent Mapping
+
+The `nextFunc` passed to `NewEventStream` must use `SSEParser` to read
+SSE events from the response body and map them to `StreamEvent` values.
+
+**Mapping rules:**
+
+| SSE data content | StreamEvent produced |
+|---|---|
+| `[DONE]` sentinel | Return `io.EOF` (no `StreamEvent` emitted) |
+| Chunk with `choices[0].delta.content` (non-empty string) | `StreamEventText` with `Text` set to the content value |
+| Chunk with `choices[0].delta.tool_calls[N]` where `id` is present | `StreamEventToolStart` with `ToolCallID` and `ToolName` set |
+| Chunk with `choices[0].delta.tool_calls[N]` where `id` is absent and `function.arguments` is present | `StreamEventToolDelta` with `ToolCallID` (looked up by index) and `ToolInput` set to the arguments fragment |
+| Chunk with `choices[0].finish_reason == "tool_calls"` | Emit one `StreamEventToolEnd` per accumulated tool call (by index order), then continue to the next SSE event |
+| Chunk with `choices[0].finish_reason == "stop"` (or any non-null, non-`"tool_calls"` value) | Continue to the next SSE event (the done event will carry stop reason) |
+| Chunk with `usage` present and `choices` empty | `StreamEventDone` with `InputTokens`, `OutputTokens`, and `StopReason` set |
+| Chunk with empty `delta` and `finish_reason == null` | Skip (no event emitted), continue to next SSE event |
+| JSON parse failure on a chunk | Return `ProviderError` with `ErrCategoryServer` |
+
+**Tool call index tracking:**
+
+- The `nextFunc` closure must maintain a map of `index` → `{id, name}` to
+  correlate tool call delta chunks with their starting chunk.
+- When a `tool_calls` entry has an `id` field, it is a new tool call —
+  store `index → {id, name}` and emit `StreamEventToolStart`.
+- When a `tool_calls` entry lacks `id`, look up the stored `id` by `index`
+  and emit `StreamEventToolDelta`.
+
+**Stop reason and usage tracking:**
+
+- The `nextFunc` closure must store the `finish_reason` from the finish
+  chunk so it can be included in the `StreamEventDone` emitted when the
+  usage chunk arrives.
+- If the stream ends (`[DONE]`) without a usage chunk (e.g., provider
+  doesn't honor `stream_options`), emit `StreamEventDone` with zero
+  tokens and the stored `finish_reason`. Do not error.
+
+### 2.3 Wire Format Types
+
+Add unexported structs for deserializing OpenAI streaming chunks. These
+are separate from the existing `openaiResponse` (which is for buffered
+responses).
+
+**Required fields:**
+
+- `model` (string)
+- `choices` (array of objects, each with):
+  - `index` (int)
+  - `delta` (object with optional `content`, `role`, `tool_calls`)
+  - `finish_reason` (nullable string)
+- `usage` (optional object with `prompt_tokens`, `completion_tokens`)
+
+The `delta.tool_calls` array entries have:
+- `index` (int) — always present
+- `id` (string) — present only on the first chunk for a given tool call
+- `type` (string) — present only on the first chunk
+- `function` (object) — with optional `name` and `arguments`
+
+### 2.4 Edge Cases
+
+1. **Empty `delta.content`**: Some providers send chunks with
+   `"content": ""`. Skip these — do not emit a `StreamEventText` with
+   empty `Text`.
+
+2. **Multiple tool calls in parallel**: The model may initiate multiple
+   tool calls in one response. Each gets a unique `index`. The mapping
+   must track all of them independently.
+
+3. **`content` and `tool_calls` in the same response**: The model may
+   produce text content before switching to tool calls. Both must be
+   emitted as their respective event types.
+
+4. **Connection drop mid-stream**: `SSEParser.Next()` returns the
+   underlying read error. The `nextFunc` must wrap this in a
+   `ProviderError` with `ErrCategoryServer`.
+
+5. **Context cancelled mid-stream**: The HTTP response body read will
+   fail with the context error. The `nextFunc` must check `ctx.Err()`
+   and return a `ProviderError` with `ErrCategoryTimeout` if the context
+   is done.
+
+6. **No choices in chunk**: Some chunks (like the usage-only chunk) have
+   an empty `choices` array. Handle gracefully — do not index into an
+   empty slice.
+
+7. **`finish_reason` of `"length"`**: Treat like `"stop"` — store it and
+   include in the done event. Do not error.
+
+8. **`stream_options` not supported by endpoint**: Some OpenAI-compatible
+   endpoints may ignore `stream_options`. The stream must still terminate
+   cleanly — emit `StreamEventDone` with zero tokens on `[DONE]` if no
+   usage chunk was received.
+
+### 2.5 Existing Code Reuse
+
+The following existing code must be reused without modification:
+
+- `convertToOpenAIMessages()` — for building the messages array
+- `convertToOpenAITools()` — for building the tools array
+- `handleErrorResponse()` — for non-2xx responses before streaming begins
+- `mapStatusToCategory()` — used by `handleErrorResponse()`
+- `NewSSEParser()` — for parsing the SSE wire format
+- `NewEventStream()` — for wrapping the response body
+
+The existing `openaiRequest` struct must be extended (or a new streaming
+variant created) to include the `stream` and `stream_options` fields.
+
+### Parallelism
+
+All work in this spec is sequential — `SendStream()` depends on the wire
+format types (2.3), and the SSE-to-StreamEvent mapping (2.2) is the core
+of `SendStream()`. There are no independent sub-tasks that can be done in
+parallel.

--- a/docs/plans/ISS-59_m3_conversation_loop_integration_implement.md
+++ b/docs/plans/ISS-59_m3_conversation_loop_integration_implement.md
@@ -1,0 +1,86 @@
+# ISS-59 M3 — Conversation Loop Integration: Implementation Guide
+
+**Spec:** `docs/plans/ISS-59_m3_conversation_loop_integration_spec.md`
+
+---
+
+## Section 1: Context Summary
+
+Axe already has `StreamProvider`, `EventStream`, and a working OpenAI `SendStream()` from M1/M2. The `--stream` flag and TOML `stream` field are resolved into `streamEnabled` in `cmd/run.go: runAgent()` but currently discarded (`_ = streamEnabled`). This milestone wires streaming into the conversation loop so that when streaming is active and the provider supports it, `SendStream()` is called instead of `Send()`, text tokens are printed incrementally to stdout (non-JSON) or buffered (JSON), tool calls are reconstructed from stream events, and a `*provider.Response` is built from the accumulated stream so all downstream code (tool execution, budget tracking, JSON envelope, memory) works unchanged.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Stream Drain Function (R2, R3, R4, R7)
+
+These tasks are tightly coupled — the drain function, text printing, and Response construction must be built together.
+
+- [x] **Create `drainEventStream()` in `cmd/run.go`** — Add a function with signature `func drainEventStream(stream *provider.EventStream, w io.Writer) (*provider.Response, error)`. `w` is the writer for incremental text output (`cmd.OutOrStdout()` in non-JSON mode, `nil` in JSON mode). The function:
+  - Calls `stream.Next()` in a loop until `io.EOF` or error.
+  - On `StreamEventText`: appends to a content string builder; if `w != nil`, writes the text payload to `w` immediately.
+  - On `StreamEventToolStart`: starts tracking a new tool call (ID, Name) keyed by `ToolCallID`.
+  - On `StreamEventToolDelta`: appends `ToolInput` to the tracked tool call's argument buffer (keyed by `ToolCallID`).
+  - On `StreamEventToolEnd`: parses the accumulated argument JSON string into `map[string]string`, constructs a `provider.ToolCall`, appends to the result list.
+  - On `StreamEventDone`: captures `InputTokens`, `OutputTokens`, `StopReason`.
+  - On `io.EOF`: stops the loop.
+  - On any other error: returns the error (caller handles).
+  - Defers `stream.Close()` at the top.
+  - Returns a `*provider.Response` with `Content`, `ToolCalls`, `InputTokens`, `OutputTokens`, `StopReason` populated from accumulated data.
+  - Edge: if no `done` event arrived before EOF, tokens default to 0 and stop reason to `""`.
+
+- [x] **Test `drainEventStream()` — text-only stream** (`cmd/run_stream_test.go`) — Create an `EventStream` from a sequence of text events + done event. Assert returned `Response.Content` matches concatenated text. Assert `Response.InputTokens` and `Response.OutputTokens` match done event values.
+
+- [x] **Test `drainEventStream()` — tool calls** (`cmd/run_stream_test.go`) — Stream with `tool_start` → multiple `tool_delta` → `tool_end` for two tool calls, then done. Assert `Response.ToolCalls` has correct IDs, names, and parsed arguments.
+
+- [x] **Test `drainEventStream()` — text + tool calls in same turn** (`cmd/run_stream_test.go`) — Stream with text events followed by tool call events. Assert both `Content` and `ToolCalls` are populated.
+
+- [x] **Test `drainEventStream()` — incremental write to writer** (`cmd/run_stream_test.go`) — Pass a `bytes.Buffer` as `w`. Assert each text event's payload was written to the buffer in order. Assert the buffer's content matches `Response.Content`.
+
+- [x] **Test `drainEventStream()` — nil writer (JSON mode)** (`cmd/run_stream_test.go`) — Pass `nil` as `w`. Assert no panic and `Response.Content` is still accumulated.
+
+- [x] **Test `drainEventStream()` — mid-stream error** (`cmd/run_stream_test.go`) — Stream returns an error after two text events. Assert the function returns the error, not partial content.
+
+- [x] **Test `drainEventStream()` — empty stream (only done)** (`cmd/run_stream_test.go`) — Stream emits only a done event. Assert `Response.Content` is `""` and `Response.ToolCalls` is nil.
+
+- [x] **Test `drainEventStream()` — EOF without done event** (`cmd/run_stream_test.go`) — Stream emits text then EOF (no done). Assert tokens are 0 and stop reason is `""` but content is accumulated.
+
+### Conversation Loop Integration (R1, R5, R6, R9)
+
+Depends on `drainEventStream()` being complete.
+
+- [x] **Wire streaming into the conversation loop** in `cmd/run.go: runAgent()` — Inside the `for turn := 0; ...` loop, replace the `prov.Send(ctx, req)` call with a branch: if `streamEnabled` and `prov` satisfies `provider.StreamProvider` (type-assert), call `sp.SendStream(ctx, req)`, then `drainEventStream(stream, textWriter)` where `textWriter` is `cmd.OutOrStdout()` when `!jsonOutput`, or `nil` when `jsonOutput`. Assign the returned `*provider.Response` to `resp`. On `SendStream()` error, handle identically to `Send()` error. On `drainEventStream()` error, map via `mapProviderError()`. Remove `_ = streamEnabled`.
+
+- [x] **Add a `streamedText` flag** in `cmd/run.go: runAgent()` — Track whether any text was printed incrementally during streaming. After the loop exits, in the non-JSON output section, skip `fmt.Fprint(cmd.OutOrStdout(), resp.Content)` when `streamedText` is true.
+
+- [x] **Verbose logging for streaming turns** in `cmd/run.go: runAgent()` — Before `SendStream()`, log `[turn N] Streaming request (M messages)` to stderr. After `drainEventStream()` returns, log `[turn N] Stream complete: <stop_reason> (K tool calls)` to stderr. Gate both behind `verbose`.
+
+### Single-Shot Path (R8)
+
+Can be implemented in parallel with the conversation loop changes — it's the `len(req.Tools) == 0` branch.
+
+- [x] **Wire streaming into the single-shot path** in `cmd/run.go: runAgent()` — In the `if len(req.Tools) == 0` block, add the same `streamEnabled` + `StreamProvider` type-assert branch. Call `SendStream()` → `drainEventStream()`. Set `streamedText` if non-JSON. Assign returned `Response` to `resp`. Error handling identical to buffered path.
+
+### Integration Tests
+
+Depends on all above tasks.
+
+- [x] **Integration test: streaming end-to-end with tools** (`cmd/run_integration_test.go`) — Use `testutil.NewMockLLMServer()` configured to return SSE streaming responses (text events → tool_calls finish → done; then after tool results, text events → stop → done). Run the compiled binary with `--stream`. Assert stdout contains the streamed text. Assert the tool was executed (check via tool side-effects or mock).
+
+- [x] **Integration test: `--stream --json` buffers output** (`cmd/run_integration_test.go`) — Same mock server, run with `--stream --json`. Assert stdout is a single valid JSON object. Assert `content` field contains the full text. Assert no incremental text appeared before the JSON envelope.
+
+- [x] **Integration test: streaming with non-StreamProvider falls back** (`cmd/run_integration_test.go`) — Use a provider that does not implement `StreamProvider`. Run with `--stream`. Assert it completes successfully using buffered `Send()`.
+
+---
+
+### Parallelism
+
+The following can be implemented concurrently:
+
+- **Group A**: `drainEventStream()` + all its unit tests
+- **Group B**: Single-shot streaming path (R8) — independent code branch, but requires `drainEventStream()` signature to be finalized
+
+Once Group A is complete:
+
+- **Group C**: Conversation loop wiring + `streamedText` flag + verbose logging
+- **Group D**: Integration tests (requires Groups A + C)

--- a/docs/plans/ISS-59_m3_conversation_loop_integration_spec.md
+++ b/docs/plans/ISS-59_m3_conversation_loop_integration_spec.md
@@ -1,0 +1,146 @@
+# ISS-59 M3 — Conversation Loop Integration Spec
+
+**Milestone source:** `docs/plans/ISS-59_streaming_milestones.md` § M3
+
+---
+
+## Section 1: Context & Constraints
+
+### Codebase State After M1 + M2
+
+- `internal/provider/stream.go` defines:
+  - `StreamEvent` with types: `text`, `tool_start`, `tool_delta`, `tool_end`, `done`.
+  - `EventStream` with `Next() (StreamEvent, error)` and `Close() error`.
+  - `StreamProvider` interface: `SendStream(ctx, *Request) (*EventStream, error)`.
+- `internal/provider/openai.go` implements `SendStream()` on the OpenAI provider. Tool calls arrive as `tool_start` → N × `tool_delta` → `tool_end` events. The `done` event carries `InputTokens`, `OutputTokens`, and `StopReason`.
+- `internal/provider/retry.go` `RetryProvider.SendStream()` delegates directly to the inner provider with no retry wrapping. `RetryProvider` already satisfies `StreamProvider`.
+- `cmd/run.go` already:
+  - Resolves `streamEnabled` from TOML `stream` field and `--stream` flag (flag wins).
+  - Assigns `_ = streamEnabled` (unused placeholder).
+  - Has a conversation loop (max 50 turns) that calls `prov.Send()`, appends assistant messages with tool calls, executes tools, appends tool results, and repeats.
+
+### Decisions Already Made
+
+- `--stream` is explicit opt-in (not TTY-detected).
+- Flag overrides TOML; both resolved before the loop starts.
+- Sub-agents always use `Send()`, never stream. The `call_agent` tool invocation path is unaffected.
+- `RetryProvider` passes `SendStream()` through without retries.
+- Bedrock streaming is deferred to a separate issue.
+
+### Approaches Ruled Out
+
+- Auto-detecting streaming from TTY — rejected in favor of explicit `--stream`.
+- Retrying streaming requests — decided against in M1.
+- Streaming sub-agent output to the parent — violates opaque sub-agent boundary.
+
+### Constraints
+
+- Axe is a Unix citizen: stdout must remain clean and pipeable. Streaming text tokens go to stdout. Debug/status goes to stderr.
+- `--json` output is a single JSON envelope on stdout. When `--stream --json`, the stream keeps the connection alive but all output is buffered and emitted as one JSON object at the end.
+- The conversation loop safety limit (50 turns) still applies.
+- Budget tracking (`budget.BudgetTracker`) must still work — token counts come from the `done` event instead of `Response` fields.
+- Memory append on success must still work — needs a final `Response`-equivalent after the stream completes.
+
+---
+
+## Section 2: Requirements
+
+### R1: Stream-or-Buffer Decision Point
+
+When the conversation loop is about to call the LLM, it must choose between `Send()` and `SendStream()` based on two conditions:
+
+1. `streamEnabled` is true.
+2. The provider (after retry wrapping) implements `StreamProvider`.
+
+If both conditions are met, use `SendStream()`. Otherwise, fall back to `Send()` (current behavior). This check happens on every turn of the loop, not just the first.
+
+### R2: Consuming the EventStream
+
+When `SendStream()` returns an `*EventStream`, the loop must drain it by calling `Next()` repeatedly until `io.EOF` or error. During consumption, the loop must:
+
+- **Accumulate text**: Concatenate all `StreamEventText` payloads into a single content string (equivalent to `Response.Content`).
+- **Accumulate tool calls**: Track `tool_start`, `tool_delta`, and `tool_end` events to reconstruct complete `ToolCall` structs (ID, Name, Arguments). Tool call arguments arrive as JSON fragment strings across multiple `tool_delta` events — they must be concatenated and then parsed into `map[string]string` once `tool_end` is received.
+- **Extract token counts**: The `done` event's `InputTokens` and `OutputTokens` fields provide the token counts for this turn.
+- **Extract stop reason**: The `done` event's `StopReason` field provides the stop reason.
+- **Close the stream**: Call `Close()` on the `EventStream` after draining, whether the drain succeeded or errored.
+
+After draining, construct a `*provider.Response` from the accumulated data so the rest of the loop (tool execution, message appending, budget tracking, JSON output, memory) works unchanged.
+
+### R3: Printing Text Tokens to Stdout (Non-JSON Mode)
+
+When `--stream` is active and `--json` is NOT active:
+
+- Each `StreamEventText` payload must be written to stdout immediately as it arrives (before the stream is fully drained).
+- No trailing newline is added between text events — the LLM's content is printed verbatim as a continuous stream.
+- After the stream completes and the conversation loop exits (no more tool calls), do NOT print `resp.Content` again. The text was already printed incrementally.
+
+### R4: Buffered Output in JSON Mode
+
+When `--stream --json` is active:
+
+- Text events are NOT printed to stdout as they arrive.
+- All text events are accumulated silently (the stream still keeps the HTTP connection alive).
+- After the conversation loop exits, the JSON envelope is emitted exactly as it is today — `resp.Content` contains the full accumulated text.
+- `tool_call_details` in the JSON envelope must include streaming tool calls with the same structure as non-streaming.
+
+### R5: Tool Call Handling Unchanged
+
+When the stream's stop reason is `tool_calls` (or the equivalent for the provider):
+
+- The accumulated tool calls are placed on the assistant message exactly as they are in the non-streaming path.
+- Tool execution proceeds identically — `executeToolCalls()` is called with the same arguments.
+- Tool results are appended to the conversation.
+- The loop continues to the next turn (which may again use `SendStream()`).
+
+### R6: Budget Tracking
+
+After draining the stream on each turn:
+
+- Call `tracker.Add(inputTokens, outputTokens)` using the values from the `done` event.
+- Accumulate `totalInputTokens` and `totalOutputTokens` the same as the non-streaming path.
+- Budget-exceeded checks happen at the same points as today (before LLM call, after LLM call but before tool execution).
+
+### R7: Error Handling
+
+- If `SendStream()` returns an error, handle it identically to a `Send()` error (map via `mapProviderError`, return `ExitError`).
+- If `Next()` returns an error other than `io.EOF`, close the stream and treat it as a provider error. Any text accumulated so far is lost — this is a failed turn.
+- Context cancellation during stream consumption must be handled: if `ctx.Err() != nil` after a `Next()` error, return a timeout error.
+
+### R8: Single-Shot Path (No Tools)
+
+When the request has no tools and `streamEnabled` is true and the provider supports streaming:
+
+- Use `SendStream()` instead of `Send()`.
+- Print text events to stdout (non-JSON) or buffer them (JSON).
+- After the stream completes, proceed to output and memory as normal.
+
+### R9: Verbose Output
+
+When `--verbose` is active and streaming:
+
+- Log `[turn N] Streaming request (M messages)` to stderr before calling `SendStream()`.
+- Log `[turn N] Stream complete: <stop_reason> (K tool calls)` to stderr after draining.
+- Token and duration logging at the end remains unchanged.
+
+### R10: Dry-Run
+
+No changes to dry-run output. `streamEnabled` is already displayed in dry-run mode.
+
+### Edge Cases
+
+1. **Provider does not implement StreamProvider**: Fall back to `Send()` silently. No error, no warning.
+2. **Stream returns zero text events and zero tool calls**: Treat as an empty response. `resp.Content` is `""`, `resp.ToolCalls` is nil. The loop exits.
+3. **Stream returns text events AND tool calls in the same turn**: Both are accumulated. Text is printed incrementally (non-JSON). Tool calls are executed after the stream completes. This is valid — some providers emit text before tool calls.
+4. **done event has zero token counts**: Use zero. Do not error.
+5. **done event is missing (stream ends with EOF before done)**: Use zero for token counts and `""` for stop reason. The turn still succeeds.
+6. **Multiple tool calls in one streamed turn**: Each gets its own `tool_start` → `tool_delta*` → `tool_end` sequence. All are accumulated and executed (in parallel or sequentially per config).
+
+### Parallelism
+
+The following parts of this spec are independent and can be implemented in parallel:
+
+- **Stream consumption + Response construction** (R2) and **text printing** (R3/R4) are tightly coupled and must be implemented together.
+- **R8 (single-shot path)** can be implemented in parallel with the conversation loop changes, as it's a separate code path.
+- **R9 (verbose output)** can be layered on after the core loop changes.
+
+---

--- a/docs/plans/ISS-59_m4_anthropic_streaming_implement.md
+++ b/docs/plans/ISS-59_m4_anthropic_streaming_implement.md
@@ -1,0 +1,66 @@
+# ISS-59 M4 — Anthropic Provider Streaming: Implementation Guide
+
+## Section 1: Context Summary
+
+Axe's streaming infrastructure (M1 types, SSE parser, EventStream) and OpenAI streaming (M2) are already in place. This milestone adds `SendStream()` to the Anthropic provider so it implements `StreamProvider`. The Anthropic SSE wire format differs from OpenAI: it uses typed `event:` fields (not `[DONE]`), splits usage across `message_start` and `message_delta`, and delivers tool identity in `content_block_start` with input fragments as `input_json_delta`. The implementation follows the same structural pattern as `OpenAI.SendStream()` — build request, set stream flag, return `NewEventStream()` with a closure that maps SSE events to `StreamEvent` values. All decisions on architecture, retry policy (none), and pull-model design are already settled in the spec.
+
+## Section 2: Implementation Checklist
+
+All tasks are **sequential** — each depends on the prior. No parallelism.
+
+### 2.1 Wire format types
+
+- [x] Add `Stream bool` field to `anthropicRequest` struct (`internal/provider/anthropic.go:73`, field: `Stream bool \`json:"stream,omitempty"\``)
+- [x] Add unexported streaming envelope structs in a new file `internal/provider/anthropic_stream_types.go`: `anthropicStreamEvent` (top-level with `Type`, `Message`, `Index`, `ContentBlock`, `Delta`, `Usage`, `Error` fields), plus nested structs for `anthropicStreamMessage`, `anthropicStreamUsage`, `anthropicStreamContentBlock`, `anthropicStreamDelta`, `anthropicStreamError`. Use concrete fields with `json:",omitempty"` — no `json.RawMessage`.
+- [x] Test: In `internal/provider/anthropic_stream_types_test.go`, add `TestAnthropicStreamEvent_Unmarshal` — table-driven test that unmarshals each of the 10 SSE event JSON payloads from the spec (message_start, content_block_start text, content_block_start tool_use, text_delta, input_json_delta, content_block_stop, message_delta, message_stop, ping, error) into `anthropicStreamEvent` and asserts the correct fields are populated.
+
+### 2.2 Mid-stream error mapping
+
+- [x] Add unexported function `mapStreamErrorType(errorType string) ErrorCategory` in `internal/provider/anthropic.go` (after `mapStatusToCategory`). Maps: `"overloaded_error"` → `ErrCategoryOverloaded`, `"rate_limit_error"` → `ErrCategoryRateLimit`, `"api_error"` → `ErrCategoryServer`, `"authentication_error"` → `ErrCategoryAuth`, default → `ErrCategoryServer`.
+- [x] Test: In `internal/provider/anthropic_stream_types_test.go`, add `TestMapStreamErrorType` — table-driven test covering all five cases above.
+
+### 2.3 SendStream method
+
+- [x] Add `SendStream(ctx context.Context, req *Request) (*EventStream, error)` method on `*Anthropic` in `internal/provider/anthropic.go`. Implementation:
+  1. Build `anthropicRequest` identically to `Send()` (reuse `convertToAnthropicMessages`, `convertToAnthropicTools`, `defaultMaxTokens`, temperature handling). Set `Stream: true`.
+  2. Marshal, create `http.NewRequestWithContext`, set same headers (`x-api-key`, `anthropic-version`, `content-type`).
+  3. `client.Do()` — on error, check `ctx.Err()` for timeout, else return `ErrCategoryServer`.
+  4. Non-2xx: read body, close body, return `handleErrorResponse()`.
+  5. 2xx: create `NewSSEParser(httpResp.Body)`, build closure state (`inputTokens int`, `blocks map[int]blockInfo` where `blockInfo` is `struct{typ, id, name string}`), return `NewEventStream(httpResp.Body, nextFunc)`.
+- [x] The `nextFunc` closure must implement the mapping table from spec §2.2:
+  - Loop calling `parser.Next()`. On parser error: check `ctx.Err()` first (→ `ErrCategoryTimeout`), then `io.EOF` passthrough, else `ErrCategoryServer`.
+  - `json.Unmarshal` into `anthropicStreamEvent`. On failure: return `ProviderError` with `ErrCategoryServer`.
+  - Switch on `event.Type`: `message_start` (store inputTokens, continue), `content_block_start` (store block info, emit `StreamEventToolStart` for tool_use only), `content_block_delta` (emit `StreamEventText` or `StreamEventToolDelta`, skip empties, skip unknown index), `content_block_stop` (emit `StreamEventToolEnd` for tool_use only), `message_delta` (emit `StreamEventDone` with tokens and stop_reason), `message_stop` (return `io.EOF`), `ping` (continue), `error` (return `ProviderError` via `mapStreamErrorType`).
+
+### 2.4 Tests — Request construction
+
+- [x] Test: `TestAnthropic_SendStream_RequestFormat` in `internal/provider/anthropic_test.go` — httptest server captures request body, asserts `"stream": true` is present alongside model, messages, max_tokens, system, temperature, and tools. Same pattern as `TestAnthropic_Send_RequestFormat`.
+- [x] Test: `TestAnthropic_SendStream_DefaultMaxTokens` — asserts max_tokens defaults to 4096 when `req.MaxTokens == 0`.
+- [x] Test: `TestAnthropic_SendStream_OmitsZeroTemperature` — asserts temperature key absent when 0.
+
+### 2.5 Tests — Error responses (pre-stream)
+
+- [x] Test: `TestAnthropic_SendStream_ErrorResponse` — httptest server returns 401 with Anthropic error JSON. Assert `ProviderError` with `ErrCategoryAuth`.
+- [x] Test: `TestAnthropic_SendStream_ContextCancelled` — httptest server sleeps, context with short timeout. Assert `ProviderError` with `ErrCategoryTimeout`.
+
+### 2.6 Tests — Text streaming
+
+- [x] Test: `TestAnthropic_SendStream_TextDeltas` — httptest server writes full SSE sequence: `message_start` → `content_block_start` (text) → two `content_block_delta` (text_delta) → `content_block_stop` → `message_delta` → `message_stop`. Consume via `Next()` loop, assert: two `StreamEventText` events with correct text, one `StreamEventDone` with `InputTokens`, `OutputTokens`, `StopReason`, then `io.EOF`.
+
+### 2.7 Tests — Tool call streaming
+
+- [x] Test: `TestAnthropic_SendStream_ToolCall` — SSE sequence: `message_start` → `content_block_start` (tool_use, id=`toolu_abc`, name=`read_file`) → two `content_block_delta` (input_json_delta with `{"pat` and `h": "x"}`) → `content_block_stop` → `message_delta` (stop_reason=`tool_use`) → `message_stop`. Assert: `StreamEventToolStart` (correct id/name), two `StreamEventToolDelta` (correct id/input fragments), `StreamEventToolEnd` (correct id), `StreamEventDone`, `io.EOF`.
+
+### 2.8 Tests — Mixed text + tool blocks
+
+- [x] Test: `TestAnthropic_SendStream_TextAndToolBlocks` — SSE sequence with text block (index 0) and tool_use block (index 1) interleaved. Assert events arrive in correct order: text events for index 0, tool start/delta/end for index 1, done, EOF.
+
+### 2.9 Tests — Edge cases
+
+- [x] Test: `TestAnthropic_SendStream_PingIgnored` — SSE sequence with `ping` events interspersed between `content_block_delta` events. Assert ping produces no `StreamEvent` — only the text deltas and done appear.
+- [x] Test: `TestAnthropic_SendStream_MidStreamError` — SSE sequence: `message_start` → `content_block_start` → `error` event with `overloaded_error`. Assert `Next()` returns `ProviderError` with `ErrCategoryOverloaded`.
+- [x] Test: `TestAnthropic_SendStream_EmptyTextDelta` — SSE `content_block_delta` with `delta.text` = `""`. Assert no `StreamEventText` emitted; next real delta is returned instead.
+- [x] Test: `TestAnthropic_SendStream_EmptyPartialJSON` — SSE `content_block_delta` with `delta.partial_json` = `""`. Assert no `StreamEventToolDelta` emitted.
+- [x] Test: `TestAnthropic_SendStream_MalformedJSON` — SSE event with invalid JSON data. Assert `ProviderError` with `ErrCategoryServer`.
+- [x] Test: `TestAnthropic_SendStream_UnknownBlockIndex` — `content_block_delta` referencing an index not in block map. Assert event is skipped, no error.
+- [x] Test: `TestAnthropic_SendStream_MessageDeltaWithoutStart` — `message_delta` arrives without prior `message_start`. Assert `StreamEventDone` with `InputTokens` = 0.

--- a/docs/plans/ISS-59_m4_anthropic_streaming_spec.md
+++ b/docs/plans/ISS-59_m4_anthropic_streaming_spec.md
@@ -1,0 +1,296 @@
+# ISS-59 M4 — Anthropic Provider Streaming
+
+Milestones: [ISS-59_streaming_milestones.md](ISS-59_streaming_milestones.md)
+
+## Section 1: Context & Constraints
+
+### Codebase Structure
+
+- **Anthropic provider** (`internal/provider/anthropic.go`): Implements
+  `Provider` with `Send()`. Uses `http.Client` to POST to `/v1/messages`.
+  Existing helpers (`convertToAnthropicMessages`, `convertToAnthropicTools`)
+  and error handling (`handleErrorResponse`, `mapStatusToCategory`) are
+  reusable. The `anthropicRequest` struct defines the request body.
+
+- **M1 types** (`internal/provider/stream.go`): `StreamEvent`,
+  `EventStream`, and `StreamProvider` interface are defined.
+  `NewEventStream(body, nextFunc)` is the constructor. `EventStream`
+  manages close-once semantics and mutex-protected `Next()`.
+
+- **SSE parser** (`internal/provider/sse.go`): `NewSSEParser(io.Reader)`
+  returns a parser with `Next() (SSEEvent, error)`. Returns `io.EOF` when
+  exhausted. Each `SSEEvent` has `Event` (the SSE `event:` field) and
+  `Data` (the `data:` field).
+
+- **OpenAI streaming reference** (`internal/provider/openai.go`):
+  `SendStream()` on OpenAI shows the established pattern — build request,
+  set streaming fields, return `NewEventStream()` with a closure that maps
+  SSE events to `StreamEvent` values. The Anthropic implementation follows
+  the same structural pattern.
+
+- **RetryProvider** (`internal/provider/retry.go`): Already delegates
+  `SendStream()` to the inner provider without retries. No changes needed.
+
+### Decisions Already Made
+
+- `StreamProvider` is an optional interface — `Anthropic` will implement it
+  by adding `SendStream()`.
+- `EventStream` with `Next()/Close()` is the streaming primitive.
+- The SSE parser handles wire-level parsing; the provider maps parsed
+  events to `StreamEvent` values.
+- No retry wrapping for streaming.
+
+### Approaches Ruled Out
+
+- **Reusing `Send()` internally**: `SendStream()` must return an
+  `EventStream` immediately with the HTTP body open. It cannot read the
+  full body.
+- **Goroutine + channel bridge**: The `EventStream.Next()` pull model
+  matches the SSE parser's pull model. No goroutine needed.
+
+### Constraints — Anthropic Streaming Wire Format
+
+Anthropic streaming uses SSE with typed `event:` fields (unlike OpenAI
+which uses only `data:`). The request must include `"stream": true`.
+
+**SSE event types and their `data:` payloads:**
+
+1. **`event: message_start`**
+   ```json
+   {
+     "type": "message_start",
+     "message": {
+       "id": "msg_abc",
+       "type": "message",
+       "role": "assistant",
+       "content": [],
+       "model": "claude-sonnet-4-20250514",
+       "stop_reason": null,
+       "usage": { "input_tokens": 25, "output_tokens": 1 }
+     }
+   }
+   ```
+   Contains `input_tokens` in `message.usage`. `output_tokens` here is
+   typically 1 (a running count at message start).
+
+2. **`event: content_block_start`** (text)
+   ```json
+   {
+     "type": "content_block_start",
+     "index": 0,
+     "content_block": { "type": "text", "text": "" }
+   }
+   ```
+
+3. **`event: content_block_start`** (tool_use)
+   ```json
+   {
+     "type": "content_block_start",
+     "index": 1,
+     "content_block": { "type": "tool_use", "id": "toolu_abc", "name": "read_file", "input": {} }
+   }
+   ```
+
+4. **`event: content_block_delta`** (text_delta)
+   ```json
+   {
+     "type": "content_block_delta",
+     "index": 0,
+     "delta": { "type": "text_delta", "text": "Hello" }
+   }
+   ```
+
+5. **`event: content_block_delta`** (input_json_delta)
+   ```json
+   {
+     "type": "content_block_delta",
+     "index": 1,
+     "delta": { "type": "input_json_delta", "partial_json": "{\"path\":" }
+   }
+   ```
+
+6. **`event: content_block_stop`**
+   ```json
+   { "type": "content_block_stop", "index": 0 }
+   ```
+
+7. **`event: message_delta`**
+   ```json
+   {
+     "type": "message_delta",
+     "delta": { "stop_reason": "end_turn" },
+     "usage": { "output_tokens": 15 }
+   }
+   ```
+   Contains `stop_reason` and final `output_tokens`.
+
+8. **`event: message_stop`**
+   ```json
+   { "type": "message_stop" }
+   ```
+   Final event. No more SSE events follow.
+
+9. **`event: ping`**
+   ```json
+   { "type": "ping" }
+   ```
+   Keepalive. Ignore.
+
+10. **`event: error`**
+    ```json
+    {
+      "type": "error",
+      "error": { "type": "overloaded_error", "message": "Overloaded" }
+    }
+    ```
+    Mid-stream error from the API.
+
+**Key differences from OpenAI streaming:**
+
+- Anthropic uses SSE `event:` field to type events; OpenAI uses only `data:`.
+- Anthropic has no `[DONE]` sentinel; `message_stop` signals the end.
+- Tool call identity (`id`, `name`) arrives in `content_block_start`, not
+  in a delta chunk.
+- Tool input arrives as `partial_json` fragments in `input_json_delta`
+  deltas, not as `arguments` fragments.
+- Usage is split: `input_tokens` in `message_start`, `output_tokens` in
+  `message_delta`.
+- Content blocks have an `index` that identifies which block is being
+  streamed (allowing text and tool_use blocks to interleave).
+
+## Section 2: Requirements
+
+### 2.1 `SendStream()` Method on `Anthropic`
+
+`Anthropic` must implement the `StreamProvider` interface by adding a
+`SendStream(ctx context.Context, req *Request) (*EventStream, error)` method.
+
+**Request construction:**
+
+- Build the request body identically to `Send()` (same message conversion,
+  tool conversion, temperature/max_tokens handling, defaultMaxTokens).
+- Set `"stream": true` in the JSON request body.
+- Send to the same endpoint: `{baseURL}/v1/messages`.
+- Use the same headers: `x-api-key`, `anthropic-version`, `content-type`.
+
+**Response handling:**
+
+- If the HTTP status is not 2xx, read the full body and return a
+  `ProviderError` using the existing `handleErrorResponse()` logic. Close
+  the body before returning.
+- If the HTTP status is 2xx, do NOT read or close the body. Wrap it in
+  an `EventStream` using `NewEventStream()` and return immediately.
+
+**Context cancellation:**
+
+- If the context is cancelled before the HTTP request completes, return a
+  `ProviderError` with `ErrCategoryTimeout` (same as `Send()`).
+
+### 2.2 SSE-to-StreamEvent Mapping
+
+The `nextFunc` passed to `NewEventStream` must use `SSEParser` to read
+SSE events from the response body and map them to `StreamEvent` values.
+
+**Mapping rules:**
+
+| SSE `event:` type | Data payload | StreamEvent produced |
+|---|---|---|
+| `message_start` | `message.usage.input_tokens` | No event emitted. Store `input_tokens` in closure state. Continue. |
+| `content_block_start` with `content_block.type == "text"` | `index`, `content_block` | No event emitted. Store block `index` → type "text" in closure state. Continue. |
+| `content_block_start` with `content_block.type == "tool_use"` | `index`, `content_block.id`, `content_block.name` | `StreamEventToolStart` with `ToolCallID` and `ToolName` set. Store block `index` → `{id, name}` in closure state. |
+| `content_block_delta` with `delta.type == "text_delta"` | `index`, `delta.text` | `StreamEventText` with `Text` set to `delta.text`. |
+| `content_block_delta` with `delta.type == "input_json_delta"` | `index`, `delta.partial_json` | `StreamEventToolDelta` with `ToolCallID` (looked up by `index`) and `ToolInput` set to `partial_json`. |
+| `content_block_stop` | `index` | If the block at `index` is a tool_use block, emit `StreamEventToolEnd` with `ToolCallID` looked up by `index`. If the block is text, no event emitted. Continue. |
+| `message_delta` | `delta.stop_reason`, `usage.output_tokens` | `StreamEventDone` with `StopReason`, `OutputTokens`, and the stored `InputTokens`. |
+| `message_stop` | — | Return `io.EOF`. |
+| `ping` | — | No event emitted. Continue. |
+| `error` | `error.type`, `error.message` | Return `ProviderError` with category mapped from `error.type` (see 2.4). |
+
+**Closure state the `nextFunc` must maintain:**
+
+- `inputTokens int` — stored from `message_start`
+- `blocks map[int]blockInfo` — maps content block `index` to `{type, id, name}` where `type` is `"text"` or `"tool_use"`
+
+### 2.3 Wire Format Types
+
+Add unexported structs for deserializing Anthropic streaming events. These
+are separate from the existing `anthropicResponse` (which is for buffered
+responses).
+
+**Required types (all unexported):**
+
+- **Envelope struct** for the outer event:
+  - `Type` (string) — matches the SSE `event:` type
+  - `Message` — present for `message_start` (contains `Usage` with `InputTokens`)
+  - `Index` (int) — present for `content_block_start`, `content_block_delta`, `content_block_stop`
+  - `ContentBlock` — present for `content_block_start` (contains `Type`, `ID`, `Name`, `Text`)
+  - `Delta` — present for `content_block_delta` and `message_delta`
+  - `Usage` — present for `message_delta` (contains `OutputTokens`)
+  - `Error` — present for `error` events (contains `Type`, `Message`)
+
+- Use `json.RawMessage` or a single struct with all optional fields. The
+  implementation should choose whichever approach is simpler. The important
+  thing is that all fields listed above are extractable from the JSON payload.
+
+### 2.4 Edge Cases
+
+1. **`ping` events**: Ignore. Do not emit any `StreamEvent`.
+
+2. **Mid-stream `error` event**: The API sends an SSE event with
+   `event: error`. Map `error.type` to a `ProviderError` category:
+   - `"overloaded_error"` → `ErrCategoryOverloaded`
+   - `"rate_limit_error"` → `ErrCategoryRateLimit`
+   - `"api_error"` → `ErrCategoryServer`
+   - `"authentication_error"` → `ErrCategoryAuth`
+   - anything else → `ErrCategoryServer`
+
+3. **Empty `text_delta`**: If `delta.text` is empty string, skip — do
+   not emit a `StreamEventText` with empty `Text`.
+
+4. **Empty `partial_json`**: If `delta.partial_json` is empty string,
+   skip — do not emit a `StreamEventToolDelta` with empty `ToolInput`.
+
+5. **Multiple content blocks**: The model may produce text blocks and
+   tool_use blocks in the same message. Each block has a unique `index`.
+   The block map must track all of them independently.
+
+6. **Connection drop mid-stream**: `SSEParser.Next()` returns the
+   underlying read error. The `nextFunc` must check `ctx.Err()` first —
+   if the context is done, return `ProviderError` with
+   `ErrCategoryTimeout`. Otherwise, return `ProviderError` with
+   `ErrCategoryServer`.
+
+7. **`content_block_stop` for a text block**: Do not emit
+   `StreamEventToolEnd`. Only emit `StreamEventToolEnd` for tool_use
+   blocks.
+
+8. **JSON parse failure**: If `json.Unmarshal` fails on any SSE event's
+   data payload, return `ProviderError` with `ErrCategoryServer`.
+
+9. **`message_delta` without prior `message_start`**: If `inputTokens`
+   was never set (no `message_start` received), emit `StreamEventDone`
+   with `InputTokens` = 0. Do not error.
+
+10. **`content_block_delta` for unknown index**: If the `index` is not
+    in the block map, skip the event. Do not error.
+
+### 2.5 Existing Code Reuse
+
+The following existing code must be reused without modification:
+
+- `convertToAnthropicMessages()` — for building the messages array
+- `convertToAnthropicTools()` — for building the tools array
+- `handleErrorResponse()` — for non-2xx responses before streaming begins
+- `mapStatusToCategory()` — used by `handleErrorResponse()`
+- `NewSSEParser()` — for parsing the SSE wire format
+- `NewEventStream()` — for wrapping the response body
+
+The existing `anthropicRequest` struct must be extended to include the
+`stream` field (boolean, `json:"stream,omitempty"`).
+
+### Parallelism
+
+All work in this spec is sequential — `SendStream()` depends on the wire
+format types (2.3), and the SSE-to-StreamEvent mapping (2.2) is the core
+of `SendStream()`. There are no independent sub-tasks that can be done in
+parallel.

--- a/docs/plans/ISS-59_m5_remaining_provider_streaming_implement.md
+++ b/docs/plans/ISS-59_m5_remaining_provider_streaming_implement.md
@@ -1,0 +1,73 @@
+# ISS-59 M5: Remaining Provider Streaming — Implementation Guide
+
+## Section 1: Context Summary
+
+Streaming infrastructure (core types, SSE parser, conversation loop integration) and reference implementations (OpenAI Chat Completions, Anthropic Messages) are complete from M1–M4. Three providers remain: Ollama (NDJSON-based streaming), Gemini (SSE via `streamGenerateContent`), and OpenCode (routing proxy that delegates to three different streaming wire formats). Each provider already has a working `Send()` method; the task is to add `SendStream()` implementing the `StreamProvider` interface. No changes to existing infrastructure are needed. All three providers can be implemented and tested in parallel.
+
+## Section 2: Implementation Checklist
+
+### Group A: Ollama Streaming (independent — can run in parallel with B and C)
+
+- [x] Add `SendStream()` method to `internal/provider/ollama.go: Ollama.SendStream()` — Build the same `ollamaRequest` as `Send()` but set `Stream: true`. Make HTTP request, check for non-2xx (read body fully, return `*ProviderError`), then return `NewEventStream()` with an NDJSON-parsing `nextFunc`. The `nextFunc` reads lines with `bufio.Scanner`, parses each as JSON into `ollamaResponse`. Map: non-empty `message.content` → `StreamEventText`; each `message.tool_calls[i]` → `StreamEventToolStart` + `StreamEventToolEnd` pair (Ollama delivers complete tool calls, no deltas); `done: true` → `StreamEventDone` with `StopReason` from `done_reason`, `InputTokens` from `prompt_eval_count`, `OutputTokens` from `eval_count`; after done object return `io.EOF`. Skip empty content strings. On context cancellation return `ProviderError{ErrCategoryTimeout}`. On malformed JSON return `ProviderError{ErrCategoryServer}`. On connection refused, same handling as existing `Send()`.
+
+- [x] Add an `ollamaStreamResponse` struct in `internal/provider/ollama.go` if needed, or reuse `ollamaResponse` with a `Done bool` field — The existing `ollamaResponse` lacks a `Done` field. Add `Done bool \`json:"done"\`` to `ollamaResponse` (it is already not used in `Send()` since `done` is always `true` in non-streaming mode, so adding it is safe).
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_RequestFormat` — Verify request body has `"stream":true`, same endpoint `/api/chat`, correct model/messages/tools. Use `httptest.NewServer` returning NDJSON lines. Drain stream.
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_TextDeltas` — Server returns 3 intermediate NDJSON objects with `message.content` fragments, then a final `done:true` object. Assert: 3 `StreamEventText` events with correct text, 1 `StreamEventDone` with token counts and stop reason, then `io.EOF`.
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_ToolCalls` — Server returns an intermediate object with `message.tool_calls` containing 2 tool calls. Assert: 2 `StreamEventToolStart`+`StreamEventToolEnd` pairs (no deltas), then `StreamEventDone`, then `io.EOF`.
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_EmptyContent` — Server returns intermediate objects with `message.content: ""` interspersed with real content. Assert: empty content objects are skipped.
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_ErrorResponse` — Server returns 500. Assert: `*ProviderError` with `ErrCategoryServer` returned from `SendStream()` (pre-stream error).
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_MalformedJSON` — Server returns a line that is not valid JSON. Assert: `*ProviderError` with `ErrCategoryServer`.
+
+- [x] Test: `internal/provider/ollama_test.go: TestOllama_SendStream_ContextCancelled` — Use `context.WithTimeout` with a slow server. Assert: `*ProviderError` with `ErrCategoryTimeout`.
+
+### Group B: Gemini Streaming (independent — can run in parallel with A and C)
+
+- [x] Add `SendStream()` method to `internal/provider/gemini.go: Gemini.SendStream()` — Build the same `geminiRequest` as `Send()`. Change endpoint to `streamGenerateContent?alt=sse`. Make HTTP request, check for non-2xx (read body fully, return `*ProviderError`). Return `NewEventStream()` using `SSEParser` on the response body. The `nextFunc` calls `parser.Next()`, parses `sseEvent.Data` as `geminiResponse`. Map: `candidates[0].content.parts` with non-empty `text` → `StreamEventText` (one per text part); parts with `functionCall` → `StreamEventToolStart` (ID: `gemini_{counter}`) + `StreamEventToolEnd`; capture `finishReason` and `usageMetadata` as they appear (always update stored values). When parser returns `io.EOF`, emit `StreamEventDone` (if not already emitted) with latest `finishReason`, `promptTokenCount`, `candidatesTokenCount`, then return `io.EOF`. Skip chunks with no candidates. Skip empty text parts. On context cancellation return `ProviderError{ErrCategoryTimeout}`. On malformed SSE data return `ProviderError{ErrCategoryServer}`.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_RequestFormat` — Verify endpoint is `streamGenerateContent?alt=sse`, request body unchanged, API key header present. Use `httptest.NewServer` returning SSE-formatted responses. Drain stream.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_TextDeltas` — Server returns 3 SSE data lines each containing a `geminiResponse` with text parts. Assert: 3 `StreamEventText` events, 1 `StreamEventDone` with token counts and finish reason, then `io.EOF`.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_ToolCalls` — Server returns SSE chunks with `functionCall` parts. Assert: `StreamEventToolStart`+`StreamEventToolEnd` pairs with `gemini_N` IDs. No `StreamEventToolDelta`.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_MixedTextAndToolCalls` — Server returns a chunk with both text and functionCall parts. Assert: text events and tool start/end events in order.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_EmptyTextPart` — Server returns chunks with empty text parts interspersed. Assert: empty parts skipped.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_NoCandidates` — Server returns a chunk with empty candidates array. Assert: chunk skipped, stream continues.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_UsageInMiddleChunk` — Server returns `usageMetadata` in a middle chunk and again in the final chunk. Assert: `StreamEventDone` uses the latest values.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_ErrorResponse` — Server returns 401. Assert: `*ProviderError` with `ErrCategoryAuth`.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_MalformedSSE` — Server returns non-JSON in `data:` line. Assert: `*ProviderError` with `ErrCategoryServer`.
+
+- [x] Test: `internal/provider/gemini_test.go: TestGemini_SendStream_ContextCancelled` — Use `context.WithTimeout` with a slow server. Assert: `*ProviderError` with `ErrCategoryTimeout`.
+
+### Group C: OpenCode Streaming (independent — can run in parallel with A and B)
+
+- [x] Add `SendStream()` method to `internal/provider/opencode.go: OpenCode.SendStream()` — Dispatch by model prefix identical to `Send()`: `claude-*` → `streamClaude()`, `gpt-*` → `streamGPT()`, default → `streamChatCompletions()`.
+
+- [x] Add `internal/provider/opencode.go: OpenCode.streamClaude()` — Build `ocAnthropicRequest` same as `sendClaude()` but add `Stream: true` field (add `Stream bool \`json:"stream,omitempty"\`` to `ocAnthropicRequest`). Set headers (Authorization Bearer, anthropic-version, Content-Type). Check non-2xx → `mapOCAnthropicHTTPError`. Return `NewEventStream()` using `SSEParser`. The `nextFunc` uses the same event mapping as `Anthropic.SendStream()`: parse SSE data as an Anthropic stream event struct, map `message_start/content_block_start/content_block_delta/content_block_stop/message_delta/message_stop` to `StreamEvent` types. Reuse or duplicate the Anthropic stream event types locally (they are unexported).
+
+- [x] Add `internal/provider/opencode.go: OpenCode.streamGPT()` — Build `ocResponsesRequest` same as `sendGPT()` but add `Stream: true` field (add `Stream bool \`json:"stream,omitempty"\`` to `ocResponsesRequest`). Set headers. Check non-2xx → `mapOCOpenAIHTTPError`. Return `NewEventStream()` using `SSEParser`. Define wire types for Responses API streaming events. The `nextFunc` maps: `response.content_part.delta` with `delta.text` → `StreamEventText`; `response.output_item.added` with `item.type=="function_call"` → `StreamEventToolStart`; `response.function_call_arguments.delta` → `StreamEventToolDelta`; `response.output_item.done` with `item.type=="function_call"` → `StreamEventToolEnd`; `response.completed` → `StreamEventDone` with usage; `[DONE]` → `io.EOF`.
+
+- [x] Add `internal/provider/opencode.go: OpenCode.streamChatCompletions()` — Build `ocChatRequest` same as `sendChatCompletions()` but add `Stream: true` and `StreamOptions` fields (add fields to `ocChatRequest`). Set `stream_options: {include_usage: true}`. Set headers. Check non-2xx → `mapOCOpenAIHTTPError`. Return `NewEventStream()` using `SSEParser`. The `nextFunc` uses the same event mapping as `OpenAI.SendStream()`: parse SSE data as OpenAI chat completion chunks, handle `[DONE]`, map deltas to `StreamEvent` types.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_ClaudeRoute` — Server verifies request to `/v1/messages` with `stream:true`, returns Anthropic-style SSE events. Assert: text events, done event with usage, `io.EOF`.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_GPTRoute` — Server verifies request to `/v1/responses` with `stream:true`, returns Responses API SSE events. Assert: text events, tool start/delta/end events, done event, `io.EOF`.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_ChatCompletionsRoute` — Server verifies request to `/v1/chat/completions` with `stream:true` and `stream_options.include_usage:true`, returns Chat Completions SSE events. Assert: text events, done event with usage, `io.EOF`.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_UnknownModelFallsThrough` — Model without known prefix (e.g., `mistral-7b`). Assert: request goes to `/v1/chat/completions`.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_ErrorResponse` — Server returns 401 for each route. Assert: `*ProviderError` with `ErrCategoryAuth`.
+
+- [x] Test: `internal/provider/opencode_test.go: TestOpenCode_SendStream_ContextCancelled` — Use `context.WithTimeout`. Assert: `*ProviderError` with `ErrCategoryTimeout`.

--- a/docs/plans/ISS-59_m5_remaining_provider_streaming_spec.md
+++ b/docs/plans/ISS-59_m5_remaining_provider_streaming_spec.md
@@ -1,0 +1,149 @@
+# ISS-59 M5: Remaining Provider Streaming
+
+**Milestone document:** [docs/plans/ISS-59_streaming_milestones.md](ISS-59_streaming_milestones.md)
+
+## Section 1: Context & Constraints
+
+### Codebase Structure
+
+The streaming infrastructure is fully in place from M1–M4:
+
+- **`internal/provider/stream.go`** — Defines `StreamEvent` (types: `text`, `tool_start`, `tool_delta`, `tool_end`, `done`), `EventStream` (with `Next()/Close()`), `NewEventStream()`, and the `StreamProvider` interface.
+- **`internal/provider/sse.go`** — Generic `SSEParser` with `Next()` returning `SSEEvent{Event, Data}`. Handles `data:`, `event:`, comment lines, and blank-line delimiters.
+- **`internal/provider/openai.go`** — Reference `SendStream()` implementation for SSE-based OpenAI Chat Completions. Uses `SSEParser`, accumulates tool calls by index, emits `StreamEvent` types, handles `[DONE]` sentinel and usage chunks.
+- **`internal/provider/anthropic.go`** — Reference `SendStream()` implementation for Anthropic typed SSE events. Uses `SSEParser`, tracks content blocks by index, maps `message_start/content_block_start/content_block_delta/content_block_stop/message_delta/message_stop` to `StreamEvent` types.
+- **`internal/provider/retry.go`** — `RetryProvider.SendStream()` delegates to inner provider without retries. `SupportsStream()` checks if inner provider implements `StreamProvider`.
+- **`cmd/run.go`** — Conversation loop calls `SendStream()` when `--stream` is active and the provider implements `StreamProvider`. Prints text events to stdout (non-JSON mode) or buffers them (JSON mode).
+
+### Providers Requiring Work
+
+1. **Ollama** (`internal/provider/ollama.go`) — Currently `Send()` only. Uses `stream: false`. Ollama streaming uses NDJSON (newline-delimited JSON), not SSE. Each line is a complete JSON object. The final object has `done: true`.
+2. **Gemini** (`internal/provider/gemini.go`) — Currently `Send()` only. Uses `generateContent` endpoint. Gemini streaming uses `streamGenerateContent?alt=sse` endpoint, which returns SSE-formatted events where each `data:` line contains a JSON object matching the non-streaming response structure (array of candidates).
+3. **OpenCode** (`internal/provider/opencode.go`) — Currently `Send()` only, routes by model prefix: `claude-*` → Anthropic Messages format, `gpt-*` → OpenAI Responses format, default → OpenAI Chat Completions format. `SendStream()` must delegate to the appropriate streaming format per route.
+
+### Providers NOT Requiring Work
+
+- **MiniMax** (`internal/provider/minimax.go`) — `NewMiniMax()` returns `*Anthropic`. It inherits `SendStream()` from the Anthropic type. No work needed.
+- **Bedrock** — Explicitly deferred to a separate issue per milestones doc (binary event stream framing, not SSE).
+
+### Decisions Already Made
+
+- `--stream` is explicit opt-in (not TTY auto-detected).
+- `stream = true` TOML field; flag overrides TOML.
+- `RetryProvider` delegates `SendStream()` without retries.
+- Sub-agents always use `Send()`, never stream.
+- `EventStream.Next()` returns `io.EOF` when the stream is exhausted.
+- Error responses (non-2xx HTTP) are read fully and returned as `*ProviderError` before creating the `EventStream`.
+
+### Approaches Ruled Out
+
+- Auto-detecting streaming support from the provider at runtime — the `StreamProvider` interface is used at compile time.
+- Adding internal retries for streaming — the `RetryProvider` explicitly skips retries for `SendStream()`.
+- Streaming for Bedrock — deferred; binary event stream framing is a separate concern.
+
+---
+
+## Section 2: Requirements
+
+### R1: Ollama Streaming
+
+The Ollama provider must implement the `StreamProvider` interface.
+
+**Request behavior:**
+- Set `stream: true` in the JSON request body (same endpoint: `POST /api/chat`).
+- All other request fields (model, messages, options, tools) remain unchanged.
+
+**Response format (NDJSON):**
+- The response body is newline-delimited JSON. Each line is a complete JSON object.
+- Each intermediate object contains a partial `message` field with `content` (text delta) and/or `tool_calls`.
+- The final object has `"done": true` and includes `done_reason`, `prompt_eval_count`, and `eval_count`.
+- There is no `[DONE]` sentinel or SSE framing. The existing `SSEParser` cannot be reused; the implementation must read lines and parse JSON directly.
+
+**Event mapping:**
+- Intermediate objects with `message.content` → `StreamEventText`
+- Intermediate objects with `message.tool_calls` → Emit `StreamEventToolStart` on first appearance of a tool call, then `StreamEventToolEnd` (Ollama delivers complete tool calls in a single object, not streamed incrementally; there is no `StreamEventToolDelta`).
+- Final object (`done: true`) → `StreamEventDone` with `StopReason` from `done_reason`, `InputTokens` from `prompt_eval_count`, `OutputTokens` from `eval_count`.
+- After the final object, `Next()` returns `io.EOF`.
+
+**Edge cases:**
+- Empty `message.content` (`""`) in intermediate objects: skip, do not emit a `StreamEventText`.
+- Context cancellation during read: return `ProviderError` with `ErrCategoryTimeout`.
+- Connection refused: same error handling as the existing `Send()` method.
+- Malformed JSON line: return `ProviderError` with `ErrCategoryServer`.
+- Multiple tool calls in a single streaming object: emit one `StreamEventToolStart` + `StreamEventToolEnd` pair per tool call, in order.
+
+### R2: Gemini Streaming
+
+The Gemini provider must implement the `StreamProvider` interface.
+
+**Request behavior:**
+- Use the `streamGenerateContent` endpoint instead of `generateContent`: `POST /v1beta/models/{model}:streamGenerateContent?alt=sse`
+- The request body is identical to the non-streaming request.
+
+**Response format (SSE):**
+- Standard SSE framing. Each `data:` line contains a JSON object matching the `geminiResponse` structure (with `candidates` array and `usageMetadata`).
+- The existing `SSEParser` can and should be reused.
+- There is no `[DONE]` sentinel. The stream ends when the HTTP response body closes (parser returns `io.EOF`).
+
+**Event mapping:**
+- `candidates[0].content.parts` with `text` field → `StreamEventText` (one event per text part).
+- `candidates[0].content.parts` with `functionCall` field → Emit `StreamEventToolStart` (with generated tool call ID in format `gemini_{index}`) followed immediately by `StreamEventToolEnd`. Gemini delivers complete function calls, not streamed incrementally; there is no `StreamEventToolDelta`.
+- `candidates[0].finishReason` present → Record it. When the stream ends or on the final chunk, emit `StreamEventDone` with the finish reason.
+- `usageMetadata` present → Capture `promptTokenCount` and `candidatesTokenCount` for the `StreamEventDone` event.
+- After SSE parser returns `io.EOF`, emit `StreamEventDone` (if not already emitted), then return `io.EOF`.
+
+**Edge cases:**
+- Empty text part (`""`) in a candidate: skip, do not emit a `StreamEventText`.
+- No candidates in a chunk: skip the chunk entirely.
+- Multiple text parts in a single chunk: emit one `StreamEventText` per non-empty text part.
+- Multiple function calls in a single chunk: emit one `StreamEventToolStart` + `StreamEventToolEnd` pair per function call.
+- `usageMetadata` may appear in any chunk (often the last); always update the stored values, use the latest when emitting `StreamEventDone`.
+- Context cancellation: return `ProviderError` with `ErrCategoryTimeout`.
+- Malformed SSE data: return `ProviderError` with `ErrCategoryServer`.
+- Tool call ID generation: Use `gemini_{counter}` format, incrementing a counter across the entire stream (consistent with the existing `Send()` method).
+
+### R3: OpenCode Streaming
+
+The OpenCode provider must implement the `StreamProvider` interface.
+
+**Routing behavior:**
+- `SendStream()` must dispatch by model prefix, identical to `Send()`:
+  - `claude-*` → Anthropic Messages streaming format (SSE with typed events: `message_start`, `content_block_delta`, etc.)
+  - `gpt-*` → OpenAI Responses streaming format (SSE with `response.output_item.*` events)
+  - All other models → OpenAI Chat Completions streaming format (SSE with `choices[].delta`)
+
+**Implementation approach:**
+- Each route builds the appropriate streaming request (same wire types as the existing `Send()` subroutines, with `stream: true` added).
+- Each route parses the SSE stream and maps provider-specific events to `StreamEvent` types.
+- The Anthropic Messages route uses the same SSE event mapping as the Anthropic provider's `SendStream()`.
+- The Chat Completions route uses the same SSE event mapping as the OpenAI provider's `SendStream()`.
+- The GPT/Responses route must handle OpenAI Responses API streaming events, which differ from Chat Completions.
+
+**OpenCode GPT/Responses streaming events:**
+- The Responses API streams events like `response.output_item.added`, `response.content_part.delta`, `response.function_call_arguments.delta`, `response.output_item.done`, and `response.completed`.
+- `response.content_part.delta` with `delta.text` → `StreamEventText`
+- `response.output_item.added` with `item.type == "function_call"` → `StreamEventToolStart` (ID from `item.id`, name from `item.name`)
+- `response.function_call_arguments.delta` → `StreamEventToolDelta` (ID from `item_id`, input from `delta`)
+- `response.output_item.done` with `item.type == "function_call"` → `StreamEventToolEnd`
+- `response.completed` → `StreamEventDone` with usage from `response.usage`
+
+**Edge cases:**
+- Unknown model prefix: fall through to Chat Completions streaming (same as `Send()`).
+- All error handling, timeout detection, and HTTP error responses follow the same patterns as the existing `Send()` subroutines.
+- `stream_options: {include_usage: true}` must be set for the Chat Completions route (same as OpenAI provider).
+
+### R4: No Changes to Existing Infrastructure
+
+- No changes to `StreamEvent`, `EventStream`, `StreamProvider`, `SSEParser`, `RetryProvider`, or the conversation loop.
+- No changes to the `Provider` interface or `New()` registry function.
+- No changes to how the conversation loop detects `StreamProvider` support.
+
+### Parallelism
+
+The following can be implemented and tested independently, in parallel:
+
+- **Ollama `SendStream()`** — standalone, no dependencies on other M5 work.
+- **Gemini `SendStream()`** — standalone, no dependencies on other M5 work.
+- **OpenCode `SendStream()`** — depends only on understanding the existing Anthropic and OpenAI streaming patterns (already implemented in M2/M4), not on Ollama or Gemini M5 work.
+
+All three providers can be implemented in parallel.

--- a/docs/plans/ISS-59_streaming_milestones.md
+++ b/docs/plans/ISS-59_streaming_milestones.md
@@ -1,0 +1,57 @@
+# ISS-59: Response Streaming — Milestones
+
+## Problem
+
+When Axe calls an LLM provider behind nginx with a 60-second idle timeout,
+long-running requests get killed before the response completes. Streaming
+keeps data flowing so the connection stays alive. Additionally, users want
+to see tokens as they arrive in terminal mode.
+
+## Behavioral Matrix
+
+| Flags              | Provider → Axe              | Axe → stdout                    |
+| ------------------ | --------------------------- | ------------------------------- |
+| (default)          | Buffered (current behavior) | Buffered                        |
+| `--stream`         | SSE streaming               | Print tokens as they arrive     |
+| `--stream --json`  | SSE streaming (keeps alive) | Buffer, emit JSON envelope last |
+
+## Milestones
+
+### M1 — Core Types, SSE Parser, Config Plumbing ✅
+
+Add `StreamEvent`, `EventStream`, and `StreamProvider` interface to the
+provider package. Implement a generic SSE line parser. Add `--stream` CLI
+flag and `stream` TOML field. No provider implementations or loop changes.
+
+### M2 — OpenAI Provider Streaming ✅
+
+Implement `SendStream()` on the OpenAI provider. This is the primary use
+case (internal AI service speaks OpenAI-compatible SSE).
+
+### M3 — Conversation Loop Integration
+
+Wire streaming into `cmd/run.go`: call `SendStream()` when `--stream` is
+active and the provider implements `StreamProvider`. Print text events to
+stdout (no `--json`) or buffer them (`--json`). Tool call accumulation and
+the rest of the loop stay unchanged. Sub-agents never stream.
+
+### M4 — Anthropic Provider Streaming
+
+Implement `SendStream()` on the Anthropic provider. Anthropic SSE uses
+typed events (`message_start`, `content_block_delta`, etc.) that map to
+the same `StreamEvent` types.
+
+### M5 — Remaining Provider Streaming
+
+Implement `SendStream()` on Ollama (NDJSON), Gemini (SSE), MiniMax
+(Anthropic-compatible SSE), and OpenCode (delegates to underlying route).
+Bedrock is deferred to a separate issue (binary event stream framing).
+
+## Decisions
+
+- **Flag**: `--stream` (explicit opt-in, not auto-detected from TTY)
+- **TOML**: `stream = true` at agent top level; flag overrides TOML
+- **Streaming primitive**: `EventStream` struct with `Next()/Close()`
+- **Retry**: `RetryProvider` delegates `SendStream()` to inner provider without retries
+- **Sub-agents**: Always use `Send()`, never stream
+- **Bedrock**: Deferred to separate issue (binary event stream, not SSE)

--- a/docs/plans/ISS-59_streaming_milestones.md
+++ b/docs/plans/ISS-59_streaming_milestones.md
@@ -35,7 +35,7 @@ active and the provider implements `StreamProvider`. Print text events to
 stdout (no `--json`) or buffer them (`--json`). Tool call accumulation and
 the rest of the loop stay unchanged. Sub-agents never stream.
 
-### M4 — Anthropic Provider Streaming
+### M4 — Anthropic Provider Streaming ✅
 
 Implement `SendStream()` on the Anthropic provider. Anthropic SSE uses
 typed events (`message_start`, `content_block_delta`, etc.) that map to

--- a/docs/plans/ISS-59_streaming_milestones.md
+++ b/docs/plans/ISS-59_streaming_milestones.md
@@ -41,7 +41,7 @@ Implement `SendStream()` on the Anthropic provider. Anthropic SSE uses
 typed events (`message_start`, `content_block_delta`, etc.) that map to
 the same `StreamEvent` types.
 
-### M5 — Remaining Provider Streaming
+### M5 — Remaining Provider Streaming ✅
 
 Implement `SendStream()` on Ollama (NDJSON), Gemini (SSE), MiniMax
 (Anthropic-compatible SSE), and OpenCode (delegates to underlying route).

--- a/docs/plans/ISS-59_streaming_milestones.md
+++ b/docs/plans/ISS-59_streaming_milestones.md
@@ -28,7 +28,7 @@ flag and `stream` TOML field. No provider implementations or loop changes.
 Implement `SendStream()` on the OpenAI provider. This is the primary use
 case (internal AI service speaks OpenAI-compatible SSE).
 
-### M3 — Conversation Loop Integration
+### M3 — Conversation Loop Integration ✅
 
 Wire streaming into `cmd/run.go`: call `SendStream()` when `--stream` is
 active and the provider implements `StreamProvider`. Print text events to

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -80,6 +80,7 @@ type AgentConfig struct {
 	Files         []string          `toml:"files"`
 	Workdir       string            `toml:"workdir"`
 	Timeout       int               `toml:"timeout"`
+	Stream        bool              `toml:"stream"`
 	Tools         []string          `toml:"tools"`
 	AllowedHosts  []string          `toml:"allowed_hosts"`
 	MCPServers    []MCPServerConfig `toml:"mcp_servers"`
@@ -336,6 +337,9 @@ model = "provider/model-name"
 
 # Run timeout in seconds (optional, default: 120)
 # timeout = 120
+
+# Enable streaming responses (optional, default: false)
+# stream = false
 
 # Tools this agent can use (optional)
 # Valid: list_directory, read_file, write_file, edit_file, run_command, url_fetch, web_search

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1106,6 +1106,47 @@ func TestValidate_MCPServers_ValidTransports(t *testing.T) {
 	}
 }
 
+func TestStreamField_TOMLRoundTrip(t *testing.T) {
+	agentsDir := setupAgentsDir(t)
+
+	t.Run("stream=true round-trips through Load", func(t *testing.T) {
+		writeAgentFile(t, agentsDir, "stream-on", `name = "stream-on"
+model = "openai/gpt-4o"
+stream = true
+`)
+		cfg, err := Load("stream-on", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cfg.Stream {
+			t.Error("expected Stream=true, got false")
+		}
+	})
+
+	t.Run("default is false when omitted", func(t *testing.T) {
+		writeAgentFile(t, agentsDir, "stream-off", `name = "stream-off"
+model = "openai/gpt-4o"
+`)
+		cfg, err := Load("stream-off", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Stream {
+			t.Error("expected Stream=false (default), got true")
+		}
+	})
+}
+
+func TestScaffold_ContainsStreamField(t *testing.T) {
+	out, err := Scaffold("test-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "# stream = false") {
+		t.Error("Scaffold output should contain commented-out stream field")
+	}
+}
+
 func TestValidate_MCPServers_DuplicateNames(t *testing.T) {
 	cfg := &AgentConfig{
 		Name:  "test",

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -69,6 +69,7 @@ type anthropicRequest struct {
 	System      string             `json:"system,omitempty"`
 	Temperature *float64           `json:"temperature,omitempty"`
 	Tools       []anthropicToolDef `json:"tools,omitempty"`
+	Stream      bool               `json:"stream,omitempty"`
 }
 
 // anthropicMessage is the wire format for a message in the Anthropic API.
@@ -337,6 +338,233 @@ func (a *Anthropic) handleErrorResponse(status int, body []byte) *ProviderError 
 		Category: category,
 		Status:   status,
 		Message:  message,
+	}
+}
+
+type anthropicBlockInfo struct {
+	typ  string
+	id   string
+	name string
+}
+
+func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	maxTokens := req.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = defaultMaxTokens
+	}
+
+	body := anthropicRequest{
+		Model:     req.Model,
+		MaxTokens: maxTokens,
+		Messages:  convertToAnthropicMessages(req.Messages),
+		System:    req.System,
+		Stream:    true,
+	}
+
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		body.Temperature = &temp
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToAnthropicTools(req.Tools)
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", a.baseURL+"/v1/messages", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("x-api-key", a.apiKey)
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
+	httpReq.Header.Set("content-type", "application/json")
+
+	httpResp, err := a.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(httpResp.Body)
+		_ = httpResp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("failed to read error response: %s", err),
+				Err:      err,
+			}
+		}
+		return nil, a.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(httpResp.Body)
+	var inputTokens int
+	blocks := make(map[int]anthropicBlockInfo)
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryTimeout,
+						Message:  ctx.Err().Error(),
+						Err:      ctx.Err(),
+					}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("stream read error: %s", err),
+					Err:      err,
+				}
+			}
+
+			var event anthropicStreamEvent
+			if err := json.Unmarshal([]byte(sseEvent.Data), &event); err != nil {
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("failed to parse streaming event: %s", err),
+					Err:      err,
+				}
+			}
+
+			switch event.Type {
+			case "message_start":
+				if event.Message != nil && event.Message.Usage != nil {
+					inputTokens = event.Message.Usage.InputTokens
+				}
+				continue
+
+			case "content_block_start":
+				if event.ContentBlock != nil {
+					blocks[event.Index] = anthropicBlockInfo{
+						typ:  event.ContentBlock.Type,
+						id:   event.ContentBlock.ID,
+						name: event.ContentBlock.Name,
+					}
+					if event.ContentBlock.Type == "tool_use" {
+						return StreamEvent{
+							Type:       StreamEventToolStart,
+							ToolCallID: event.ContentBlock.ID,
+							ToolName:   event.ContentBlock.Name,
+						}, nil
+					}
+				}
+				continue
+
+			case "content_block_delta":
+				if event.Delta == nil {
+					continue
+				}
+				block, ok := blocks[event.Index]
+				if !ok {
+					continue
+				}
+				switch event.Delta.Type {
+				case "text_delta":
+					if event.Delta.Text == "" {
+						continue
+					}
+					return StreamEvent{
+						Type: StreamEventText,
+						Text: event.Delta.Text,
+					}, nil
+				case "input_json_delta":
+					if event.Delta.PartialJSON == "" {
+						continue
+					}
+					return StreamEvent{
+						Type:       StreamEventToolDelta,
+						ToolCallID: block.id,
+						ToolInput:  event.Delta.PartialJSON,
+					}, nil
+				}
+				continue
+
+			case "content_block_stop":
+				block, ok := blocks[event.Index]
+				if ok && block.typ == "tool_use" {
+					return StreamEvent{
+						Type:       StreamEventToolEnd,
+						ToolCallID: block.id,
+					}, nil
+				}
+				continue
+
+			case "message_delta":
+				var stopReason string
+				if event.Delta != nil {
+					stopReason = event.Delta.StopReason
+				}
+				var outputTokens int
+				if event.Usage != nil {
+					outputTokens = event.Usage.OutputTokens
+				}
+				return StreamEvent{
+					Type:         StreamEventDone,
+					StopReason:   stopReason,
+					InputTokens:  inputTokens,
+					OutputTokens: outputTokens,
+				}, nil
+
+			case "message_stop":
+				return StreamEvent{}, io.EOF
+
+			case "ping":
+				continue
+
+			case "error":
+				if event.Error != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: mapStreamErrorType(event.Error.Type),
+						Message:  event.Error.Message,
+					}
+				}
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  "unknown stream error",
+				}
+
+			default:
+				continue
+			}
+		}
+	}
+
+	return NewEventStream(httpResp.Body, nextFunc), nil
+}
+
+func mapStreamErrorType(errorType string) ErrorCategory {
+	switch errorType {
+	case "overloaded_error":
+		return ErrCategoryOverloaded
+	case "rate_limit_error":
+		return ErrCategoryRateLimit
+	case "api_error":
+		return ErrCategoryServer
+	case "authentication_error":
+		return ErrCategoryAuth
+	default:
+		return ErrCategoryServer
 	}
 }
 

--- a/internal/provider/anthropic_stream_test.go
+++ b/internal/provider/anthropic_stream_test.go
@@ -1,0 +1,667 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func writeSSE(w http.ResponseWriter, event, data string) {
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// --- Task 2.4: Request construction ---
+
+func TestAnthropic_SendStream_RequestFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":10}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("my-api-key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		System:      "Be helpful",
+		Messages:    []Message{{Role: "user", Content: "Hi"}},
+		Temperature: 0.7,
+		MaxTokens:   1024,
+		Tools: []Tool{{
+			Name:        "read_file",
+			Description: "Read a file",
+			Parameters:  map[string]ToolParameter{"path": {Type: "string", Description: "File path", Required: true}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Drain the stream
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+	}
+
+	if gotBody["stream"] != true {
+		t.Errorf("stream = %v, want true", gotBody["stream"])
+	}
+	if gotBody["model"] != "claude-sonnet-4-20250514" {
+		t.Errorf("model = %v, want claude-sonnet-4-20250514", gotBody["model"])
+	}
+	if gotBody["system"] != "Be helpful" {
+		t.Errorf("system = %v, want Be helpful", gotBody["system"])
+	}
+	if gotBody["max_tokens"] != float64(1024) {
+		t.Errorf("max_tokens = %v, want 1024", gotBody["max_tokens"])
+	}
+	if gotBody["temperature"] != float64(0.7) {
+		t.Errorf("temperature = %v, want 0.7", gotBody["temperature"])
+	}
+
+	msgs, ok := gotBody["messages"].([]interface{})
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("messages = %v, want 1-element array", gotBody["messages"])
+	}
+
+	tools, ok := gotBody["tools"].([]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %v, want 1-element array", gotBody["tools"])
+	}
+}
+
+func TestAnthropic_SendStream_DefaultMaxTokens(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:     "claude-sonnet-4-20250514",
+		MaxTokens: 0,
+		Messages:  []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	if gotBody["max_tokens"] != float64(defaultMaxTokens) {
+		t.Errorf("max_tokens = %v, want %d", gotBody["max_tokens"], defaultMaxTokens)
+	}
+}
+
+func TestAnthropic_SendStream_OmitsZeroTemperature(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		Temperature: 0,
+		Messages:    []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	if _, exists := gotBody["temperature"]; exists {
+		t.Errorf("body contains 'temperature' key when Temperature is 0")
+	}
+}
+
+// --- Task 2.5: Error responses (pre-stream) ---
+
+func TestAnthropic_SendStream_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"type": "error",
+			"error": map[string]string{
+				"type":    "authentication_error",
+				"message": "invalid x-api-key",
+			},
+		})
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("bad-key", WithBaseURL(server.URL))
+	_, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var pe *ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if pe.Category != ErrCategoryAuth {
+		t.Errorf("Category = %q, want %q", pe.Category, ErrCategoryAuth)
+	}
+}
+
+func TestAnthropic_SendStream_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := a.SendStream(ctx, &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var pe *ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if pe.Category != ErrCategoryTimeout {
+		t.Errorf("Category = %q, want %q", pe.Category, ErrCategoryTimeout)
+	}
+}
+
+// --- Task 2.6: Text streaming ---
+
+func TestAnthropic_SendStream_TextDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":25}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("events[0] = %+v, want Text Hello", events[0])
+	}
+	if events[1].Type != StreamEventText || events[1].Text != " world" {
+		t.Errorf("events[1] = %+v, want Text ' world'", events[1])
+	}
+	if events[2].Type != StreamEventDone {
+		t.Errorf("events[2].Type = %q, want %q", events[2].Type, StreamEventDone)
+	}
+	if events[2].InputTokens != 25 {
+		t.Errorf("InputTokens = %d, want 25", events[2].InputTokens)
+	}
+	if events[2].OutputTokens != 15 {
+		t.Errorf("OutputTokens = %d, want 15", events[2].OutputTokens)
+	}
+	if events[2].StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want %q", events[2].StopReason, "end_turn")
+	}
+}
+
+// --- Task 2.7: Tool call streaming ---
+
+func TestAnthropic_SendStream_ToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":10}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc","name":"read_file"}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"pat"}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"h\": \"x\"}"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":8}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if len(events) != 5 {
+		t.Fatalf("got %d events, want 5 (start, 2 deltas, end, done)", len(events))
+	}
+
+	if events[0].Type != StreamEventToolStart || events[0].ToolCallID != "toolu_abc" || events[0].ToolName != "read_file" {
+		t.Errorf("events[0] = %+v, want ToolStart toolu_abc read_file", events[0])
+	}
+	if events[1].Type != StreamEventToolDelta || events[1].ToolCallID != "toolu_abc" || events[1].ToolInput != `{"pat` {
+		t.Errorf("events[1] = %+v, want ToolDelta toolu_abc {\"pat", events[1])
+	}
+	if events[2].Type != StreamEventToolDelta || events[2].ToolCallID != "toolu_abc" || events[2].ToolInput != `h": "x"}` {
+		t.Errorf("events[2] = %+v, want ToolDelta toolu_abc h\": \"x\"}", events[2])
+	}
+	if events[3].Type != StreamEventToolEnd || events[3].ToolCallID != "toolu_abc" {
+		t.Errorf("events[3] = %+v, want ToolEnd toolu_abc", events[3])
+	}
+	if events[4].Type != StreamEventDone || events[4].StopReason != "tool_use" {
+		t.Errorf("events[4] = %+v, want Done tool_use", events[4])
+	}
+}
+
+// --- Task 2.8: Mixed text + tool blocks ---
+
+func TestAnthropic_SendStream_TextAndToolBlocks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":5}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me read that."}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_xyz","name":"read_file"}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"a.go\"}"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":1}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":20}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// text delta, tool start, tool delta, tool end, done
+	if len(events) != 5 {
+		t.Fatalf("got %d events, want 5", len(events))
+	}
+
+	if events[0].Type != StreamEventText || events[0].Text != "Let me read that." {
+		t.Errorf("events[0] = %+v, want Text", events[0])
+	}
+	if events[1].Type != StreamEventToolStart || events[1].ToolName != "read_file" {
+		t.Errorf("events[1] = %+v, want ToolStart", events[1])
+	}
+	if events[2].Type != StreamEventToolDelta {
+		t.Errorf("events[2] = %+v, want ToolDelta", events[2])
+	}
+	if events[3].Type != StreamEventToolEnd || events[3].ToolCallID != "toolu_xyz" {
+		t.Errorf("events[3] = %+v, want ToolEnd toolu_xyz", events[3])
+	}
+	if events[4].Type != StreamEventDone {
+		t.Errorf("events[4] = %+v, want Done", events[4])
+	}
+}
+
+// --- Task 2.9: Edge cases ---
+
+func TestAnthropic_SendStream_PingIgnored(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "ping", `{"type":"ping"}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"A"}}`)
+		writeSSE(w, "ping", `{"type":"ping"}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"B"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Only text A, text B, done — no ping events
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3 (no ping events)", len(events))
+	}
+	if events[0].Text != "A" || events[1].Text != "B" {
+		t.Errorf("events = %+v, want A, B texts", events)
+	}
+}
+
+func TestAnthropic_SendStream_MidStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "error", `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Consume until error
+	for {
+		_, err := stream.Next()
+		if err != nil {
+			var pe *ProviderError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected ProviderError, got %T: %v", err, err)
+			}
+			if pe.Category != ErrCategoryOverloaded {
+				t.Errorf("Category = %q, want %q", pe.Category, ErrCategoryOverloaded)
+			}
+			break
+		}
+	}
+}
+
+func TestAnthropic_SendStream_EmptyTextDelta(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"real"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Empty text delta should be skipped; only "real" + done
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Text != "real" {
+		t.Errorf("events[0].Text = %q, want %q", events[0].Text, "real")
+	}
+}
+
+func TestAnthropic_SendStream_EmptyPartialJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"test"}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// tool_start, tool_delta (only non-empty "{}"), tool_end, done
+	if len(events) != 4 {
+		t.Fatalf("got %d events, want 4", len(events))
+	}
+	if events[1].Type != StreamEventToolDelta || events[1].ToolInput != "{}" {
+		t.Errorf("events[1] = %+v, want ToolDelta with input {}", events[1])
+	}
+}
+
+func TestAnthropic_SendStream_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprintf(w, "event: message_start\ndata: {invalid json\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = stream.Next()
+	var pe *ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if pe.Category != ErrCategoryServer {
+		t.Errorf("Category = %q, want %q", pe.Category, ErrCategoryServer)
+	}
+}
+
+func TestAnthropic_SendStream_UnknownBlockIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		// Delta for index 99 which was never started
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":99,"delta":{"type":"text_delta","text":"ghost"}}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Only done event; the unknown index delta should be skipped
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (only done)", len(events))
+	}
+	if events[0].Type != StreamEventDone {
+		t.Errorf("events[0].Type = %q, want %q", events[0].Type, StreamEventDone)
+	}
+}
+
+func TestAnthropic_SendStream_MessageDeltaWithoutStart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// No message_start, jump straight to message_delta
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-20250514",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("Type = %q, want %q", ev.Type, StreamEventDone)
+	}
+	if ev.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0", ev.InputTokens)
+	}
+	if ev.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", ev.OutputTokens)
+	}
+}

--- a/internal/provider/anthropic_stream_types.go
+++ b/internal/provider/anthropic_stream_types.go
@@ -1,0 +1,40 @@
+package provider
+
+type anthropicStreamEvent struct {
+	Type         string                       `json:"type"`
+	Message      *anthropicStreamMessage       `json:"message,omitempty"`
+	Index        int                          `json:"index,omitempty"`
+	ContentBlock *anthropicStreamContentBlock  `json:"content_block,omitempty"`
+	Delta        *anthropicStreamDelta         `json:"delta,omitempty"`
+	Usage        *anthropicStreamUsage         `json:"usage,omitempty"`
+	Error        *anthropicStreamError         `json:"error,omitempty"`
+}
+
+type anthropicStreamMessage struct {
+	ID    string                `json:"id,omitempty"`
+	Usage *anthropicStreamUsage `json:"usage,omitempty"`
+}
+
+type anthropicStreamUsage struct {
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+}
+
+type anthropicStreamContentBlock struct {
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+type anthropicStreamDelta struct {
+	Type        string `json:"type,omitempty"`
+	Text        string `json:"text,omitempty"`
+	PartialJSON string `json:"partial_json,omitempty"`
+	StopReason  string `json:"stop_reason,omitempty"`
+}
+
+type anthropicStreamError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/internal/provider/anthropic_stream_types_test.go
+++ b/internal/provider/anthropic_stream_types_test.go
@@ -1,0 +1,194 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMapStreamErrorType(t *testing.T) {
+	tests := []struct {
+		errorType string
+		want      ErrorCategory
+	}{
+		{"overloaded_error", ErrCategoryOverloaded},
+		{"rate_limit_error", ErrCategoryRateLimit},
+		{"api_error", ErrCategoryServer},
+		{"authentication_error", ErrCategoryAuth},
+		{"unknown_error", ErrCategoryServer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errorType, func(t *testing.T) {
+			got := mapStreamErrorType(tt.errorType)
+			if got != tt.want {
+				t.Errorf("mapStreamErrorType(%q) = %q, want %q", tt.errorType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnthropicStreamEvent_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name   string
+		json   string
+		assert func(t *testing.T, e anthropicStreamEvent)
+	}{
+		{
+			name: "message_start",
+			json: `{"type":"message_start","message":{"id":"msg_abc","usage":{"input_tokens":25,"output_tokens":1}}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "message_start" {
+					t.Errorf("Type = %q, want %q", e.Type, "message_start")
+				}
+				if e.Message == nil {
+					t.Fatal("Message is nil")
+				}
+				if e.Message.ID != "msg_abc" {
+					t.Errorf("Message.ID = %q, want %q", e.Message.ID, "msg_abc")
+				}
+				if e.Message.Usage == nil || e.Message.Usage.InputTokens != 25 {
+					t.Errorf("Message.Usage.InputTokens = %v, want 25", e.Message.Usage)
+				}
+			},
+		},
+		{
+			name: "content_block_start_text",
+			json: `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "content_block_start" {
+					t.Errorf("Type = %q, want %q", e.Type, "content_block_start")
+				}
+				if e.Index != 0 {
+					t.Errorf("Index = %d, want 0", e.Index)
+				}
+				if e.ContentBlock == nil || e.ContentBlock.Type != "text" {
+					t.Errorf("ContentBlock.Type = %v, want text", e.ContentBlock)
+				}
+			},
+		},
+		{
+			name: "content_block_start_tool_use",
+			json: `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_abc","name":"read_file"}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "content_block_start" {
+					t.Errorf("Type = %q, want %q", e.Type, "content_block_start")
+				}
+				if e.Index != 1 {
+					t.Errorf("Index = %d, want 1", e.Index)
+				}
+				if e.ContentBlock == nil {
+					t.Fatal("ContentBlock is nil")
+				}
+				if e.ContentBlock.Type != "tool_use" {
+					t.Errorf("ContentBlock.Type = %q, want %q", e.ContentBlock.Type, "tool_use")
+				}
+				if e.ContentBlock.ID != "toolu_abc" {
+					t.Errorf("ContentBlock.ID = %q, want %q", e.ContentBlock.ID, "toolu_abc")
+				}
+				if e.ContentBlock.Name != "read_file" {
+					t.Errorf("ContentBlock.Name = %q, want %q", e.ContentBlock.Name, "read_file")
+				}
+			},
+		},
+		{
+			name: "content_block_delta_text",
+			json: `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "content_block_delta" {
+					t.Errorf("Type = %q, want %q", e.Type, "content_block_delta")
+				}
+				if e.Index != 0 {
+					t.Errorf("Index = %d, want 0", e.Index)
+				}
+				if e.Delta == nil || e.Delta.Type != "text_delta" || e.Delta.Text != "Hello" {
+					t.Errorf("Delta = %+v, want type=text_delta text=Hello", e.Delta)
+				}
+			},
+		},
+		{
+			name: "content_block_delta_input_json",
+			json: `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "content_block_delta" {
+					t.Errorf("Type = %q, want %q", e.Type, "content_block_delta")
+				}
+				if e.Delta == nil || e.Delta.Type != "input_json_delta" || e.Delta.PartialJSON != `{"path":` {
+					t.Errorf("Delta = %+v, want type=input_json_delta partial_json={\"path\":", e.Delta)
+				}
+			},
+		},
+		{
+			name: "content_block_stop",
+			json: `{"type":"content_block_stop","index":0}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "content_block_stop" {
+					t.Errorf("Type = %q, want %q", e.Type, "content_block_stop")
+				}
+				if e.Index != 0 {
+					t.Errorf("Index = %d, want 0", e.Index)
+				}
+			},
+		},
+		{
+			name: "message_delta",
+			json: `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "message_delta" {
+					t.Errorf("Type = %q, want %q", e.Type, "message_delta")
+				}
+				if e.Delta == nil || e.Delta.StopReason != "end_turn" {
+					t.Errorf("Delta.StopReason = %v, want end_turn", e.Delta)
+				}
+				if e.Usage == nil || e.Usage.OutputTokens != 15 {
+					t.Errorf("Usage.OutputTokens = %v, want 15", e.Usage)
+				}
+			},
+		},
+		{
+			name: "message_stop",
+			json: `{"type":"message_stop"}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "message_stop" {
+					t.Errorf("Type = %q, want %q", e.Type, "message_stop")
+				}
+			},
+		},
+		{
+			name: "ping",
+			json: `{"type":"ping"}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "ping" {
+					t.Errorf("Type = %q, want %q", e.Type, "ping")
+				}
+			},
+		},
+		{
+			name: "error",
+			json: `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			assert: func(t *testing.T, e anthropicStreamEvent) {
+				if e.Type != "error" {
+					t.Errorf("Type = %q, want %q", e.Type, "error")
+				}
+				if e.Error == nil {
+					t.Fatal("Error is nil")
+				}
+				if e.Error.Type != "overloaded_error" {
+					t.Errorf("Error.Type = %q, want %q", e.Error.Type, "overloaded_error")
+				}
+				if e.Error.Message != "Overloaded" {
+					t.Errorf("Error.Message = %q, want %q", e.Error.Message, "Overloaded")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var event anthropicStreamEvent
+			if err := json.Unmarshal([]byte(tt.json), &event); err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+			tt.assert(t, event)
+		})
+	}
+}

--- a/internal/provider/awscreds_test.go
+++ b/internal/provider/awscreds_test.go
@@ -40,6 +40,7 @@ func TestResolveCredentials_File(t *testing.T) {
 
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_PROFILE", "")
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credsPath)
 
 	creds, err := resolveCredentials("")

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -378,6 +378,185 @@ func (g *Gemini) Send(ctx context.Context, req *Request) (*Response, error) {
 	return resp, nil
 }
 
+// SendStream makes a streaming completion request to the Google Gemini API.
+func (g *Gemini) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	body := geminiRequest{
+		Contents: convertToGeminiContents(req.Messages),
+	}
+
+	if req.System != "" {
+		body.SystemInstruction = &geminiSystemInstruction{
+			Parts: []geminiPart{{Text: req.System}},
+		}
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToGeminiTools(req.Tools)
+	}
+
+	var genCfg geminiGenerationConfig
+	hasGenCfg := false
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		genCfg.Temperature = &temp
+		hasGenCfg = true
+	}
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		genCfg.MaxOutputTokens = &mt
+		hasGenCfg = true
+	}
+	if hasGenCfg {
+		body.GenerationConfig = &genCfg
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", g.baseURL, req.Model)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("x-goog-api-key", g.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := g.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(httpResp.Body)
+		_ = httpResp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("failed to read error response: %s", err),
+				Err:      err,
+			}
+		}
+		return nil, g.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(httpResp.Body)
+	toolCallIdx := 0
+	var finishReason string
+	var inputTokens, outputTokens int
+	doneEmitted := false
+	var pending []StreamEvent
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			if len(pending) > 0 {
+				ev := pending[0]
+				pending = pending[1:]
+				return ev, nil
+			}
+
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryTimeout,
+						Message:  ctx.Err().Error(),
+						Err:      ctx.Err(),
+					}
+				}
+				if err == io.EOF {
+					if !doneEmitted {
+						doneEmitted = true
+						return StreamEvent{
+							Type:         StreamEventDone,
+							StopReason:   finishReason,
+							InputTokens:  inputTokens,
+							OutputTokens: outputTokens,
+						}, nil
+					}
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("stream read error: %s", err),
+					Err:      err,
+				}
+			}
+
+			var chunk geminiResponse
+			if err := json.Unmarshal([]byte(sseEvent.Data), &chunk); err != nil {
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("failed to parse streaming chunk: %s", err),
+					Err:      err,
+				}
+			}
+
+			if chunk.UsageMetadata != nil {
+				inputTokens = chunk.UsageMetadata.PromptTokenCount
+				outputTokens = chunk.UsageMetadata.CandidatesTokenCount
+			}
+
+			if len(chunk.Candidates) == 0 {
+				continue
+			}
+
+			candidate := chunk.Candidates[0]
+			if candidate.FinishReason != "" {
+				finishReason = candidate.FinishReason
+			}
+
+			if candidate.Content == nil {
+				continue
+			}
+
+			for _, part := range candidate.Content.Parts {
+				if part.FunctionCall != nil {
+					args := make(map[string]string)
+					for k, v := range part.FunctionCall.Args {
+						args[k] = fmt.Sprintf("%v", v)
+					}
+					id := fmt.Sprintf("gemini_%d", toolCallIdx)
+					toolCallIdx++
+					argsJSON, _ := json.Marshal(args)
+					pending = append(pending, StreamEvent{
+						Type:       StreamEventToolStart,
+						ToolCallID: id,
+						ToolName:   part.FunctionCall.Name,
+						ToolInput:  string(argsJSON),
+					})
+					pending = append(pending, StreamEvent{
+						Type:       StreamEventToolEnd,
+						ToolCallID: id,
+					})
+				} else if part.Text != "" {
+					pending = append(pending, StreamEvent{
+						Type: StreamEventText,
+						Text: part.Text,
+					})
+				}
+			}
+
+			continue
+		}
+	}
+
+	return NewEventStream(httpResp.Body, nextFunc), nil
+}
+
 // handleErrorResponse maps HTTP error responses to ProviderError.
 func (g *Gemini) handleErrorResponse(status int, body []byte) *ProviderError {
 	message := http.StatusText(status)

--- a/internal/provider/gemini_test.go
+++ b/internal/provider/gemini_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -844,6 +846,424 @@ func TestGemini_Send_UnparseableErrorBody(t *testing.T) {
 	// Should fall back to HTTP status text
 	if provErr.Message != "Internal Server Error" {
 		t.Errorf("expected 'Internal Server Error', got %q", provErr.Message)
+	}
+}
+
+// --- Streaming Tests ---
+
+func geminiSSEChunk(jsonData string) string {
+	return "data: " + jsonData + "\n\n"
+}
+
+func TestGemini_SendStream_RequestFormat(t *testing.T) {
+	var capturedPath string
+	var capturedAPIKey string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path + "?" + r.URL.RawQuery
+		capturedAPIKey = r.Header.Get("x-goog-api-key")
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+	}
+
+	expectedPath := "/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse"
+	if capturedPath != expectedPath {
+		t.Errorf("expected path %q, got %q", expectedPath, capturedPath)
+	}
+	if capturedAPIKey != "test-key" {
+		t.Errorf("expected API key 'test-key', got %q", capturedAPIKey)
+	}
+}
+
+func TestGemini_SendStream_TextDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}`))
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":" "}]}}]}`))
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":20}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// 3 text + 1 done
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+	if events[1].Type != StreamEventText || events[1].Text != " " {
+		t.Errorf("event 1: expected text ' ', got type=%s text=%q", events[1].Type, events[1].Text)
+	}
+	if events[2].Type != StreamEventText || events[2].Text != "world" {
+		t.Errorf("event 2: expected text 'world', got type=%s text=%q", events[2].Type, events[2].Text)
+	}
+	if events[3].Type != StreamEventDone {
+		t.Errorf("event 3: expected done, got type=%s", events[3].Type)
+	}
+	if events[3].StopReason != "STOP" {
+		t.Errorf("expected stop reason 'STOP', got %q", events[3].StopReason)
+	}
+	if events[3].InputTokens != 10 {
+		t.Errorf("expected 10 input tokens, got %d", events[3].InputTokens)
+	}
+	if events[3].OutputTokens != 20 {
+		t.Errorf("expected 20 output tokens, got %d", events[3].OutputTokens)
+	}
+}
+
+func TestGemini_SendStream_ToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"NYC"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// tool_start + tool_end + done = 3
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+
+	if events[0].Type != StreamEventToolStart || events[0].ToolName != "get_weather" {
+		t.Errorf("event 0: expected tool_start get_weather, got type=%s name=%s", events[0].Type, events[0].ToolName)
+	}
+	if events[0].ToolCallID != "gemini_0" {
+		t.Errorf("event 0: expected ID 'gemini_0', got %q", events[0].ToolCallID)
+	}
+	if events[1].Type != StreamEventToolEnd || events[1].ToolCallID != "gemini_0" {
+		t.Errorf("event 1: expected tool_end gemini_0, got type=%s id=%s", events[1].Type, events[1].ToolCallID)
+	}
+	if events[2].Type != StreamEventDone {
+		t.Errorf("event 2: expected done, got type=%s", events[2].Type)
+	}
+}
+
+func TestGemini_SendStream_MixedTextAndToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Let me check"},{"functionCall":{"name":"search","args":{"q":"test"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Search"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// text + tool_start + tool_end + done = 4
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	if events[0].Type != StreamEventText || events[0].Text != "Let me check" {
+		t.Errorf("event 0: expected text, got type=%s", events[0].Type)
+	}
+	if events[1].Type != StreamEventToolStart {
+		t.Errorf("event 1: expected tool_start, got type=%s", events[1].Type)
+	}
+	if events[2].Type != StreamEventToolEnd {
+		t.Errorf("event 2: expected tool_end, got type=%s", events[2].Type)
+	}
+	if events[3].Type != StreamEventDone {
+		t.Errorf("event 3: expected done, got type=%s", events[3].Type)
+	}
+}
+
+func TestGemini_SendStream_EmptyTextPart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":""}]}}]}`))
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// 1 text + 1 done (empty text skipped)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+}
+
+func TestGemini_SendStream_NoCandidates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[]}`))
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// 1 text + 1 done (empty candidates skipped)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+}
+
+func TestGemini_SendStream_UsageInMiddleChunk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":1}}`))
+		_, _ = fmt.Fprint(w, geminiSSEChunk(`{"candidates":[{"content":{"role":"model","parts":[{"text":" world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// 2 text + 1 done
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	done := events[2]
+	if done.Type != StreamEventDone {
+		t.Fatalf("expected done event, got %s", done.Type)
+	}
+	if done.OutputTokens != 10 {
+		t.Errorf("expected latest output tokens 10, got %d", done.OutputTokens)
+	}
+}
+
+func TestGemini_SendStream_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"error":{"code":401,"message":"Invalid API key","status":"UNAUTHENTICATED"}}`))
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("bad-key", WithGeminiBaseURL(server.URL))
+	_, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T", err)
+	}
+	if provErr.Category != ErrCategoryAuth {
+		t.Errorf("expected ErrCategoryAuth, got %s", provErr.Category)
+	}
+}
+
+func TestGemini_SendStream_MalformedSSE(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: not valid json\n\n")
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	stream, err := g.SendStream(context.Background(), &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from SendStream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = stream.Next()
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if provErr.Category != ErrCategoryServer {
+		t.Errorf("expected ErrCategoryServer, got %s", provErr.Category)
+	}
+}
+
+func TestGemini_SendStream_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	g, _ := NewGemini("test-key", WithGeminiBaseURL(server.URL))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	stream, err := g.SendStream(ctx, &Request{
+		Model:    "gemini-2.0-flash",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		var provErr *ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatalf("expected ProviderError, got %T", err)
+		}
+		if provErr.Category != ErrCategoryTimeout {
+			t.Errorf("expected ErrCategoryTimeout, got %s", provErr.Category)
+		}
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			t.Fatal("expected timeout error, got EOF")
+		}
+		var provErr *ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatalf("expected ProviderError, got %T: %v", err, err)
+		}
+		if provErr.Category != ErrCategoryTimeout {
+			t.Errorf("expected ErrCategoryTimeout, got %s", provErr.Category)
+		}
+		break
 	}
 }
 

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -104,6 +105,7 @@ type ollamaResponse struct {
 		Content   string               `json:"content"`
 		ToolCalls []ollamaToolCallWire `json:"tool_calls"`
 	} `json:"message"`
+	Done            bool   `json:"done"`
 	DoneReason      string `json:"done_reason"`
 	PromptEvalCount int    `json:"prompt_eval_count"`
 	EvalCount       int    `json:"eval_count"`
@@ -325,6 +327,182 @@ func (o *Ollama) Send(ctx context.Context, req *Request) (*Response, error) {
 		OutputTokens: apiResp.EvalCount,
 		StopReason:   apiResp.DoneReason,
 	}, nil
+}
+
+// SendStream makes a streaming completion request to the Ollama Chat API.
+func (o *Ollama) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	var messages []Message
+	if req.System != "" {
+		messages = append(messages, Message{Role: "system", Content: req.System})
+	}
+	messages = append(messages, req.Messages...)
+
+	body := ollamaRequest{
+		Model:    req.Model,
+		Messages: convertToOllamaMessages(messages),
+		Stream:   true,
+	}
+
+	var opts ollamaOptions
+	hasOpts := false
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		opts.Temperature = &temp
+		hasOpts = true
+	}
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		opts.NumPredict = &mt
+		hasOpts = true
+	}
+	if hasOpts {
+		body.Options = &opts
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOllamaTools(req.Tools)
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/api/chat", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		if isConnectionRefused(err) {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("connection refused: is Ollama running? (expected at %s)", o.baseURL),
+				Err:      err,
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(httpResp.Body)
+		_ = httpResp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("failed to read error response: %s", err),
+				Err:      err,
+			}
+		}
+		return nil, o.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	scanner := bufio.NewScanner(httpResp.Body)
+	toolCallIdx := 0
+	var pending []StreamEvent
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			if len(pending) > 0 {
+				ev := pending[0]
+				pending = pending[1:]
+				return ev, nil
+			}
+
+			if !scanner.Scan() {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryTimeout,
+						Message:  ctx.Err().Error(),
+						Err:      ctx.Err(),
+					}
+				}
+				if err := scanner.Err(); err != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryServer,
+						Message:  fmt.Sprintf("stream read error: %s", err),
+						Err:      err,
+					}
+				}
+				return StreamEvent{}, io.EOF
+			}
+
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+
+			var chunk ollamaResponse
+			if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("failed to parse streaming chunk: %s", err),
+					Err:      err,
+				}
+			}
+
+			if len(chunk.Message.ToolCalls) > 0 {
+				for _, tc := range chunk.Message.ToolCalls {
+					args := make(map[string]string)
+					for k, v := range tc.Function.Arguments {
+						args[k] = fmt.Sprintf("%v", v)
+					}
+					id := fmt.Sprintf("ollama_%d", toolCallIdx)
+					toolCallIdx++
+					pending = append(pending, StreamEvent{
+						Type:       StreamEventToolStart,
+						ToolCallID: id,
+						ToolName:   tc.Function.Name,
+						ToolInput:  mustMarshal(args),
+					})
+					pending = append(pending, StreamEvent{
+						Type:       StreamEventToolEnd,
+						ToolCallID: id,
+					})
+				}
+				continue
+			}
+
+			if chunk.Done {
+				return StreamEvent{
+					Type:         StreamEventDone,
+					StopReason:   chunk.DoneReason,
+					InputTokens:  chunk.PromptEvalCount,
+					OutputTokens: chunk.EvalCount,
+				}, nil
+			}
+
+			if chunk.Message.Content != "" {
+				return StreamEvent{
+					Type: StreamEventText,
+					Text: chunk.Message.Content,
+				}, nil
+			}
+
+			continue
+		}
+	}
+
+	return NewEventStream(httpResp.Body, nextFunc), nil
+}
+
+func mustMarshal(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
 }
 
 // handleErrorResponse maps HTTP error responses to ProviderError.

--- a/internal/provider/ollama_test.go
+++ b/internal/provider/ollama_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -808,6 +809,313 @@ func TestOllama_Send_ToolResultMessage(t *testing.T) {
 				t.Errorf("expected content 'Another result', got %v", msg["content"])
 			}
 		}
+	}
+}
+
+// --- Streaming Tests ---
+
+func TestOllama_SendStream_RequestFormat(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotStream interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		gotStream = req["stream"]
+
+		// Return NDJSON: one text chunk then done
+		_, _ = fmt.Fprintln(w, `{"message":{"content":"hi"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":2}`)
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Drain the stream
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/api/chat" {
+		t.Errorf("expected /api/chat, got %s", gotPath)
+	}
+	if gotStream != true {
+		t.Errorf("expected stream=true, got %v", gotStream)
+	}
+}
+
+func TestOllama_SendStream_TextDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `{"message":{"content":"Hello"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":" "},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":"world"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":20}`)
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Expect 3 text events + 1 done
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+	if events[1].Type != StreamEventText || events[1].Text != " " {
+		t.Errorf("event 1: expected text ' ', got type=%s text=%q", events[1].Type, events[1].Text)
+	}
+	if events[2].Type != StreamEventText || events[2].Text != "world" {
+		t.Errorf("event 2: expected text 'world', got type=%s text=%q", events[2].Type, events[2].Text)
+	}
+	if events[3].Type != StreamEventDone {
+		t.Errorf("event 3: expected done, got type=%s", events[3].Type)
+	}
+	if events[3].StopReason != "stop" {
+		t.Errorf("expected stop reason 'stop', got %q", events[3].StopReason)
+	}
+	if events[3].InputTokens != 10 {
+		t.Errorf("expected 10 input tokens, got %d", events[3].InputTokens)
+	}
+	if events[3].OutputTokens != 20 {
+		t.Errorf("expected 20 output tokens, got %d", events[3].OutputTokens)
+	}
+}
+
+func TestOllama_SendStream_ToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `{"message":{"content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"NYC"}}},{"function":{"name":"get_time","arguments":{"tz":"EST"}}}]},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":8,"eval_count":4}`)
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "What's the weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// 2 tool calls × (start + end) + 1 done = 5 events
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events, got %d: %+v", len(events), events)
+	}
+
+	if events[0].Type != StreamEventToolStart || events[0].ToolName != "get_weather" {
+		t.Errorf("event 0: expected tool_start get_weather, got type=%s name=%s", events[0].Type, events[0].ToolName)
+	}
+	if events[0].ToolCallID != "ollama_0" {
+		t.Errorf("event 0: expected ID 'ollama_0', got %q", events[0].ToolCallID)
+	}
+	if events[1].Type != StreamEventToolEnd || events[1].ToolCallID != "ollama_0" {
+		t.Errorf("event 1: expected tool_end ollama_0, got type=%s id=%s", events[1].Type, events[1].ToolCallID)
+	}
+	if events[2].Type != StreamEventToolStart || events[2].ToolName != "get_time" {
+		t.Errorf("event 2: expected tool_start get_time, got type=%s name=%s", events[2].Type, events[2].ToolName)
+	}
+	if events[2].ToolCallID != "ollama_1" {
+		t.Errorf("event 2: expected ID 'ollama_1', got %q", events[2].ToolCallID)
+	}
+	if events[3].Type != StreamEventToolEnd || events[3].ToolCallID != "ollama_1" {
+		t.Errorf("event 3: expected tool_end ollama_1, got type=%s id=%s", events[3].Type, events[3].ToolCallID)
+	}
+	if events[4].Type != StreamEventDone {
+		t.Errorf("event 4: expected done, got type=%s", events[4].Type)
+	}
+}
+
+func TestOllama_SendStream_EmptyContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":"Hello"},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":false}`)
+		_, _ = fmt.Fprintln(w, `{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":3}`)
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Only 1 text event (empty content skipped) + 1 done = 2
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+	if events[1].Type != StreamEventDone {
+		t.Errorf("event 1: expected done, got type=%s", events[1].Type)
+	}
+}
+
+func TestOllama_SendStream_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	_, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T", err)
+	}
+	if provErr.Category != ErrCategoryServer {
+		t.Errorf("expected ErrCategoryServer, got %s", provErr.Category)
+	}
+}
+
+func TestOllama_SendStream_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `not valid json at all`)
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from SendStream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = stream.Next()
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if provErr.Category != ErrCategoryServer {
+		t.Errorf("expected ErrCategoryServer, got %s", provErr.Category)
+	}
+}
+
+func TestOllama_SendStream_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	o, _ := NewOllama(WithOllamaBaseURL(server.URL))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	stream, err := o.SendStream(ctx, &Request{
+		Model:    "llama3",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		var provErr *ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatalf("expected ProviderError, got %T", err)
+		}
+		if provErr.Category != ErrCategoryTimeout {
+			t.Errorf("expected ErrCategoryTimeout, got %s", provErr.Category)
+		}
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	for {
+		_, err := stream.Next()
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			t.Fatal("expected timeout error, got EOF")
+		}
+		var provErr *ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatalf("expected ProviderError, got %T: %v", err, err)
+		}
+		if provErr.Category != ErrCategoryTimeout {
+			t.Errorf("expected ErrCategoryTimeout, got %s", provErr.Category)
+		}
+		break
 	}
 }
 

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 )
 
 const (
@@ -58,11 +59,13 @@ func NewOpenAI(apiKey string, opts ...OpenAIOption) (*OpenAI, error) {
 
 // openaiRequest is the JSON body sent to the OpenAI Chat Completions API.
 type openaiRequest struct {
-	Model       string          `json:"model"`
-	Messages    []openaiMessage `json:"messages"`
-	Temperature *float64        `json:"temperature,omitempty"`
-	MaxTokens   *int            `json:"max_completion_tokens,omitempty"`
-	Tools       []openaiToolDef `json:"tools,omitempty"`
+	Model         string               `json:"model"`
+	Messages      []openaiMessage      `json:"messages"`
+	Temperature   *float64             `json:"temperature,omitempty"`
+	MaxTokens     *int                 `json:"max_completion_tokens,omitempty"`
+	Tools         []openaiToolDef      `json:"tools,omitempty"`
+	Stream        bool                 `json:"stream,omitempty"`
+	StreamOptions *openaiStreamOptions `json:"stream_options,omitempty"`
 }
 
 // openaiMessage is the wire format for a message in the OpenAI API.
@@ -342,6 +345,246 @@ func (o *OpenAI) handleErrorResponse(status int, body []byte) *ProviderError {
 		Status:   status,
 		Message:  message,
 	}
+}
+
+// SendStream makes a streaming completion request to the OpenAI Chat Completions API.
+func (o *OpenAI) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	var messages []Message
+	if req.System != "" {
+		messages = append(messages, Message{Role: "system", Content: req.System})
+	}
+	messages = append(messages, req.Messages...)
+
+	body := openaiRequest{
+		Model:         req.Model,
+		Messages:      convertToOpenAIMessages(messages),
+		Stream:        true,
+		StreamOptions: &openaiStreamOptions{IncludeUsage: true},
+	}
+
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		body.Temperature = &temp
+	}
+
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		body.MaxTokens = &mt
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOpenAITools(req.Tools)
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(httpResp.Body)
+		_ = httpResp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("failed to read error response: %s", err),
+				Err:      err,
+			}
+		}
+		return nil, o.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(httpResp.Body)
+	toolCalls := make(map[int]struct{ id, name string })
+	var finishReason string
+	var gotUsage bool
+	var pendingToolEnds []StreamEvent
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			if len(pendingToolEnds) > 0 {
+				ev := pendingToolEnds[0]
+				pendingToolEnds = pendingToolEnds[1:]
+				return ev, nil
+			}
+
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryTimeout,
+						Message:  ctx.Err().Error(),
+						Err:      ctx.Err(),
+					}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("stream read error: %s", err),
+					Err:      err,
+				}
+			}
+
+			if sseEvent.Data == "[DONE]" {
+				if !gotUsage {
+					return StreamEvent{
+						Type:       StreamEventDone,
+						StopReason: finishReason,
+					}, nil
+				}
+				return StreamEvent{}, io.EOF
+			}
+
+			var chunk openaiStreamChunk
+			if err := json.Unmarshal([]byte(sseEvent.Data), &chunk); err != nil {
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("failed to parse streaming chunk: %s", err),
+					Err:      err,
+				}
+			}
+
+			if len(chunk.Choices) == 0 {
+				if chunk.Usage != nil {
+					gotUsage = true
+					return StreamEvent{
+						Type:         StreamEventDone,
+						InputTokens:  chunk.Usage.PromptTokens,
+						OutputTokens: chunk.Usage.CompletionTokens,
+						StopReason:   finishReason,
+					}, nil
+				}
+				continue
+			}
+
+			choice := chunk.Choices[0]
+
+			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
+				return StreamEvent{
+					Type: StreamEventText,
+					Text: *choice.Delta.Content,
+				}, nil
+			}
+
+			if len(choice.Delta.ToolCalls) > 0 {
+				tc := choice.Delta.ToolCalls[0]
+				if tc.ID != "" {
+					toolCalls[tc.Index] = struct{ id, name string }{id: tc.ID, name: tc.Function.Name}
+					return StreamEvent{
+						Type:       StreamEventToolStart,
+						ToolCallID: tc.ID,
+						ToolName:   tc.Function.Name,
+					}, nil
+				}
+				info := toolCalls[tc.Index]
+				args := ""
+				if tc.Function != nil {
+					args = tc.Function.Arguments
+				}
+				return StreamEvent{
+					Type:       StreamEventToolDelta,
+					ToolCallID: info.id,
+					ToolInput:  args,
+				}, nil
+			}
+
+			if choice.FinishReason != nil {
+				fr := *choice.FinishReason
+				finishReason = fr
+				if fr == "tool_calls" {
+					indices := make([]int, 0, len(toolCalls))
+					for idx := range toolCalls {
+						indices = append(indices, idx)
+					}
+					sort.Ints(indices)
+					for _, idx := range indices {
+						info := toolCalls[idx]
+						pendingToolEnds = append(pendingToolEnds, StreamEvent{
+							Type:       StreamEventToolEnd,
+							ToolCallID: info.id,
+						})
+					}
+				}
+				continue
+			}
+
+			continue
+		}
+	}
+
+	return NewEventStream(httpResp.Body, nextFunc), nil
+}
+
+// openaiStreamChunk represents a single SSE chunk from the OpenAI streaming API.
+type openaiStreamChunk struct {
+	Model   string               `json:"model"`
+	Choices []openaiStreamChoice `json:"choices"`
+	Usage   *openaiStreamUsage   `json:"usage,omitempty"`
+}
+
+// openaiStreamChoice is a single choice entry in a streaming chunk.
+type openaiStreamChoice struct {
+	Index        int               `json:"index"`
+	Delta        openaiStreamDelta `json:"delta"`
+	FinishReason *string           `json:"finish_reason"`
+}
+
+// openaiStreamDelta is the delta object within a streaming choice.
+type openaiStreamDelta struct {
+	Content   *string                   `json:"content,omitempty"`
+	Role      string                    `json:"role,omitempty"`
+	ToolCalls []openaiStreamToolCall    `json:"tool_calls,omitempty"`
+}
+
+// openaiStreamToolCall is a tool call entry within a streaming delta.
+type openaiStreamToolCall struct {
+	Index    int                             `json:"index"`
+	ID       string                          `json:"id,omitempty"`
+	Type     string                          `json:"type,omitempty"`
+	Function *openaiStreamToolCallFunction   `json:"function,omitempty"`
+}
+
+// openaiStreamToolCallFunction holds function info within a streaming tool call.
+type openaiStreamToolCallFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// openaiStreamUsage holds token usage info from the streaming usage chunk.
+type openaiStreamUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+// openaiStreamOptions controls streaming behavior in the request.
+type openaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 // mapStatusToCategory maps HTTP status codes to error categories.

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -896,6 +896,530 @@ func TestOpenAI_Send_ToolResultMessage(t *testing.T) {
 	}
 }
 
+func TestOpenAI_Send_DoesNotSetStreamField(t *testing.T) {
+	var gotBody map[string]json.RawMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"model":   "gpt-4o",
+			"choices": []map[string]interface{}{{"message": map[string]string{"content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	_, err := o.Send(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := gotBody["stream"]; ok {
+		t.Error("Send() request body should NOT contain 'stream' key")
+	}
+	if _, ok := gotBody["stream_options"]; ok {
+		t.Error("Send() request body should NOT contain 'stream_options' key")
+	}
+}
+
+// --- SendStream tests ---
+
+func TestOpenAI_SendStream_RequestFormat(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotBody map[string]json.RawMessage
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\ndata: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("test-key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Drain the stream
+	for {
+		_, err := stream.Next()
+		if err != nil {
+			break
+		}
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/chat/completions" {
+		t.Errorf("expected /chat/completions, got %s", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("expected 'Bearer test-key', got %q", gotAuth)
+	}
+
+	var streamVal bool
+	if err := json.Unmarshal(gotBody["stream"], &streamVal); err != nil {
+		t.Fatalf("failed to parse stream field: %v", err)
+	}
+	if !streamVal {
+		t.Error("expected stream to be true")
+	}
+
+	var streamOpts map[string]interface{}
+	if err := json.Unmarshal(gotBody["stream_options"], &streamOpts); err != nil {
+		t.Fatalf("failed to parse stream_options: %v", err)
+	}
+	if streamOpts["include_usage"] != true {
+		t.Errorf("expected include_usage to be true, got %v", streamOpts["include_usage"])
+	}
+}
+
+func TestOpenAI_SendStream_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid API key","type":"invalid_request_error","code":"invalid_api_key"}}`))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("bad-key", WithOpenAIBaseURL(server.URL))
+	_, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if provErr.Category != ErrCategoryAuth {
+		t.Errorf("expected ErrCategoryAuth, got %s", provErr.Category)
+	}
+}
+
+func TestOpenAI_SendStream_ContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := o.SendStream(ctx, &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if provErr.Category != ErrCategoryTimeout {
+		t.Errorf("expected ErrCategoryTimeout, got %s", provErr.Category)
+	}
+}
+
+func TestOpenAI_SendStream_TextDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"!\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Event 1: text "Hello"
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on event 1: %v", err)
+	}
+	if ev.Type != StreamEventText || ev.Text != "Hello" {
+		t.Errorf("event 1: got type=%q text=%q, want type=%q text=%q", ev.Type, ev.Text, StreamEventText, "Hello")
+	}
+
+	// Event 2: text " world"
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on event 2: %v", err)
+	}
+	if ev.Type != StreamEventText || ev.Text != " world" {
+		t.Errorf("event 2: got type=%q text=%q, want type=%q text=%q", ev.Type, ev.Text, StreamEventText, " world")
+	}
+
+	// Event 3: text "!"
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on event 3: %v", err)
+	}
+	if ev.Type != StreamEventText || ev.Text != "!" {
+		t.Errorf("event 3: got type=%q text=%q, want type=%q text=%q", ev.Type, ev.Text, StreamEventText, "!")
+	}
+
+	// Event 4: done with usage
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on event 4: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("event 4: got type=%q, want %q", ev.Type, StreamEventDone)
+	}
+	if ev.InputTokens != 10 {
+		t.Errorf("event 4: InputTokens=%d, want 10", ev.InputTokens)
+	}
+	if ev.OutputTokens != 5 {
+		t.Errorf("event 4: OutputTokens=%d, want 5", ev.OutputTokens)
+	}
+	if ev.StopReason != "stop" {
+		t.Errorf("event 4: StopReason=%q, want %q", ev.StopReason, "stop")
+	}
+
+	// Event 5: io.EOF
+	_, err = stream.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestOpenAI_SendStream_ToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"pa\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"th\\\": \\\"f.go\\\"}\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Event 1: tool start
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventToolStart {
+		t.Errorf("event 1: type=%q, want %q", ev.Type, StreamEventToolStart)
+	}
+	if ev.ToolCallID != "call_1" {
+		t.Errorf("event 1: ToolCallID=%q, want %q", ev.ToolCallID, "call_1")
+	}
+	if ev.ToolName != "read_file" {
+		t.Errorf("event 1: ToolName=%q, want %q", ev.ToolName, "read_file")
+	}
+
+	// Event 2: tool delta
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventToolDelta {
+		t.Errorf("event 2: type=%q, want %q", ev.Type, StreamEventToolDelta)
+	}
+	if ev.ToolCallID != "call_1" {
+		t.Errorf("event 2: ToolCallID=%q, want %q", ev.ToolCallID, "call_1")
+	}
+	if ev.ToolInput != "{\"pa" {
+		t.Errorf("event 2: ToolInput=%q, want %q", ev.ToolInput, "{\"pa")
+	}
+
+	// Event 3: tool delta
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventToolDelta {
+		t.Errorf("event 3: type=%q, want %q", ev.Type, StreamEventToolDelta)
+	}
+	if ev.ToolInput != "th\": \"f.go\"}" {
+		t.Errorf("event 3: ToolInput=%q, want %q", ev.ToolInput, "th\": \"f.go\"}")
+	}
+
+	// Event 4: tool end
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventToolEnd {
+		t.Errorf("event 4: type=%q, want %q", ev.Type, StreamEventToolEnd)
+	}
+	if ev.ToolCallID != "call_1" {
+		t.Errorf("event 4: ToolCallID=%q, want %q", ev.ToolCallID, "call_1")
+	}
+
+	// Event 5: done
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("event 5: type=%q, want %q", ev.Type, StreamEventDone)
+	}
+
+	// Event 6: EOF
+	_, err = stream.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestOpenAI_SendStream_MultipleToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"write_file\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"p\\\":\\\"a\\\"}\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\"{\\\"q\\\":\\\"b\\\"}\"}}]},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Collect all events
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	// Expected: tool_start(call_a), tool_start(call_b), tool_delta(call_a), tool_delta(call_b), tool_end(call_a), tool_end(call_b), done
+	if len(events) != 7 {
+		t.Fatalf("got %d events, want 7", len(events))
+	}
+
+	if events[0].Type != StreamEventToolStart || events[0].ToolCallID != "call_a" || events[0].ToolName != "read_file" {
+		t.Errorf("event 0: %+v", events[0])
+	}
+	if events[1].Type != StreamEventToolStart || events[1].ToolCallID != "call_b" || events[1].ToolName != "write_file" {
+		t.Errorf("event 1: %+v", events[1])
+	}
+	if events[2].Type != StreamEventToolDelta || events[2].ToolCallID != "call_a" {
+		t.Errorf("event 2: %+v", events[2])
+	}
+	if events[3].Type != StreamEventToolDelta || events[3].ToolCallID != "call_b" {
+		t.Errorf("event 3: %+v", events[3])
+	}
+	if events[4].Type != StreamEventToolEnd || events[4].ToolCallID != "call_a" {
+		t.Errorf("event 4: %+v", events[4])
+	}
+	if events[5].Type != StreamEventToolEnd || events[5].ToolCallID != "call_b" {
+		t.Errorf("event 5: %+v", events[5])
+	}
+	if events[6].Type != StreamEventDone {
+		t.Errorf("event 6: %+v", events[6])
+	}
+}
+
+func TestOpenAI_SendStream_EmptyContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventText || ev.Text != "hello" {
+		t.Errorf("got type=%q text=%q, want type=%q text=%q", ev.Type, ev.Text, StreamEventText, "hello")
+	}
+
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("got type=%q, want %q", ev.Type, StreamEventDone)
+	}
+
+	_, err = stream.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestOpenAI_SendStream_NoUsageChunk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventText {
+		t.Errorf("got type=%q, want %q", ev.Type, StreamEventText)
+	}
+
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("got type=%q, want %q", ev.Type, StreamEventDone)
+	}
+	if ev.InputTokens != 0 || ev.OutputTokens != 0 {
+		t.Errorf("expected zero tokens, got input=%d output=%d", ev.InputTokens, ev.OutputTokens)
+	}
+	if ev.StopReason != "stop" {
+		t.Errorf("StopReason=%q, want %q", ev.StopReason, "stop")
+	}
+
+	_, err = stream.Next()
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestOpenAI_SendStream_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {not json}\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = stream.Next()
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if provErr.Category != ErrCategoryServer {
+		t.Errorf("expected ErrCategoryServer, got %s", provErr.Category)
+	}
+}
+
+func TestOpenAI_SendStream_FinishReasonLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":100}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Skip text event
+	_, _ = stream.Next()
+
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("got type=%q, want %q", ev.Type, StreamEventDone)
+	}
+	if ev.StopReason != "length" {
+		t.Errorf("StopReason=%q, want %q", ev.StopReason, "length")
+	}
+}
+
 func TestOpenAI_Send_AssistantToolCallMessage(t *testing.T) {
 	var gotBody map[string]json.RawMessage
 

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -315,6 +316,495 @@ func (o *OpenCode) sendClaude(ctx context.Context, req *Request) (*Response, err
 	}
 
 	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+// SendStream dispatches the streaming request by model prefix.
+func (o *OpenCode) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	switch {
+	case strings.HasPrefix(req.Model, "claude-"):
+		return o.streamClaude(ctx, req)
+	case strings.HasPrefix(req.Model, "gpt-"):
+		return o.streamGPT(ctx, req)
+	default:
+		return o.streamChatCompletions(ctx, req)
+	}
+}
+
+// --- Claude (Anthropic Messages) streaming ---
+
+type ocAnthropicStreamRequest struct {
+	Model       string               `json:"model"`
+	MaxTokens   int                  `json:"max_tokens"`
+	Messages    []ocAnthropicMessage `json:"messages"`
+	System      string               `json:"system,omitempty"`
+	Temperature *float64             `json:"temperature,omitempty"`
+	Tools       []ocAnthropicToolDef `json:"tools,omitempty"`
+	Stream      bool                 `json:"stream"`
+}
+
+func (o *OpenCode) streamClaude(ctx context.Context, req *Request) (*EventStream, error) {
+	maxTokens := req.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = 4096
+	}
+
+	body := ocAnthropicStreamRequest{
+		Model:     req.Model,
+		MaxTokens: maxTokens,
+		Messages:  convertToOCAnthropicMessages(req.Messages),
+		System:    req.System,
+		Stream:    true,
+	}
+
+	if req.Temperature != 0 {
+		t := req.Temperature
+		body.Temperature = &t
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOCAnthropicTools(req.Tools)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to marshal request: %s", err)}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/v1/messages", bytes.NewReader(data))
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to create request: %s", err)}
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error()}
+		}
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: err.Error()}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to read error response: %s", err)}
+		}
+		return nil, mapOCAnthropicHTTPError(resp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(resp.Body)
+	var inputTokens int
+	blocks := make(map[int]anthropicBlockInfo)
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error(), Err: ctx.Err()}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("stream read error: %s", err), Err: err}
+			}
+
+			var event anthropicStreamEvent
+			if err := json.Unmarshal([]byte(sseEvent.Data), &event); err != nil {
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to parse streaming event: %s", err), Err: err}
+			}
+
+			switch event.Type {
+			case "message_start":
+				if event.Message != nil && event.Message.Usage != nil {
+					inputTokens = event.Message.Usage.InputTokens
+				}
+				continue
+			case "content_block_start":
+				if event.ContentBlock != nil {
+					blocks[event.Index] = anthropicBlockInfo{typ: event.ContentBlock.Type, id: event.ContentBlock.ID, name: event.ContentBlock.Name}
+					if event.ContentBlock.Type == "tool_use" {
+						return StreamEvent{Type: StreamEventToolStart, ToolCallID: event.ContentBlock.ID, ToolName: event.ContentBlock.Name}, nil
+					}
+				}
+				continue
+			case "content_block_delta":
+				if event.Delta == nil {
+					continue
+				}
+				block, ok := blocks[event.Index]
+				if !ok {
+					continue
+				}
+				switch event.Delta.Type {
+				case "text_delta":
+					if event.Delta.Text == "" {
+						continue
+					}
+					return StreamEvent{Type: StreamEventText, Text: event.Delta.Text}, nil
+				case "input_json_delta":
+					if event.Delta.PartialJSON == "" {
+						continue
+					}
+					return StreamEvent{Type: StreamEventToolDelta, ToolCallID: block.id, ToolInput: event.Delta.PartialJSON}, nil
+				}
+				continue
+			case "content_block_stop":
+				block, ok := blocks[event.Index]
+				if ok && block.typ == "tool_use" {
+					return StreamEvent{Type: StreamEventToolEnd, ToolCallID: block.id}, nil
+				}
+				continue
+			case "message_delta":
+				var stopReason string
+				if event.Delta != nil {
+					stopReason = event.Delta.StopReason
+				}
+				var outputTokens int
+				if event.Usage != nil {
+					outputTokens = event.Usage.OutputTokens
+				}
+				return StreamEvent{Type: StreamEventDone, StopReason: stopReason, InputTokens: inputTokens, OutputTokens: outputTokens}, nil
+			case "message_stop":
+				return StreamEvent{}, io.EOF
+			case "ping":
+				continue
+			case "error":
+				if event.Error != nil {
+					return StreamEvent{}, &ProviderError{Category: mapStreamErrorType(event.Error.Type), Message: event.Error.Message}
+				}
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: "unknown stream error"}
+			default:
+				continue
+			}
+		}
+	}
+
+	return NewEventStream(resp.Body, nextFunc), nil
+}
+
+// --- GPT (OpenAI Responses API) streaming ---
+
+type ocResponsesStreamRequest struct {
+	Model           string            `json:"model"`
+	Input           []interface{}     `json:"input"`
+	Temperature     *float64          `json:"temperature,omitempty"`
+	MaxOutputTokens *int              `json:"max_output_tokens,omitempty"`
+	Tools           []ocOpenAIToolDef `json:"tools,omitempty"`
+	Stream          bool              `json:"stream"`
+}
+
+type ocRespStreamEvent struct {
+	Type   string          `json:"type"`
+	ItemID string          `json:"item_id,omitempty"`
+	Item   json.RawMessage `json:"item,omitempty"`
+	Delta  string          `json:"delta,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+type ocRespStreamItem struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type ocRespStreamResponse struct {
+	Usage struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+func (o *OpenCode) streamGPT(ctx context.Context, req *Request) (*EventStream, error) {
+	body := ocResponsesStreamRequest{
+		Model:  req.Model,
+		Input:  convertToOCResponsesMessages(req),
+		Stream: true,
+	}
+
+	if req.Temperature != 0 {
+		t := req.Temperature
+		body.Temperature = &t
+	}
+
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		body.MaxOutputTokens = &mt
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to marshal request: %s", err)}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/v1/responses", bytes.NewReader(data))
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to create request: %s", err)}
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error()}
+		}
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: err.Error()}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to read error response: %s", err)}
+		}
+		return nil, mapOCOpenAIHTTPError(resp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(resp.Body)
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error(), Err: ctx.Err()}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("stream read error: %s", err), Err: err}
+			}
+
+			if sseEvent.Data == "[DONE]" {
+				return StreamEvent{}, io.EOF
+			}
+
+			var event ocRespStreamEvent
+			if err := json.Unmarshal([]byte(sseEvent.Data), &event); err != nil {
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to parse streaming event: %s", err), Err: err}
+			}
+
+			switch event.Type {
+			case "response.content_part.delta":
+				if event.Delta == "" {
+					continue
+				}
+				return StreamEvent{Type: StreamEventText, Text: event.Delta}, nil
+
+			case "response.output_item.added":
+				var item ocRespStreamItem
+				if err := json.Unmarshal(event.Item, &item); err != nil {
+					continue
+				}
+				if item.Type == "function_call" {
+					return StreamEvent{Type: StreamEventToolStart, ToolCallID: item.ID, ToolName: item.Name}, nil
+				}
+				continue
+
+			case "response.function_call_arguments.delta":
+				return StreamEvent{Type: StreamEventToolDelta, ToolCallID: event.ItemID, ToolInput: event.Delta}, nil
+
+			case "response.output_item.done":
+				var item ocRespStreamItem
+				if err := json.Unmarshal(event.Item, &item); err != nil {
+					continue
+				}
+				if item.Type == "function_call" {
+					return StreamEvent{Type: StreamEventToolEnd, ToolCallID: item.ID}, nil
+				}
+				continue
+
+			case "response.completed":
+				var respObj ocRespStreamResponse
+				if err := json.Unmarshal(event.Response, &respObj); err == nil {
+					return StreamEvent{
+						Type:         StreamEventDone,
+						InputTokens:  respObj.Usage.InputTokens,
+						OutputTokens: respObj.Usage.OutputTokens,
+					}, nil
+				}
+				return StreamEvent{Type: StreamEventDone}, nil
+
+			default:
+				continue
+			}
+		}
+	}
+
+	return NewEventStream(resp.Body, nextFunc), nil
+}
+
+// --- Chat Completions streaming ---
+
+type ocChatStreamRequest struct {
+	Model         string             `json:"model"`
+	Messages      []ocChatMessage    `json:"messages"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	MaxTokens     *int               `json:"max_tokens,omitempty"`
+	Tools         []ocOpenAIToolDef  `json:"tools,omitempty"`
+	Stream        bool               `json:"stream"`
+	StreamOptions *ocStreamOptions   `json:"stream_options,omitempty"`
+}
+
+type ocStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+func (o *OpenCode) streamChatCompletions(ctx context.Context, req *Request) (*EventStream, error) {
+	body := ocChatStreamRequest{
+		Model:         req.Model,
+		Messages:      convertToOCChatMessages(req),
+		Stream:        true,
+		StreamOptions: &ocStreamOptions{IncludeUsage: true},
+	}
+
+	if req.Temperature != 0 {
+		t := req.Temperature
+		body.Temperature = &t
+	}
+
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		body.MaxTokens = &mt
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to marshal request: %s", err)}
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/v1/chat/completions", bytes.NewReader(data))
+	if err != nil {
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to create request: %s", err)}
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error()}
+		}
+		return nil, &ProviderError{Category: ErrCategoryServer, Message: err.Error()}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to read error response: %s", err)}
+		}
+		return nil, mapOCOpenAIHTTPError(resp.StatusCode, respBody)
+	}
+
+	parser := NewSSEParser(resp.Body)
+	toolCalls := make(map[int]struct{ id, name string })
+	var finishReason string
+	var gotUsage bool
+	var pendingToolEnds []StreamEvent
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			if len(pendingToolEnds) > 0 {
+				ev := pendingToolEnds[0]
+				pendingToolEnds = pendingToolEnds[1:]
+				return ev, nil
+			}
+
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{Category: ErrCategoryTimeout, Message: ctx.Err().Error(), Err: ctx.Err()}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("stream read error: %s", err), Err: err}
+			}
+
+			if sseEvent.Data == "[DONE]" {
+				if !gotUsage {
+					return StreamEvent{Type: StreamEventDone, StopReason: finishReason}, nil
+				}
+				return StreamEvent{}, io.EOF
+			}
+
+			var chunk openaiStreamChunk
+			if err := json.Unmarshal([]byte(sseEvent.Data), &chunk); err != nil {
+				return StreamEvent{}, &ProviderError{Category: ErrCategoryServer, Message: fmt.Sprintf("failed to parse streaming chunk: %s", err), Err: err}
+			}
+
+			if len(chunk.Choices) == 0 {
+				if chunk.Usage != nil {
+					gotUsage = true
+					return StreamEvent{
+						Type:         StreamEventDone,
+						InputTokens:  chunk.Usage.PromptTokens,
+						OutputTokens: chunk.Usage.CompletionTokens,
+						StopReason:   finishReason,
+					}, nil
+				}
+				continue
+			}
+
+			choice := chunk.Choices[0]
+
+			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
+				return StreamEvent{Type: StreamEventText, Text: *choice.Delta.Content}, nil
+			}
+
+			if len(choice.Delta.ToolCalls) > 0 {
+				tc := choice.Delta.ToolCalls[0]
+				if tc.ID != "" {
+					toolCalls[tc.Index] = struct{ id, name string }{id: tc.ID, name: tc.Function.Name}
+					return StreamEvent{Type: StreamEventToolStart, ToolCallID: tc.ID, ToolName: tc.Function.Name}, nil
+				}
+				info := toolCalls[tc.Index]
+				args := ""
+				if tc.Function != nil {
+					args = tc.Function.Arguments
+				}
+				return StreamEvent{Type: StreamEventToolDelta, ToolCallID: info.id, ToolInput: args}, nil
+			}
+
+			if choice.FinishReason != nil {
+				fr := *choice.FinishReason
+				finishReason = fr
+				if fr == "tool_calls" {
+					indices := make([]int, 0, len(toolCalls))
+					for idx := range toolCalls {
+						indices = append(indices, idx)
+					}
+					sort.Ints(indices)
+					for _, idx := range indices {
+						info := toolCalls[idx]
+						pendingToolEnds = append(pendingToolEnds, StreamEvent{Type: StreamEventToolEnd, ToolCallID: info.id})
+					}
+				}
+				continue
+			}
+
+			continue
+		}
+	}
+
+	return NewEventStream(resp.Body, nextFunc), nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1076,6 +1077,329 @@ func TestOpenCode_Send_ChatCompletions_ServerError(t *testing.T) {
 		Messages: []Message{{Role: "user", Content: "hi"}},
 	})
 	assertProviderError(t, err, ErrCategoryServer)
+}
+
+// ---------------------------------------------------------------------------
+// Streaming Tests
+// ---------------------------------------------------------------------------
+
+func sseData(jsonStr string) string {
+	return "data: " + jsonStr + "\n\n"
+}
+
+func TestOpenCode_SendStream_ClaudeRoute(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = readBody(r)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseData(`{"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"content_block_start","index":0,"content_block":{"type":"text"}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"content_block_stop","index":0}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"message_stop"}`))
+	}))
+	defer srv.Close()
+
+	p, _ := NewOpenCode("zen-key", WithOpenCodeBaseURL(srv.URL))
+	stream, err := p.SendStream(context.Background(), &Request{
+		Model:    "claude-sonnet-4-6",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if capturedPath != "/v1/messages" {
+		t.Errorf("expected path '/v1/messages', got %q", capturedPath)
+	}
+	if !strings.Contains(string(capturedBody), `"stream":true`) {
+		t.Errorf("expected stream:true in body, got %s", capturedBody)
+	}
+
+	// text + done = 2
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+	if events[1].Type != StreamEventDone {
+		t.Errorf("event 1: expected done, got type=%s", events[1].Type)
+	}
+	if events[1].InputTokens != 10 {
+		t.Errorf("expected 10 input tokens, got %d", events[1].InputTokens)
+	}
+	if events[1].OutputTokens != 5 {
+		t.Errorf("expected 5 output tokens, got %d", events[1].OutputTokens)
+	}
+}
+
+func TestOpenCode_SendStream_GPTRoute(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = readBody(r)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseData(`{"type":"response.content_part.delta","delta":"Hello"}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","name":"read_file"}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"path\":\"/tmp\"}"}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1"}}`))
+		_, _ = fmt.Fprint(w, sseData(`{"type":"response.completed","response":{"usage":{"input_tokens":8,"output_tokens":4}}}`))
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, _ := NewOpenCode("zen-key", WithOpenCodeBaseURL(srv.URL))
+	stream, err := p.SendStream(context.Background(), &Request{
+		Model:    "gpt-5",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if capturedPath != "/v1/responses" {
+		t.Errorf("expected path '/v1/responses', got %q", capturedPath)
+	}
+	if !strings.Contains(string(capturedBody), `"stream":true`) {
+		t.Errorf("expected stream:true in body, got %s", capturedBody)
+	}
+
+	// text + tool_start + tool_delta + tool_end + done = 5
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text, got type=%s", events[0].Type)
+	}
+	if events[1].Type != StreamEventToolStart || events[1].ToolName != "read_file" {
+		t.Errorf("event 1: expected tool_start read_file, got type=%s name=%s", events[1].Type, events[1].ToolName)
+	}
+	if events[2].Type != StreamEventToolDelta {
+		t.Errorf("event 2: expected tool_delta, got type=%s", events[2].Type)
+	}
+	if events[3].Type != StreamEventToolEnd || events[3].ToolCallID != "fc_1" {
+		t.Errorf("event 3: expected tool_end fc_1, got type=%s id=%s", events[3].Type, events[3].ToolCallID)
+	}
+	if events[4].Type != StreamEventDone {
+		t.Errorf("event 4: expected done, got type=%s", events[4].Type)
+	}
+	if events[4].InputTokens != 8 {
+		t.Errorf("expected 8 input tokens, got %d", events[4].InputTokens)
+	}
+}
+
+func TestOpenCode_SendStream_ChatCompletionsRoute(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = readBody(r)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[{"index":0,"delta":{"content":"Hello"}}]}`))
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[{"index":0,"delta":{"content":" world"}}]}`))
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[{"index":0,"finish_reason":"stop","delta":{}}]}`))
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":6}}`))
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, _ := NewOpenCode("zen-key", WithOpenCodeBaseURL(srv.URL))
+	stream, err := p.SendStream(context.Background(), &Request{
+		Model:    "kimi-k2",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var events []StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+		events = append(events, ev)
+	}
+
+	if capturedPath != "/v1/chat/completions" {
+		t.Errorf("expected path '/v1/chat/completions', got %q", capturedPath)
+	}
+	if !strings.Contains(string(capturedBody), `"stream":true`) {
+		t.Errorf("expected stream:true in body, got %s", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), `"stream_options"`) {
+		t.Errorf("expected stream_options in body, got %s", capturedBody)
+	}
+
+	// 2 text + 1 done = 3
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != StreamEventText || events[0].Text != "Hello" {
+		t.Errorf("event 0: expected text 'Hello', got type=%s text=%q", events[0].Type, events[0].Text)
+	}
+	if events[1].Type != StreamEventText || events[1].Text != " world" {
+		t.Errorf("event 1: expected text ' world', got type=%s text=%q", events[1].Type, events[1].Text)
+	}
+	if events[2].Type != StreamEventDone {
+		t.Errorf("event 2: expected done, got type=%s", events[2].Type)
+	}
+	if events[2].InputTokens != 12 {
+		t.Errorf("expected 12 input tokens, got %d", events[2].InputTokens)
+	}
+	if events[2].OutputTokens != 6 {
+		t.Errorf("expected 6 output tokens, got %d", events[2].OutputTokens)
+	}
+}
+
+func TestOpenCode_SendStream_UnknownModelFallsThrough(t *testing.T) {
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[{"index":0,"delta":{"content":"ok"}}]}`))
+		_, _ = fmt.Fprint(w, sseData(`{"choices":[{"index":0,"finish_reason":"stop","delta":{}}]}`))
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, _ := NewOpenCode("zen-key", WithOpenCodeBaseURL(srv.URL))
+	stream, err := p.SendStream(context.Background(), &Request{
+		Model:    "mistral-7b",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	for {
+		_, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected stream error: %v", err)
+		}
+	}
+
+	if capturedPath != "/v1/chat/completions" {
+		t.Errorf("expected path '/v1/chat/completions', got %q", capturedPath)
+	}
+}
+
+func TestOpenCode_SendStream_ErrorResponse(t *testing.T) {
+	routes := []struct {
+		model string
+		name  string
+	}{
+		{"claude-sonnet-4-6", "claude"},
+		{"gpt-5", "gpt"},
+		{"kimi-k2", "chat"},
+	}
+
+	for _, tc := range routes {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer srv.Close()
+
+			p, _ := NewOpenCode("bad-key", WithOpenCodeBaseURL(srv.URL))
+			_, err := p.SendStream(context.Background(), &Request{
+				Model:    tc.model,
+				Messages: []Message{{Role: "user", Content: "hi"}},
+			})
+			assertProviderError(t, err, ErrCategoryAuth)
+		})
+	}
+}
+
+func TestOpenCode_SendStream_ContextCancelled(t *testing.T) {
+	routes := []struct {
+		model string
+		name  string
+	}{
+		{"claude-sonnet-4-6", "claude"},
+		{"gpt-5", "gpt"},
+		{"kimi-k2", "chat"},
+	}
+
+	for _, tc := range routes {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.(http.Flusher).Flush()
+				<-r.Context().Done()
+			}))
+			defer srv.Close()
+
+			p, _ := NewOpenCode("zen-key", WithOpenCodeBaseURL(srv.URL))
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			stream, err := p.SendStream(ctx, &Request{
+				Model:    tc.model,
+				Messages: []Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				assertProviderError(t, err, ErrCategoryTimeout)
+				return
+			}
+			defer func() { _ = stream.Close() }()
+
+			for {
+				_, err := stream.Next()
+				if err == nil {
+					continue
+				}
+				if err == io.EOF {
+					t.Fatal("expected timeout error, got EOF")
+				}
+				assertProviderError(t, err, ErrCategoryTimeout)
+				break
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -112,6 +112,19 @@ func ctxCancelErr(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// SendStream delegates to the inner provider's SendStream if it implements StreamProvider.
+// No retry wrapping is applied to streaming requests.
+func (r *RetryProvider) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	sp, ok := r.inner.(StreamProvider)
+	if !ok {
+		return nil, &ProviderError{
+			Category: ErrCategoryBadRequest,
+			Message:  "inner provider does not support streaming",
+		}
+	}
+	return sp.SendStream(ctx, req)
+}
+
 // isRetriable returns true if the error is a ProviderError with a retriable category.
 func isRetriable(err error) bool {
 	if err == nil {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -112,6 +112,12 @@ func ctxCancelErr(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// SupportsStream returns true if the inner provider implements StreamProvider.
+func (r *RetryProvider) SupportsStream() bool {
+	_, ok := r.inner.(StreamProvider)
+	return ok
+}
+
 // SendStream delegates to the inner provider's SendStream if it implements StreamProvider.
 // No retry wrapping is applied to streaming requests.
 func (r *RetryProvider) SendStream(ctx context.Context, req *Request) (*EventStream, error) {

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -501,5 +504,101 @@ func TestRetrySend_ContextCanceled_NotProviderError(t *testing.T) {
 	// The error should be context.Canceled
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected error to be context.Canceled, got %T: %v", err, err)
+	}
+}
+
+// --- SendStream delegation tests ---
+
+// streamMockProvider implements both Provider and StreamProvider.
+type streamMockProvider struct {
+	retryMockProvider
+	streamResult *EventStream
+	streamErr    error
+}
+
+func (m *streamMockProvider) SendStream(_ context.Context, _ *Request) (*EventStream, error) {
+	return m.streamResult, m.streamErr
+}
+
+func TestRetrySendStream_DelegatesToStreamProvider(t *testing.T) {
+	pr, pw := io.Pipe()
+	go func() { _ = pw.Close() }()
+
+	es := NewEventStream(pr, func() (StreamEvent, error) {
+		return StreamEvent{Type: StreamEventDone}, nil
+	})
+
+	mock := &streamMockProvider{streamResult: es}
+	rp := NewRetry(mock, RetryConfig{MaxRetries: 3})
+
+	got, err := rp.SendStream(context.Background(), &Request{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != es {
+		t.Error("expected SendStream to return the inner provider's EventStream")
+	}
+	_ = got.Close()
+}
+
+func TestRetryProvider_SendStream_DelegatesToOpenAI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	openai, err := NewOpenAI("test-key", WithOpenAIBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("unexpected error creating OpenAI: %v", err)
+	}
+
+	rp := NewRetry(openai, RetryConfig{MaxRetries: 3})
+	stream, err := rp.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on Next(): %v", err)
+	}
+	if ev.Type != StreamEventText || ev.Text != "hi" {
+		t.Errorf("got type=%q text=%q, want type=%q text=%q", ev.Type, ev.Text, StreamEventText, "hi")
+	}
+
+	ev, err = stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error on Next(): %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Errorf("got type=%q, want %q", ev.Type, StreamEventDone)
+	}
+	if ev.InputTokens != 5 || ev.OutputTokens != 2 {
+		t.Errorf("got tokens input=%d output=%d, want 5/2", ev.InputTokens, ev.OutputTokens)
+	}
+}
+
+func TestRetrySendStream_NonStreamProviderReturnsError(t *testing.T) {
+	mock := &retryMockProvider{}
+	rp := NewRetry(mock, RetryConfig{MaxRetries: 3})
+
+	_, err := rp.SendStream(context.Background(), &Request{})
+	if err == nil {
+		t.Fatal("expected error for non-StreamProvider, got nil")
+	}
+	var provErr *ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("expected ProviderError, got %T", err)
+	}
+	if provErr.Category != ErrCategoryBadRequest {
+		t.Errorf("got category %s, want bad_request", provErr.Category)
 	}
 }

--- a/internal/provider/sse.go
+++ b/internal/provider/sse.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+type SSEEvent struct {
+	Event string
+	Data  string
+}
+
+type SSEParser struct {
+	scanner *bufio.Scanner
+}
+
+func NewSSEParser(r io.Reader) *SSEParser {
+	return &SSEParser{scanner: bufio.NewScanner(r)}
+}
+
+func (p *SSEParser) Next() (SSEEvent, error) {
+	var event SSEEvent
+	var dataLines []string
+	hasData := false
+
+	for p.scanner.Scan() {
+		line := p.scanner.Text()
+
+		if line == "" {
+			if hasData || event.Event != "" {
+				event.Data = strings.Join(dataLines, "\n")
+				return event, nil
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		field, value := parseSSEField(line)
+
+		switch field {
+		case "data":
+			hasData = true
+			dataLines = append(dataLines, value)
+		case "event":
+			event.Event = value
+		case "id", "retry":
+			// ignored per spec
+		}
+	}
+
+	if err := p.scanner.Err(); err != nil {
+		return SSEEvent{}, err
+	}
+
+	if hasData || event.Event != "" {
+		event.Data = strings.Join(dataLines, "\n")
+		return event, nil
+	}
+
+	return SSEEvent{}, io.EOF
+}
+
+func parseSSEField(line string) (field, value string) {
+	idx := strings.Index(line, ":")
+	if idx < 0 {
+		return line, ""
+	}
+	field = line[:idx]
+	value = line[idx+1:]
+	value = strings.TrimPrefix(value, " ")
+	return field, value
+}

--- a/internal/provider/sse_test.go
+++ b/internal/provider/sse_test.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSSEParser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		want   []SSEEvent
+	}{
+		{
+			name:  "single data event",
+			input: "data: hello world\n\n",
+			want:  []SSEEvent{{Data: "hello world"}},
+		},
+		{
+			name:  "multi-line data joined with newline",
+			input: "data: line1\ndata: line2\ndata: line3\n\n",
+			want:  []SSEEvent{{Data: "line1\nline2\nline3"}},
+		},
+		{
+			name:  "event type field",
+			input: "event: message_start\ndata: {}\n\n",
+			want:  []SSEEvent{{Event: "message_start", Data: "{}"}},
+		},
+		{
+			name:  "comment lines skipped",
+			input: ": this is a comment\ndata: hello\n\n",
+			want:  []SSEEvent{{Data: "hello"}},
+		},
+		{
+			name:  "DONE sentinel passed through",
+			input: "data: [DONE]\n\n",
+			want:  []SSEEvent{{Data: "[DONE]"}},
+		},
+		{
+			name:  "space after colon stripping",
+			input: "data:hello\n\ndata: world\n\n",
+			want:  []SSEEvent{{Data: "hello"}, {Data: "world"}},
+		},
+		{
+			name:  "empty events between blank lines",
+			input: "\n\ndata: first\n\n\n\ndata: second\n\n",
+			want:  []SSEEvent{{Data: "first"}, {Data: "second"}},
+		},
+		{
+			name:  "id and retry fields ignored",
+			input: "id: 123\nretry: 5000\ndata: payload\n\n",
+			want:  []SSEEvent{{Data: "payload"}},
+		},
+		{
+			name:  "multiple events",
+			input: "data: first\n\ndata: second\n\ndata: third\n\n",
+			want:  []SSEEvent{{Data: "first"}, {Data: "second"}, {Data: "third"}},
+		},
+		{
+			name:  "event without trailing blank line at EOF",
+			input: "data: last",
+			want:  []SSEEvent{{Data: "last"}},
+		},
+		{
+			name:  "event type with data",
+			input: "event: content_block_delta\ndata: {\"delta\":\"hi\"}\n\n",
+			want:  []SSEEvent{{Event: "content_block_delta", Data: "{\"delta\":\"hi\"}"}},
+		},
+		{
+			name:  "only comments produces no events",
+			input: ": comment1\n: comment2\n\n",
+			want:  nil,
+		},
+		{
+			name:  "empty data field",
+			input: "data:\n\n",
+			want:  []SSEEvent{{Data: ""}},
+		},
+		{
+			name:  "data with no space after colon",
+			input: "data:no-space\n\n",
+			want:  []SSEEvent{{Data: "no-space"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := NewSSEParser(strings.NewReader(tt.input))
+			var got []SSEEvent
+
+			for {
+				event, err := parser.Next()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got = append(got, event)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d events, want %d", len(got), len(tt.want))
+			}
+
+			for i := range got {
+				if got[i].Event != tt.want[i].Event {
+					t.Errorf("event %d: Event got %q, want %q", i, got[i].Event, tt.want[i].Event)
+				}
+				if got[i].Data != tt.want[i].Data {
+					t.Errorf("event %d: Data got %q, want %q", i, got[i].Data, tt.want[i].Data)
+				}
+			}
+		})
+	}
+}
+
+func TestSSEParser_EOF(t *testing.T) {
+	t.Parallel()
+
+	parser := NewSSEParser(strings.NewReader(""))
+	_, err := parser.Next()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF for empty reader, got %v", err)
+	}
+}

--- a/internal/provider/stream.go
+++ b/internal/provider/stream.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+const (
+	StreamEventText      = "text"
+	StreamEventToolStart = "tool_start"
+	StreamEventToolDelta = "tool_delta"
+	StreamEventToolEnd   = "tool_end"
+	StreamEventDone      = "done"
+)
+
+type StreamEvent struct {
+	Type         string
+	Text         string
+	ToolCallID   string
+	ToolName     string
+	ToolInput    string
+	InputTokens  int
+	OutputTokens int
+	StopReason   string
+}
+
+type EventStream struct {
+	nextFunc func() (StreamEvent, error)
+	body     io.Closer
+	closed   bool
+	mu       sync.Mutex
+}
+
+func NewEventStream(body io.Closer, nextFunc func() (StreamEvent, error)) *EventStream {
+	return &EventStream{
+		body:     body,
+		nextFunc: nextFunc,
+	}
+}
+
+func (s *EventStream) Next() (StreamEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return StreamEvent{}, io.EOF
+	}
+
+	return s.nextFunc()
+}
+
+func (s *EventStream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.body.Close()
+}
+
+type StreamProvider interface {
+	Provider
+	SendStream(ctx context.Context, req *Request) (*EventStream, error)
+}

--- a/internal/provider/stream_test.go
+++ b/internal/provider/stream_test.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"io"
+	"testing"
+)
+
+func TestEventStream_NextReturnsEventsInOrderThenEOF(t *testing.T) {
+	t.Parallel()
+
+	events := []StreamEvent{
+		{Type: StreamEventText, Text: "hello"},
+		{Type: StreamEventText, Text: " world"},
+		{Type: StreamEventDone, InputTokens: 10, OutputTokens: 5, StopReason: "end_turn"},
+	}
+
+	idx := 0
+	pr, pw := io.Pipe()
+	go func() { _ = pw.Close() }()
+
+	stream := NewEventStream(pr, func() (StreamEvent, error) {
+		if idx >= len(events) {
+			return StreamEvent{}, io.EOF
+		}
+		e := events[idx]
+		idx++
+		return e, nil
+	})
+	defer func() { _ = stream.Close() }()
+
+	for i, want := range events {
+		got, err := stream.Next()
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		if got.Type != want.Type {
+			t.Errorf("event %d: got type %q, want %q", i, got.Type, want.Type)
+		}
+		if got.Text != want.Text {
+			t.Errorf("event %d: got text %q, want %q", i, got.Text, want.Text)
+		}
+		if got.InputTokens != want.InputTokens {
+			t.Errorf("event %d: got input_tokens %d, want %d", i, got.InputTokens, want.InputTokens)
+		}
+		if got.OutputTokens != want.OutputTokens {
+			t.Errorf("event %d: got output_tokens %d, want %d", i, got.OutputTokens, want.OutputTokens)
+		}
+		if got.StopReason != want.StopReason {
+			t.Errorf("event %d: got stop_reason %q, want %q", i, got.StopReason, want.StopReason)
+		}
+	}
+
+	_, err := stream.Next()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF after all events, got %v", err)
+	}
+}
+
+func TestEventStream_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	go func() { _ = pw.Close() }()
+
+	stream := NewEventStream(pr, func() (StreamEvent, error) {
+		return StreamEvent{}, io.EOF
+	})
+
+	if err := stream.Close(); err != nil {
+		t.Fatalf("first Close: unexpected error: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("second Close: unexpected error: %v", err)
+	}
+}
+
+func TestEventStream_NextAfterCloseReturnsEOF(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	go func() { _ = pw.Close() }()
+
+	called := false
+	stream := NewEventStream(pr, func() (StreamEvent, error) {
+		called = true
+		return StreamEvent{Type: StreamEventText, Text: "should not see"}, nil
+	})
+
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+
+	_, err := stream.Next()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF after Close, got %v", err)
+	}
+	if called {
+		t.Error("nextFunc should not be called after Close")
+	}
+}
+
+func TestEventStream_ToolCallEvents(t *testing.T) {
+	t.Parallel()
+
+	events := []StreamEvent{
+		{Type: StreamEventToolStart, ToolCallID: "tc_1", ToolName: "read_file"},
+		{Type: StreamEventToolDelta, ToolCallID: "tc_1", ToolInput: `{"path":"`},
+		{Type: StreamEventToolDelta, ToolCallID: "tc_1", ToolInput: `foo.txt"}`},
+		{Type: StreamEventToolEnd, ToolCallID: "tc_1"},
+		{Type: StreamEventDone, InputTokens: 20, OutputTokens: 10, StopReason: "tool_use"},
+	}
+
+	idx := 0
+	pr, pw := io.Pipe()
+	go func() { _ = pw.Close() }()
+
+	stream := NewEventStream(pr, func() (StreamEvent, error) {
+		if idx >= len(events) {
+			return StreamEvent{}, io.EOF
+		}
+		e := events[idx]
+		idx++
+		return e, nil
+	})
+	defer func() { _ = stream.Close() }()
+
+	for i, want := range events {
+		got, err := stream.Next()
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		if got.Type != want.Type {
+			t.Errorf("event %d: type got %q, want %q", i, got.Type, want.Type)
+		}
+		if got.ToolCallID != want.ToolCallID {
+			t.Errorf("event %d: tool_call_id got %q, want %q", i, got.ToolCallID, want.ToolCallID)
+		}
+		if got.ToolName != want.ToolName {
+			t.Errorf("event %d: tool_name got %q, want %q", i, got.ToolName, want.ToolName)
+		}
+		if got.ToolInput != want.ToolInput {
+			t.Errorf("event %d: tool_input got %q, want %q", i, got.ToolInput, want.ToolInput)
+		}
+	}
+}
+
+func TestStreamEventConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		constant string
+		want     string
+	}{
+		{StreamEventText, "text"},
+		{StreamEventToolStart, "tool_start"},
+		{StreamEventToolDelta, "tool_delta"},
+		{StreamEventToolEnd, "tool_end"},
+		{StreamEventDone, "done"},
+	}
+
+	for _, tt := range tests {
+		if tt.constant != tt.want {
+			t.Errorf("constant value %q != %q", tt.constant, tt.want)
+		}
+	}
+}

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -14,8 +14,9 @@ import (
 
 // MockLLMResponse represents a canned response for the mock LLM server.
 type MockLLMResponse struct {
-	StatusCode int
-	Body       string
+	StatusCode  int
+	Body        string
+	ContentType string
 }
 
 // MockLLMRequest captures an HTTP request received by the mock server.
@@ -100,9 +101,16 @@ func NewMockLLMServer(t *testing.T, responses []MockLLMResponse) *MockLLMServer 
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		ct := "application/json"
+		if resp.ContentType != "" {
+			ct = resp.ContentType
+		}
+		w.Header().Set("Content-Type", ct)
 		w.WriteHeader(resp.StatusCode)
 		_, _ = fmt.Fprint(w, resp.Body)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
 	}))
 
 	t.Cleanup(m.Server.Close)
@@ -231,6 +239,56 @@ func GeminiToolCallResponse(text string, toolCalls []MockToolCall) MockLLMRespon
 func GeminiErrorResponse(statusCode int, message string) MockLLMResponse {
 	body := fmt.Sprintf(`{"error":{"code":%d,"message":%s,"status":"ERROR"}}`, statusCode, jsonString(message))
 	return MockLLMResponse{StatusCode: statusCode, Body: body}
+}
+
+// OpenAIStreamResponse returns a MockLLMResponse with SSE-formatted OpenAI
+// streaming chunks for a text-only response.
+func OpenAIStreamResponse(text string, inputTokens, outputTokens int) MockLLMResponse {
+	var sb strings.Builder
+	for _, ch := range text {
+		chunk := fmt.Sprintf(`{"model":"gpt-4o","choices":[{"delta":{"content":%s},"index":0}]}`, jsonString(string(ch)))
+		sb.WriteString("data: " + chunk + "\n\n")
+	}
+	// finish_reason chunk
+	sb.WriteString(`data: {"model":"gpt-4o","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}` + "\n\n")
+	// usage chunk
+	usage := fmt.Sprintf(`data: {"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":%d,"completion_tokens":%d}}`, inputTokens, outputTokens)
+	sb.WriteString(usage + "\n\n")
+	sb.WriteString("data: [DONE]\n\n")
+	return MockLLMResponse{StatusCode: 200, Body: sb.String(), ContentType: "text/event-stream"}
+}
+
+// OpenAIStreamToolCallResponse returns a MockLLMResponse with SSE-formatted
+// OpenAI streaming chunks containing tool calls.
+func OpenAIStreamToolCallResponse(text string, toolCalls []MockToolCall, inputTokens, outputTokens int) MockLLMResponse {
+	var sb strings.Builder
+
+	// Text chunks (if any)
+	if text != "" {
+		chunk := fmt.Sprintf(`{"model":"gpt-4o","choices":[{"delta":{"content":%s},"index":0}]}`, jsonString(text))
+		sb.WriteString("data: " + chunk + "\n\n")
+	}
+
+	// Tool call chunks
+	for i, tc := range toolCalls {
+		argsJSON, _ := json.Marshal(tc.Input)
+
+		// tool_start: ID + function name
+		startChunk := fmt.Sprintf(`{"model":"gpt-4o","choices":[{"delta":{"tool_calls":[{"index":%d,"id":%s,"type":"function","function":{"name":%s,"arguments":""}}]},"index":0}]}`, i, jsonString(tc.ID), jsonString(tc.Name))
+		sb.WriteString("data: " + startChunk + "\n\n")
+
+		// tool_delta: arguments
+		deltaChunk := fmt.Sprintf(`{"model":"gpt-4o","choices":[{"delta":{"tool_calls":[{"index":%d,"function":{"arguments":%s}}]},"index":0}]}`, i, jsonString(string(argsJSON)))
+		sb.WriteString("data: " + deltaChunk + "\n\n")
+	}
+
+	// finish_reason chunk
+	sb.WriteString(`data: {"model":"gpt-4o","choices":[{"delta":{},"index":0,"finish_reason":"tool_calls"}]}` + "\n\n")
+	// usage chunk
+	usage := fmt.Sprintf(`data: {"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":%d,"completion_tokens":%d}}`, inputTokens, outputTokens)
+	sb.WriteString(usage + "\n\n")
+	sb.WriteString("data: [DONE]\n\n")
+	return MockLLMResponse{StatusCode: 200, Body: sb.String(), ContentType: "text/event-stream"}
 }
 
 // jsonString returns a JSON-encoded string value (with quotes and escaping).

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -241,8 +241,6 @@ func GeminiErrorResponse(statusCode int, message string) MockLLMResponse {
 	return MockLLMResponse{StatusCode: statusCode, Body: body}
 }
 
-// OpenAIStreamResponse returns a MockLLMResponse with SSE-formatted OpenAI
-// streaming chunks for a text-only response.
 // AnthropicStreamResponse returns a MockLLMResponse with SSE-formatted
 // Anthropic streaming events for a text-only response.
 func AnthropicStreamResponse(text string, inputTokens, outputTokens int) MockLLMResponse {

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -247,13 +247,13 @@ func GeminiErrorResponse(statusCode int, message string) MockLLMResponse {
 // Anthropic streaming events for a text-only response.
 func AnthropicStreamResponse(text string, inputTokens, outputTokens int) MockLLMResponse {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_mock\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":%d,\"output_tokens\":0}}}\n\n", inputTokens))
+	fmt.Fprintf(&sb, "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_mock\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":%d,\"output_tokens\":0}}}\n\n", inputTokens)
 	sb.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
 	for _, ch := range text {
-		sb.WriteString(fmt.Sprintf("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":%s}}\n\n", jsonString(string(ch))))
+		fmt.Fprintf(&sb, "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":%s}}\n\n", jsonString(string(ch)))
 	}
 	sb.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
-	sb.WriteString(fmt.Sprintf("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":%d}}\n\n", outputTokens))
+	fmt.Fprintf(&sb, "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":%d}}\n\n", outputTokens)
 	sb.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
 	return MockLLMResponse{StatusCode: 200, Body: sb.String(), ContentType: "text/event-stream"}
 }

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -243,6 +243,21 @@ func GeminiErrorResponse(statusCode int, message string) MockLLMResponse {
 
 // OpenAIStreamResponse returns a MockLLMResponse with SSE-formatted OpenAI
 // streaming chunks for a text-only response.
+// AnthropicStreamResponse returns a MockLLMResponse with SSE-formatted
+// Anthropic streaming events for a text-only response.
+func AnthropicStreamResponse(text string, inputTokens, outputTokens int) MockLLMResponse {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_mock\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-20250514\",\"usage\":{\"input_tokens\":%d,\"output_tokens\":0}}}\n\n", inputTokens))
+	sb.WriteString("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+	for _, ch := range text {
+		sb.WriteString(fmt.Sprintf("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":%s}}\n\n", jsonString(string(ch))))
+	}
+	sb.WriteString("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+	sb.WriteString(fmt.Sprintf("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":%d}}\n\n", outputTokens))
+	sb.WriteString("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+	return MockLLMResponse{StatusCode: 200, Body: sb.String(), ContentType: "text/event-stream"}
+}
+
 func OpenAIStreamResponse(text string, inputTokens, outputTokens int) MockLLMResponse {
 	var sb strings.Builder
 	for _, ch := range text {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Adds end-to-end response streaming across the CLI and providers. Introduces a CLI --stream flag and an agent config option, a streaming abstraction and SSE parser, provider SendStream implementations (OpenAI, Anthropic, Gemini, Ollama, OpenCode) plus retry-wrapper support, and run-command plumbing to prefer streaming when available. Implements a drainEventStream helper that assembles final responses from streamed events, preserves JSON buffering and incremental stdout output, and adds comprehensive unit and integration tests and mock-server helpers to validate streaming behavior and error handling.

## Changelog

### Added
- CLI `--stream` flag for the `run` command.
- `Stream bool` field on AgentConfig (TOML tag `stream`) and scaffold documentation.
- Streaming abstraction and types:
  - `StreamProvider` interface.
  - `EventStream` type and stream event constants (`StreamEventText`, `StreamEventToolStart`, `StreamEventToolDelta`, `StreamEventToolEnd`, `StreamEventDone`).
- SSE parsing utilities: `SSEParser` and `SSEEvent`.
- Provider streaming implementations: `SendStream()` for OpenAI, Anthropic, Gemini, Ollama, OpenCode.
- Retry wrapper streaming support: `RetryProvider.SupportsStream()` and `RetryProvider.SendStream()`.
- CLI plumbing:
  - `--stream` resolution (agent config or flag override).
  - Routing to provider streaming path when enabled.
  - `drainEventStream(stream *provider.EventStream, w io.Writer)` helper to consume events, emit incremental text, reconstruct tool calls, and synthesize a final `provider.Response`.
- Test & tooling:
  - Extensive unit tests for providers, SSE parsing, stream abstraction, and run streaming flows.
  - Integration tests exercising end-to-end streaming and JSON buffering.
  - Mock server helpers for streamed responses (Anthropic/OpenAI streaming helpers).
- Dry-run output now includes resolved stream mode.

### Changed
- `printDryRun()` signature updated to accept `streamEnabled`; golden dry-run fixtures updated to display `Stream: no`.
- run command resolves streaming preference from agent config or explicit `--stream` flag (flag overrides config).
- When streaming is enabled and supported by the provider, run prefers `SendStream()` and funnels events through `drainEventStream`; if the (retry-wrapped) provider does not support streaming, streaming is disabled/falls back to non-streaming.
- Streaming requests bypass retry loops; retry wrapper delegates directly to inner provider when it supports streaming and returns a bad-request error when it does not.
- Verbose logging enhanced to distinguish streaming vs non-streaming requests and to label completion messages (“Stream complete” vs “Received response”).
- Mock server response helpers now support configurable Content-Type and call Flush to enable streamed responses.
- Test helpers updated to reset the `--stream` flag and its Changed state between tests.

### Fixed
- `Fix drainEventStream to capture ToolInput from StreamEventToolStart` (commit-level fix adjusting stream draining behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->