### PR TITLE
Fix: Mask URLs in Command Path Validation

### DIFF
--- a/docs/plans/GAI-5223_url_path_validation_implement.md
+++ b/docs/plans/GAI-5223_url_path_validation_implement.md
@@ -1,0 +1,36 @@
+# GAI-5223: URL Path Validation — Implementation Guide
+
+**Spec:** [docs/plans/GAI-5223_url_path_validation_spec.md](GAI-5223_url_path_validation_spec.md)
+
+---
+
+## Section 1: Context Summary
+
+The `run_command` tool's `validateCommand()` function uses a regex to find absolute paths in shell commands and rejects any that fall outside the workdir. This regex also matches URL path segments (e.g., `/api/v2/data` from `https://example.com/api/v2/data`), causing legitimate HTTP requests to be rejected. The fix masks HTTP/HTTPS URLs before the absolute-path scan so their path components are invisible to the check, while preserving all existing sandbox protections for real filesystem paths, `/dev/*` allowlisting, tilde expansion, and `..` traversal detection.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Implementation (can run in parallel with tests)
+
+- [x] **Add URL regex** — `internal/tool/command_validation.go`: Add a package-level `var urlRe` compiled regex matching `https?://` followed by one or more non-whitespace, non-quote (single, double, backtick) characters. Place it alongside the existing `absPathRe`, `dotDotRe`, and `tildeRe` declarations (lines 8–20).
+
+- [x] **Mask URLs before absolute-path scan** — `internal/tool/command_validation.go: validateCommand()`: Before the `absPathRe.FindAllString(command, -1)` call (line 74), create a masked copy of `command` where all `urlRe` matches are replaced with underscore characters of equal length. Pass the masked string to `absPathRe.FindAllString` instead of the raw `command`. Do not change the input to the tilde or `..` checks — they must continue using the original `command`.
+
+### Tests (can run in parallel with implementation)
+
+- [x] **Test URL-only commands pass** — `internal/tool/command_validation_test.go`: Add `TestValidateCommand_URLPathsAllowed` with table-driven subtests:
+  - `"curl https://api.example.com/api/v2/data"` → `nil`
+  - `"curl http://localhost:8080/graphql"` → `nil`
+  - `"node -e 'fetch(\"https://youtube.com/api/v2/transcripts\")'"` → `nil`
+
+- [x] **Test mixed URL + bad filesystem path** — `internal/tool/command_validation_test.go`: Add `TestValidateCommand_URLWithBadFilesystemPath` asserting `"curl https://example.com/api/v2 > /tmp/out"` returns an error containing `"absolute path"` and `"/tmp/out"`.
+
+- [x] **Test non-HTTP scheme not masked** — `internal/tool/command_validation_test.go`: Add `TestValidateCommand_NonHTTPSchemeNotMasked` asserting `"curl ftp://example.com/etc/passwd"` returns an error containing `"absolute path"`.
+
+- [x] **Test URL with sensitive-looking path passes** — `internal/tool/command_validation_test.go`: Add `TestValidateCommand_URLWithSensitivePath` asserting `"curl https://example.com/etc/passwd"` returns `nil`.
+
+### Verification
+
+- [x] **Run full test suite** — Execute `go test ./internal/tool/...` and confirm all existing tests pass alongside new tests. Zero test modifications to existing tests.

--- a/docs/plans/GAI-5223_url_path_validation_spec.md
+++ b/docs/plans/GAI-5223_url_path_validation_spec.md
@@ -1,0 +1,92 @@
+# GAI-5223: URL Path Segments Must Not Trigger Command Sandbox Rejection
+
+**Linear issue:** https://linear.app/gloo/issue/GAI-5223/unblock-external-api-calls-to-apiv
+
+---
+
+## Section 1: Context & Constraints
+
+### Codebase Structure
+
+- `internal/tool/command_validation.go` contains `validateCommand()`, the sole heuristic guard for the `run_command` tool.
+- `validateCommand` is called from exactly one place: `internal/tool/run_command.go:75`.
+- The absolute-path check uses `absPathRe` (line 12): `(/[\w./_-]*)` — it matches any `/` followed by path characters.
+- After matching, each candidate is checked via `isWithinDir(cleanPath, cleanWorkdir)`. Paths outside the workdir are rejected.
+- `internal/tool/path_validation.go` (`validatePath`) is a separate code path used by file tools (`read_file`, `write_file`, `edit_file`, `list_directory`). It is not affected by this change.
+
+### The Problem
+
+When a command contains a URL (e.g., `curl https://api.youtube.com/api/v2/transcripts`), `absPathRe` extracts the URL's path segment (`/api/v2/transcripts`) and `isWithinDir` rejects it because it is not inside the workdir. The validator cannot distinguish a URL path from a filesystem path.
+
+The existing test `TestValidateCommand_QuotedAbsolutePathRejected` (line 340) documents this class of false positive as "known conservative."
+
+### Decisions Already Made
+
+- The command validator is explicitly documented as heuristic, not airtight (see docstring lines 22–31).
+- `/dev/*` paths are already allowlisted (line 82–84).
+- The `sandboxEnv` function strips environment variables and sets `HOME`/`TMPDIR` to workdir, limiting what a URL-shaped string could do even if it somehow became a file operation.
+
+### Approaches Ruled Out
+
+- **Full shell parsing:** Shell is Turing-complete; the docstring already acknowledges this. Not worth the complexity.
+- **Allowlisting specific URL hostnames:** Too brittle; doesn't scale.
+- **Removing the absolute path check entirely:** Would remove a real safety guard for filesystem paths.
+
+### Constraints
+
+- The fix must not weaken the sandbox for actual filesystem absolute paths.
+- The tilde (`~`) and `..` traversal checks operate on the raw command string and must continue to do so (URLs do not trigger these patterns).
+- `absPathRe` is used in exactly one place (line 74). The masking only needs to affect the input to that one `FindAllString` call.
+
+---
+
+## Section 2: Requirements
+
+### R1: URL Masking Before Absolute-Path Scan
+
+Before `absPathRe.FindAllString` is called, HTTP/HTTPS URLs in the command string must be replaced with inert placeholder characters so their path segments are not scanned.
+
+- A URL is defined as: `https?://` followed by one or more non-whitespace, non-quote characters (single quote, double quote, backtick).
+- The replacement must preserve string length (same number of characters) so that no positional side effects occur if future logic ever depends on match indices.
+- Only the `absPathRe` scan uses the masked string. The tilde check and `..` traversal check must continue to operate on the original, unmasked command string.
+
+### R2: Existing Filesystem Path Rejection Must Be Preserved
+
+Commands containing actual filesystem absolute paths outside the workdir must still be rejected, even if the command also contains URLs.
+
+**Example:** `curl https://example.com/api/v2 > /tmp/out` — the URL is allowed, but `/tmp/out` must still be rejected.
+
+### R3: Existing Allowlists Must Be Preserved
+
+- `/dev/*` paths must remain allowed.
+- Paths inside the workdir must remain allowed.
+- Root workdir (`/`) must continue to allow all absolute paths.
+
+### R4: Edge Cases
+
+| Input | Expected |
+|---|---|
+| `curl https://api.example.com/api/v2/data` | Pass (URL path masked) |
+| `curl http://localhost:8080/graphql` | Pass (URL path masked) |
+| `node -e 'fetch("https://youtube.com/api/v2/transcripts")'` | Pass (URL inside quotes, still masked) |
+| `curl https://example.com/api/v2 > /tmp/out` | Fail on `/tmp/out` (URL masked, filesystem path still caught) |
+| `cat /etc/passwd` | Fail (no URL, unchanged behavior) |
+| `echo hello > /dev/null` | Pass (allowlisted, unchanged behavior) |
+| `curl ftp://example.com/etc/passwd` | Fail on `/etc/passwd` (only `http://` and `https://` are masked) |
+| `curl https://example.com/etc/passwd` | Pass (the `/etc/passwd` is part of the URL, not a filesystem access) |
+| `cat ../../etc/passwd` | Fail (traversal check, unchanged behavior) |
+| `cat ~/secrets` | Fail (tilde check, unchanged behavior) |
+
+### R5: Test Coverage
+
+New test cases must cover:
+1. URL-only commands that previously failed (R4 rows 1–3) — must now pass.
+2. Mixed URL + bad filesystem path (R4 row 4) — URL passes, filesystem path still rejected.
+3. Non-HTTP scheme URLs are not masked (R4 row 7) — `ftp://` path segments still scanned.
+4. URL containing a path that looks like a sensitive filesystem path (R4 row 8) — must pass because it's inside a URL.
+
+All existing tests must continue to pass without modification.
+
+### Parallelism
+
+R1 (implementation) and R5 (tests) can be developed in parallel since the test cases are fully specified above. The tests will initially fail (red) until R1 is applied (green).

--- a/internal/tool/command_validation.go
+++ b/internal/tool/command_validation.go
@@ -12,8 +12,9 @@ import (
 var absPathRe = regexp.MustCompile(`(/[\w./_-]*)`)
 
 // Regex to match HTTP/HTTPS URLs so their path segments can be masked before the
-// absolute-path scan. Matches the scheme through the first whitespace or quote character.
-var urlRe = regexp.MustCompile(`https?://[^\s'` + "`" + `"]+`)
+// absolute-path scan. Stops at whitespace, quotes, and shell metacharacters so
+// redirections like >/tmp/out are not swallowed into the URL match.
+var urlRe = regexp.MustCompile(`https?://[^\s'` + "`" + `";<>|&()]+`)
 
 // Regex to match .. as a path component (not inside a filename like file..bak)
 // Matches: standalone "..", "../something", "something/..", "something/../other"

--- a/internal/tool/command_validation.go
+++ b/internal/tool/command_validation.go
@@ -11,6 +11,10 @@ import (
 // Regex to match absolute paths: / followed by one or more path characters
 var absPathRe = regexp.MustCompile(`(/[\w./_-]*)`)
 
+// Regex to match HTTP/HTTPS URLs so their path segments can be masked before the
+// absolute-path scan. Matches the scheme through the first whitespace or quote character.
+var urlRe = regexp.MustCompile(`https?://[^\s'` + "`" + `"]+`)
+
 // Regex to match .. as a path component (not inside a filename like file..bak)
 // Matches: standalone "..", "../something", "something/..", "something/../other"
 var dotDotRe = regexp.MustCompile(`(?:^|/)\.\.(?:/|$)`)
@@ -68,10 +72,15 @@ func validateCommand(workdir, command string) error {
 		}
 	}
 
+	// Mask HTTP/HTTPS URLs so their path segments are not mistaken for filesystem paths
+	masked := urlRe.ReplaceAllStringFunc(command, func(match string) string {
+		return strings.Repeat("_", len(match))
+	})
+
 	// Check for absolute paths outside workdir
 	// Skip tokens that contain ".." as they were already handled above
 	// Allow /dev/ paths (device files are system resources, not file system traversal)
-	matches := absPathRe.FindAllString(command, -1)
+	matches := absPathRe.FindAllString(masked, -1)
 	for _, match := range matches {
 		// Skip if this match is part of a parent traversal
 		if strings.Contains(match, "..") {

--- a/internal/tool/command_validation_test.go
+++ b/internal/tool/command_validation_test.go
@@ -332,6 +332,64 @@ func TestValidateCommand_CompoundCommandOneBad(t *testing.T) {
 	}
 }
 
+func TestValidateCommand_URLPathsAllowed(t *testing.T) {
+	workdir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"https URL with path", `curl https://api.example.com/api/v2/data`},
+		{"http localhost URL", `curl http://localhost:8080/graphql`},
+		{"URL inside quotes", `node -e 'fetch("https://youtube.com/api/v2/transcripts")'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCommand(workdir, tt.command)
+			if err != nil {
+				t.Errorf("expected nil error for command %q, got: %v", tt.command, err)
+			}
+		})
+	}
+}
+
+func TestValidateCommand_URLWithBadFilesystemPath(t *testing.T) {
+	workdir := t.TempDir()
+
+	err := validateCommand(workdir, `curl https://example.com/api/v2 > /tmp/out`)
+	if err == nil {
+		t.Fatal("expected error for mixed URL + bad filesystem path, got nil")
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("error should contain 'absolute path', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/tmp/out") {
+		t.Errorf("error should mention '/tmp/out', got: %v", err)
+	}
+}
+
+func TestValidateCommand_NonHTTPSchemeNotMasked(t *testing.T) {
+	workdir := t.TempDir()
+
+	err := validateCommand(workdir, `curl ftp://example.com/etc/passwd`)
+	if err == nil {
+		t.Fatal("expected error for non-HTTP scheme URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("error should contain 'absolute path', got: %v", err)
+	}
+}
+
+func TestValidateCommand_URLWithSensitivePath(t *testing.T) {
+	workdir := t.TempDir()
+
+	err := validateCommand(workdir, `curl https://example.com/etc/passwd`)
+	if err != nil {
+		t.Errorf("expected nil error for URL containing sensitive-looking path, got: %v", err)
+	}
+}
+
 func TestValidateCommand_QuotedAbsolutePathRejected(t *testing.T) {
 	workdir := t.TempDir()
 

--- a/internal/tool/command_validation_test.go
+++ b/internal/tool/command_validation_test.go
@@ -332,61 +332,33 @@ func TestValidateCommand_CompoundCommandOneBad(t *testing.T) {
 	}
 }
 
-func TestValidateCommand_URLPathsAllowed(t *testing.T) {
+func TestValidateCommand_URLs(t *testing.T) {
 	workdir := t.TempDir()
 
 	tests := []struct {
 		name    string
 		command string
+		wantErr bool
 	}{
-		{"https URL with path", `curl https://api.example.com/api/v2/data`},
-		{"http localhost URL", `curl http://localhost:8080/graphql`},
-		{"URL inside quotes", `node -e 'fetch("https://youtube.com/api/v2/transcripts")'`},
+		{"https URL with path", `curl https://api.example.com/api/v2/data`, false},
+		{"http localhost URL", `curl http://localhost:8080/graphql`, false},
+		{"URL inside quotes", `node -e 'fetch("https://youtube.com/api/v2/transcripts")'`, false},
+		{"URL with sensitive-looking path", `curl https://example.com/etc/passwd`, false},
+		{"URL then spaced redirect to bad path", `curl https://example.com/api/v2 > /tmp/out`, true},
+		{"no-space redirect after URL", `curl https://example.com/api>/tmp/out`, true},
+		{"ftp scheme not masked", `curl ftp://example.com/etc/passwd`, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateCommand(workdir, tt.command)
-			if err != nil {
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for command %q, got nil", tt.command)
+			}
+			if !tt.wantErr && err != nil {
 				t.Errorf("expected nil error for command %q, got: %v", tt.command, err)
 			}
 		})
-	}
-}
-
-func TestValidateCommand_URLWithBadFilesystemPath(t *testing.T) {
-	workdir := t.TempDir()
-
-	err := validateCommand(workdir, `curl https://example.com/api/v2 > /tmp/out`)
-	if err == nil {
-		t.Fatal("expected error for mixed URL + bad filesystem path, got nil")
-	}
-	if !strings.Contains(err.Error(), "absolute path") {
-		t.Errorf("error should contain 'absolute path', got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "/tmp/out") {
-		t.Errorf("error should mention '/tmp/out', got: %v", err)
-	}
-}
-
-func TestValidateCommand_NonHTTPSchemeNotMasked(t *testing.T) {
-	workdir := t.TempDir()
-
-	err := validateCommand(workdir, `curl ftp://example.com/etc/passwd`)
-	if err == nil {
-		t.Fatal("expected error for non-HTTP scheme URL, got nil")
-	}
-	if !strings.Contains(err.Error(), "absolute path") {
-		t.Errorf("error should contain 'absolute path', got: %v", err)
-	}
-}
-
-func TestValidateCommand_URLWithSensitivePath(t *testing.T) {
-	workdir := t.TempDir()
-
-	err := validateCommand(workdir, `curl https://example.com/etc/passwd`)
-	if err != nil {
-		t.Errorf("expected nil error for URL containing sensitive-looking path, got: %v", err)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
This PR updates command path validation to mask HTTP/HTTPS URLs before scanning for absolute filesystem paths. URLs are replaced with underscore sequences of the same length so path-like segments inside URLs (e.g., /etc/passwd) are not misinterpreted as absolute paths, reducing false positives while preserving existing checks for tilde expansion and parent traversal.

## Changelog

### Added
- URL detection regex pattern (`urlRe`) to identify HTTP/HTTPS URLs in command strings.
- URL masking step in `validateCommand` that replaces matched URL substrings with underscores before running absolute-path detection.
- Tests exercising URL handling in command validation (including URLs with path-like segments, URLs embedded in quoted code, non-HTTP(S) schemes, and URL + redirection edge cases).

### Changed
- Absolute path detection now operates on the masked command string rather than the raw command, so URL path components are no longer treated as filesystem absolute paths.

### Fixed
- False positives where HTTP/HTTPS URL path segments were flagged as absolute filesystem paths are prevented by masking prior to validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->