### PR TITLE
Add structured output support for Ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Agents are defined as TOML files in `$XDG_CONFIG_HOME/axe/agents/`.
 name = "pr-reviewer"
 description = "Reviews pull requests for issues and improvements"
 model = "anthropic/claude-sonnet-4-20250514"
-format = "json"  # optional, Ollama only
+format = "json"  # optional, supported by most providers
 system_prompt = "You are a senior code reviewer. Be concise and actionable."
 skill = "skills/code-review/SKILL.md"
 files = ["src/**/*.go", "CONTRIBUTING.md"]

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Agents are defined as TOML files in `$XDG_CONFIG_HOME/axe/agents/`.
 name = "pr-reviewer"
 description = "Reviews pull requests for issues and improvements"
 model = "anthropic/claude-sonnet-4-20250514"
+format = "json"  # optional, Ollama only
 system_prompt = "You are a senior code reviewer. Be concise and actionable."
 skill = "skills/code-review/SKILL.md"
 files = ["src/**/*.go", "CONTRIBUTING.md"]

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -79,6 +79,13 @@ var agentsShowCmd = &cobra.Command{
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "Description:", cfg.Description)
 		}
 		_, _ = fmt.Fprintf(w, "%-16s%s\n", "Model:", cfg.Model)
+		if cfg.Format != nil {
+			if fstr, ok := cfg.Format.(string); ok {
+				_, _ = fmt.Fprintf(w, "%-16s%s\n", "Format:", fstr)
+			} else {
+				_, _ = fmt.Fprintf(w, "%-16s%s\n", "Format:", "JSON Schema")
+			}
+		}
 		if cfg.SystemPrompt != "" {
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "System Prompt:", cfg.SystemPrompt)
 		}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -168,6 +168,7 @@ func TestAgentsShow_ValidAgent(t *testing.T) {
 	toml := `name = "full"
 description = "A full agent"
 model = "anthropic/claude-sonnet-4-20250514"
+format = "json"
 system_prompt = "You are helpful."
 skill = "skills/sample/SKILL.md"
 files = ["src/**/*.go", "README.md"]
@@ -202,6 +203,8 @@ max_tokens = 4096
 		"A full agent",
 		"Model:",
 		"anthropic/claude-sonnet-4-20250514",
+		"Format:",
+		"json",
 		"System Prompt:",
 		"You are helpful.",
 		"Skill:",
@@ -314,7 +317,7 @@ func TestAgentsShow_MinimalAgent(t *testing.T) {
 		t.Error("show output missing Model field")
 	}
 	// Optional fields should NOT appear
-	for _, absent := range []string{"Description:", "System Prompt:", "Skill:", "Files:", "Workdir:", "Sub-Agents:", "Memory Enabled:", "Memory Path:", "Memory LastN:", "Memory MaxEntries:", "Temperature:", "Max Tokens:"} {
+	for _, absent := range []string{"Description:", "Format:", "System Prompt:", "Skill:", "Files:", "Workdir:", "Sub-Agents:", "Memory Enabled:", "Memory Path:", "Memory LastN:", "Memory MaxEntries:", "Temperature:", "Max Tokens:"} {
 		if strings.Contains(output, absent) {
 			t.Errorf("show output should not contain %q for minimal agent\nfull output:\n%s", absent, output)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -391,6 +391,13 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		streamEnabled = false
 	}
 
+	if cfg.Format != nil && provName != "ollama" {
+		return &ExitError{
+			Code: 2,
+			Err:  fmt.Errorf("format is only supported with provider %q; remove format or switch model provider", "ollama"),
+		}
+	}
+
 	// Step 16: Build request
 	req := &provider.Request{
 		Model:       modelName,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -398,6 +398,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		Messages:    []provider.Message{{Role: "user", Content: userMessage}},
 		Temperature: cfg.Params.Temperature,
 		MaxTokens:   cfg.Params.MaxTokens,
+		Format:      cfg.Format,
 	}
 
 	// Step 16b: Create tool registry and resolve configured tools

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -391,10 +391,24 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		streamEnabled = false
 	}
 
-	if cfg.Format != nil && provName != "ollama" {
-		return &ExitError{
-			Code: 2,
-			Err:  fmt.Errorf("format is only supported with provider %q; remove format or switch model provider", "ollama"),
+	var reqFormat *provider.ResponseFormat
+	if cfg.Format != nil {
+		reqFormat = &provider.ResponseFormat{}
+		switch v := cfg.Format.(type) {
+		case string:
+			if v == "json" {
+				reqFormat.Type = provider.FormatJSON
+			}
+		case map[string]interface{}:
+			reqFormat.Type = provider.FormatSchema
+			reqFormat.Schema = v
+		}
+
+		if reqFormat.Type != provider.FormatNone && !retryProv.SupportsFormat(reqFormat) {
+			return &ExitError{
+				Code: 2,
+				Err:  fmt.Errorf("provider %q does not support the requested structured output format; remove format or switch model provider", provName),
+			}
 		}
 	}
 
@@ -405,7 +419,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 		Messages:    []provider.Message{{Role: "user", Content: userMessage}},
 		Temperature: cfg.Params.Temperature,
 		MaxTokens:   cfg.Params.MaxTokens,
-		Format:      cfg.Format,
+		Format:      reqFormat,
 	}
 
 	// Step 16b: Create tool registry and resolve configured tools

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -126,16 +126,18 @@ model = "fakeprovider/some-model"`,
 			wantSubstrs: []string{`unsupported provider "fakeprovider"`, "anthropic, openai, ollama"},
 		},
 		{
-			name:      "format requires ollama",
-			agentName: "format-agent",
-			agentToml: `name = "format-agent"
-model = "openai/gpt-4o"
+			name:      "unsupported format",
+			agentName: "unsupported-format",
+			agentToml: `name = "unsupported-format"
+model = "bedrock/anthropic.claude-v2"
 format = "json"`,
 			envSetup: func(t *testing.T) {
-				t.Setenv("OPENAI_API_KEY", "dummy")
+				t.Setenv("AWS_REGION", "us-east-1")
+				t.Setenv("AWS_ACCESS_KEY_ID", "dummy")
+				t.Setenv("AWS_SECRET_ACCESS_KEY", "dummy")
 			},
 			wantCode:    2,
-			wantSubstrs: []string{`format is only supported with provider "ollama"`},
+			wantSubstrs: []string{`provider "bedrock" does not support the requested structured output format`},
 		},
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -145,6 +145,37 @@ model = "fakeprovider/some-model"
 	}
 }
 
+func TestRun_FormatRequiresOllamaProvider(t *testing.T) {
+	resetRunCmd(t)
+	setupRunTestAgent(t, "format-agent", `name = "format-agent"
+model = "openai/gpt-4o"
+format = "json"
+`)
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "format-agent"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for format on unsupported provider, got nil")
+	}
+	
+	exitErr, ok := err.(*ExitError)
+	if !ok {
+		t.Fatalf("expected *ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Code != 2 {
+		t.Errorf("expected exit code 2, got %d", exitErr.Code)
+	}
+	if !strings.Contains(err.Error(), `format is only supported with provider "ollama"`) {
+		t.Errorf("expected format unsupported error, got: %v", err)
+	}
+}
+
 // --- Phase 11c: Config Loading and Overrides ---
 
 func TestRun_MissingAgent(t *testing.T) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -100,82 +100,80 @@ func TestRun_NoArgs(t *testing.T) {
 
 // --- Phase 11b: Model Parsing and Provider Validation ---
 
-func TestRun_InvalidModelFormat(t *testing.T) {
-	resetRunCmd(t)
-	setupRunTestAgent(t, "badmodel", `name = "badmodel"
-model = "noprefix"
-`)
-
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"run", "badmodel"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for invalid model format, got nil")
-	}
-	if !strings.Contains(err.Error(), "invalid model format") {
-		t.Errorf("expected 'invalid model format' error, got: %v", err)
-	}
-}
-
-func TestRun_UnsupportedProvider(t *testing.T) {
-	resetRunCmd(t)
-	setupRunTestAgent(t, "fakeprov-agent", `name = "fakeprov-agent"
-model = "fakeprovider/some-model"
-`)
-
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"run", "fakeprov-agent"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for unsupported provider, got nil")
-	}
-	if !strings.Contains(err.Error(), `unsupported provider "fakeprovider"`) {
-		t.Errorf("expected 'unsupported provider' error, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "anthropic, openai, ollama") {
-		t.Errorf("expected supported providers list, got: %v", err)
-	}
-}
-
-func TestRun_FormatRequiresOllamaProvider(t *testing.T) {
-	resetRunCmd(t)
-	setupRunTestAgent(t, "format-agent", `name = "format-agent"
+func TestRun_ProviderConfigValidation(t *testing.T) {
+	cases := []struct {
+		name        string
+		agentName   string
+		agentToml   string
+		envSetup    func(t *testing.T)
+		wantCode    int
+		wantSubstrs []string
+	}{
+		{
+			name:      "invalid model format",
+			agentName: "badmodel",
+			agentToml: `name = "badmodel"
+model = "noprefix"`,
+			wantCode:    1,
+			wantSubstrs: []string{"invalid model format"},
+		},
+		{
+			name:      "unsupported provider",
+			agentName: "fakeprov",
+			agentToml: `name = "fakeprov"
+model = "fakeprovider/some-model"`,
+			wantCode:    1,
+			wantSubstrs: []string{`unsupported provider "fakeprovider"`, "anthropic, openai, ollama"},
+		},
+		{
+			name:      "format requires ollama",
+			agentName: "format-agent",
+			agentToml: `name = "format-agent"
 model = "openai/gpt-4o"
-format = "json"
-`)
-	t.Setenv("OPENAI_API_KEY", "dummy")
+format = "json"`,
+			envSetup: func(t *testing.T) {
+				t.Setenv("OPENAI_API_KEY", "dummy")
+			},
+			wantCode:    2,
+			wantSubstrs: []string{`format is only supported with provider "ollama"`},
+		},
+	}
 
-	buf := new(bytes.Buffer)
-	errBuf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"run", "format-agent"})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetRunCmd(t)
+			setupRunTestAgent(t, tc.agentName, tc.agentToml)
+			if tc.envSetup != nil {
+				tc.envSetup(t)
+			}
 
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for format on unsupported provider, got nil")
-	}
-	
-	exitErr, ok := err.(*ExitError)
-	if !ok {
-		t.Fatalf("expected *ExitError, got %T: %v", err, err)
-	}
-	if exitErr.Code != 2 {
-		t.Errorf("expected exit code 2, got %d", exitErr.Code)
-	}
-	if !strings.Contains(err.Error(), `format is only supported with provider "ollama"`) {
-		t.Errorf("expected format unsupported error, got: %v", err)
+			buf := new(bytes.Buffer)
+			errBuf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(errBuf)
+			rootCmd.SetArgs([]string{"run", tc.agentName})
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			exitErr, ok := err.(*ExitError)
+			if !ok {
+				t.Fatalf("expected *ExitError, got %T: %v", err, err)
+			}
+			if exitErr.Code != tc.wantCode {
+				t.Errorf("expected exit code %d, got %d", tc.wantCode, exitErr.Code)
+			}
+
+			for _, wantSubstr := range tc.wantSubstrs {
+				if !strings.Contains(err.Error(), wantSubstr) {
+					t.Errorf("expected error containing %q, got: %v", wantSubstr, err.Error())
+				}
+			}
+		})
 	}
 }
-
 // --- Phase 11c: Config Loading and Overrides ---
 
 func TestRun_MissingAgent(t *testing.T) {

--- a/docs/design/agent-config-schema.md
+++ b/docs/design/agent-config-schema.md
@@ -11,6 +11,9 @@ description = "Reviews pull requests for style and correctness"
 # Full provider/model per models.dev
 model = "anthropic/claude-sonnet-4-20250514"
 
+# Structured output (optional, Ollama only)
+# format = "json"
+
 # Agent persona — reusable across skills
 system_prompt = """
 You are a senior code reviewer. Be concise, actionable,

--- a/docs/design/agent-config-schema.md
+++ b/docs/design/agent-config-schema.md
@@ -11,7 +11,7 @@ description = "Reviews pull requests for style and correctness"
 # Full provider/model per models.dev
 model = "anthropic/claude-sonnet-4-20250514"
 
-# Structured output (optional, Ollama only)
+# Structured output (optional, supported by most providers)
 # format = "json"
 
 # Agent persona — reusable across skills

--- a/docs/src/configuration/agent-config.md
+++ b/docs/src/configuration/agent-config.md
@@ -8,6 +8,7 @@ All fields except `name` and `model` are optional.
 name = "pr-reviewer"
 description = "Reviews pull requests for issues and improvements"
 model = "anthropic/claude-sonnet-4-20250514"
+format = "json"  # optional, Ollama only
 system_prompt = "You are a senior code reviewer. Be concise and actionable."
 skill = "skills/code-review/SKILL.md"
 files = ["src/**/*.go", "CONTRIBUTING.md"]

--- a/docs/src/configuration/agent-config.md
+++ b/docs/src/configuration/agent-config.md
@@ -8,7 +8,7 @@ All fields except `name` and `model` are optional.
 name = "pr-reviewer"
 description = "Reviews pull requests for issues and improvements"
 model = "anthropic/claude-sonnet-4-20250514"
-format = "json"  # optional, Ollama only
+format = "json"  # optional, supported by most providers
 system_prompt = "You are a senior code reviewer. Be concise and actionable."
 skill = "skills/code-review/SKILL.md"
 files = ["src/**/*.go", "CONTRIBUTING.md"]

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -340,6 +340,9 @@ description = ""
 # Full provider/model per models.dev
 model = "provider/model-name"
 
+# Structured output (optional, Ollama only)
+# format = "json"
+
 # Agent persona (optional)
 # system_prompt = ""
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -423,4 +423,3 @@ func BuildSearchDirs(flagDir string, baseDir string) []string {
 
 // tomlDecode is a package-level wrapper for toml.Decode, used by tests.
 var tomlDecode = toml.Decode
-Decode

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -340,7 +340,7 @@ description = ""
 # Full provider/model per models.dev
 model = "provider/model-name"
 
-# Structured output (optional, Ollama only)
+# Structured output (optional, supported by most providers)
 # format = "json"
 
 # Agent persona (optional)
@@ -423,3 +423,4 @@ func BuildSearchDirs(flagDir string, baseDir string) []string {
 
 // tomlDecode is a package-level wrapper for toml.Decode, used by tests.
 var tomlDecode = toml.Decode
+Decode

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -186,6 +186,19 @@ func Validate(cfg *AgentConfig) error {
 		return &ValidationError{msg: "artifacts.dir must not contain path traversal sequences"}
 	}
 
+	if cfg.Format != nil {
+		switch v := cfg.Format.(type) {
+		case string:
+			if v != "json" {
+				return &ValidationError{msg: `format must be "json" or a JSON Schema table`}
+			}
+		case map[string]interface{}:
+			// Valid JSON Schema table
+		default:
+			return &ValidationError{msg: `format must be "json" or a JSON Schema table`}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -91,6 +91,10 @@ type AgentConfig struct {
 	Retry         RetryConfig       `toml:"retry"`
 	Budget        BudgetConfig      `toml:"budget"`
 	Artifacts     ArtifactsConfig   `toml:"artifacts"`
+	// Format controls structured output. Set to "json" for JSON mode, or a
+	// JSON Schema object (as a TOML table) to constrain output to a specific schema.
+	// Only supported by the Ollama provider.
+	Format        interface{}       `toml:"format"`
 }
 
 // Validate checks that required fields are present in the agent configuration.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1807,6 +1807,60 @@ func TestValidate_Artifacts(t *testing.T) {
 	}
 }
 
+func TestValidate_Format(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *AgentConfig
+		wantErr bool
+		wantMsg string
+	}{
+		{
+			name:    "valid json string",
+			cfg:     &AgentConfig{Name: "test", Model: "openai/gpt-4o", Format: "json"},
+			wantErr: false,
+		},
+		{
+			name:    "valid schema map",
+			cfg:     &AgentConfig{Name: "test", Model: "openai/gpt-4o", Format: map[string]interface{}{"type": "object"}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			cfg:     &AgentConfig{Name: "test", Model: "openai/gpt-4o", Format: "xml"},
+			wantErr: true,
+			wantMsg: `format must be "json" or a JSON Schema table`,
+		},
+		{
+			name:    "invalid type",
+			cfg:     &AgentConfig{Name: "test", Model: "openai/gpt-4o", Format: 123},
+			wantErr: true,
+			wantMsg: `format must be "json" or a JSON Schema table`,
+		},
+		{
+			name:    "nil format",
+			cfg:     &AgentConfig{Name: "test", Model: "openai/gpt-4o", Format: nil},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantMsg) {
+					t.Errorf("got %q, want error containing %q", err.Error(), tc.wantMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestScaffold_IncludesArtifactsConfig(t *testing.T) {
 	out, err := Scaffold("test")
 	if err != nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1758,6 +1758,16 @@ func TestScaffold_IncludesTopLevelTimeout(t *testing.T) {
 	}
 }
 
+func TestScaffold_IncludesFormat(t *testing.T) {
+	out, err := Scaffold("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, `# format = "json"`) {
+		t.Errorf("scaffold output missing '# format = \"json\"'\nfull output:\n%s", out)
+	}
+}
+
 func TestValidate_Artifacts(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -61,15 +61,21 @@ func NewAnthropic(apiKey string, opts ...AnthropicOption) (*Anthropic, error) {
 	return a, nil
 }
 
+type anthropicToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
 // anthropicRequest is the JSON body sent to the Anthropic Messages API.
 type anthropicRequest struct {
-	Model       string             `json:"model"`
-	MaxTokens   int                `json:"max_tokens"`
-	Messages    []anthropicMessage `json:"messages"`
-	System      string             `json:"system,omitempty"`
-	Temperature *float64           `json:"temperature,omitempty"`
-	Tools       []anthropicToolDef `json:"tools,omitempty"`
-	Stream      bool               `json:"stream,omitempty"`
+	Model       string               `json:"model"`
+	MaxTokens   int                  `json:"max_tokens"`
+	Messages    []anthropicMessage   `json:"messages"`
+	System      string               `json:"system,omitempty"`
+	Temperature *float64             `json:"temperature,omitempty"`
+	Tools       []anthropicToolDef   `json:"tools,omitempty"`
+	ToolChoice  *anthropicToolChoice `json:"tool_choice,omitempty"`
+	Stream      bool                 `json:"stream,omitempty"`
 }
 
 // anthropicMessage is the wire format for a message in the Anthropic API.
@@ -210,6 +216,11 @@ func convertToAnthropicTools(tools []Tool) []anthropicToolDef {
 	return result
 }
 
+// SupportsFormat returns true as Anthropic supports JSON mode (via prompt injection) and JSON Schema (via tool use).
+func (a *Anthropic) SupportsFormat(format *ResponseFormat) bool {
+	return true
+}
+
 // Send makes a completion request to the Anthropic Messages API.
 func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 	maxTokens := req.MaxTokens
@@ -231,6 +242,24 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToAnthropicTools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatSchema {
+			// Add forced tool call for schema enforcement
+			body.Tools = append(body.Tools, anthropicToolDef{
+				Name:        "print_output",
+				Description: "Outputs the response in the requested structured format.",
+				InputSchema: req.Format.Schema,
+			})
+			body.ToolChoice = &anthropicToolChoice{Type: "tool", Name: "print_output"}
+		} else if req.Format.Type == FormatJSON {
+			// Prompt injection for JSON mode
+			if body.System != "" {
+				body.System += "\n\n"
+			}
+			body.System += "You must output your response in valid JSON. Do not include any markdown formatting, preamble, or conversational text. Output only the JSON."
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -301,15 +330,22 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 		case "text":
 			textContent += block.Text
 		case "tool_use":
-			args := make(map[string]string)
-			for k, v := range block.Input {
-				args[k] = fmt.Sprintf("%v", v)
+			if req.Format != nil && req.Format.Type == FormatSchema && block.Name == "print_output" {
+				marshaled, _ := json.Marshal(block.Input)
+				textContent = string(marshaled)
+				// Clear tool calls as this was a format enforcement tool
+				toolCalls = nil
+			} else {
+				args := make(map[string]string)
+				for k, v := range block.Input {
+					args[k] = fmt.Sprintf("%v", v)
+				}
+				toolCalls = append(toolCalls, ToolCall{
+					ID:        block.ID,
+					Name:      block.Name,
+					Arguments: args,
+				})
 			}
-			toolCalls = append(toolCalls, ToolCall{
-				ID:        block.ID,
-				Name:      block.Name,
-				Arguments: args,
-			})
 		}
 	}
 
@@ -368,6 +404,24 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToAnthropicTools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatSchema {
+			// Add forced tool call for schema enforcement
+			body.Tools = append(body.Tools, anthropicToolDef{
+				Name:        "print_output",
+				Description: "Outputs the response in the requested structured format.",
+				InputSchema: req.Format.Schema,
+			})
+			body.ToolChoice = &anthropicToolChoice{Type: "tool", Name: "print_output"}
+		} else if req.Format.Type == FormatJSON {
+			// Prompt injection for JSON mode
+			if body.System != "" {
+				body.System += "\n\n"
+			}
+			body.System += "You must output your response in valid JSON. Do not include any markdown formatting, preamble, or conversational text. Output only the JSON."
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/internal/provider/bedrock.go
+++ b/internal/provider/bedrock.go
@@ -282,6 +282,11 @@ func (b *Bedrock) mapStatusToCategory(status int) ErrorCategory {
 	}
 }
 
+// SupportsFormat returns false as Bedrock structured output is not yet implemented.
+func (b *Bedrock) SupportsFormat(format *ResponseFormat) bool {
+	return false
+}
+
 // Send makes a completion request to the AWS Bedrock Converse API.
 func (b *Bedrock) Send(ctx context.Context, req *Request) (*Response, error) {
 	body, err := json.Marshal(buildBedrockRequest(req))

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -103,8 +103,10 @@ type geminiFunctionDeclaration struct {
 }
 
 type geminiGenerationConfig struct {
-	Temperature     *float64 `json:"temperature,omitempty"`
-	MaxOutputTokens *int     `json:"maxOutputTokens,omitempty"`
+	Temperature      *float64               `json:"temperature,omitempty"`
+	MaxOutputTokens  *int                   `json:"maxOutputTokens,omitempty"`
+	ResponseMimeType string                 `json:"response_mime_type,omitempty"`
+	ResponseSchema   map[string]interface{} `json:"response_schema,omitempty"`
 }
 
 type geminiResponse struct {
@@ -245,6 +247,11 @@ func convertToGeminiTools(tools []Tool) []geminiToolDef {
 
 // --- Send method ---
 
+// SupportsFormat returns true as Gemini supports both JSON mode and JSON Schema.
+func (g *Gemini) SupportsFormat(format *ResponseFormat) bool {
+	return true
+}
+
 // Send makes a completion request to the Google Gemini API.
 func (g *Gemini) Send(ctx context.Context, req *Request) (*Response, error) {
 	body := geminiRequest{
@@ -274,6 +281,18 @@ func (g *Gemini) Send(ctx context.Context, req *Request) (*Response, error) {
 		genCfg.MaxOutputTokens = &mt
 		hasGenCfg = true
 	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			genCfg.ResponseMimeType = "application/json"
+			hasGenCfg = true
+		} else if req.Format.Type == FormatSchema {
+			genCfg.ResponseMimeType = "application/json"
+			genCfg.ResponseSchema = req.Format.Schema
+			hasGenCfg = true
+		}
+	}
+
 	if hasGenCfg {
 		body.GenerationConfig = &genCfg
 	}
@@ -406,6 +425,18 @@ func (g *Gemini) SendStream(ctx context.Context, req *Request) (*EventStream, er
 		genCfg.MaxOutputTokens = &mt
 		hasGenCfg = true
 	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			genCfg.ResponseMimeType = "application/json"
+			hasGenCfg = true
+		} else if req.Format.Type == FormatSchema {
+			genCfg.ResponseMimeType = "application/json"
+			genCfg.ResponseSchema = req.Format.Schema
+			hasGenCfg = true
+		}
+	}
+
 	if hasGenCfg {
 		body.GenerationConfig = &genCfg
 	}

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -65,6 +65,8 @@ type ollamaRequest struct {
 	Stream   bool            `json:"stream"`
 	Options  *ollamaOptions  `json:"options,omitempty"`
 	Tools    []ollamaToolDef `json:"tools,omitempty"`
+	// Format controls structured output: "json" for JSON mode, or a JSON Schema object.
+	Format   interface{}     `json:"format,omitempty"`
 }
 
 // ollamaMessage is the wire format for a message in the Ollama API.
@@ -229,6 +231,10 @@ func (o *Ollama) Send(ctx context.Context, req *Request) (*Response, error) {
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOllamaTools(req.Tools)
+	}
+
+	if req.Format != nil {
+		body.Format = req.Format
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -198,6 +198,11 @@ func convertToOllamaTools(tools []Tool) []ollamaToolDef {
 	return result
 }
 
+// SupportsFormat returns true, as Ollama natively supports both JSON mode and JSON Schema formats.
+func (o *Ollama) SupportsFormat(format *ResponseFormat) bool {
+	return true
+}
+
 // Send makes a completion request to the Ollama Chat API.
 func (o *Ollama) Send(ctx context.Context, req *Request) (*Response, error) {
 	var messages []Message
@@ -234,7 +239,11 @@ func (o *Ollama) Send(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	if req.Format != nil {
-		body.Format = req.Format
+		if req.Format.Type == FormatJSON {
+			body.Format = "json"
+		} else if req.Format.Type == FormatSchema {
+			body.Format = req.Format.Schema
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -370,7 +379,11 @@ func (o *Ollama) SendStream(ctx context.Context, req *Request) (*EventStream, er
 	}
 
 	if req.Format != nil {
-		body.Format = req.Format
+		if req.Format.Type == FormatJSON {
+			body.Format = "json"
+		} else if req.Format.Type == FormatSchema {
+			body.Format = req.Format.Schema
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/internal/provider/ollama.go
+++ b/internal/provider/ollama.go
@@ -369,6 +369,10 @@ func (o *Ollama) SendStream(ctx context.Context, req *Request) (*EventStream, er
 		body.Tools = convertToOllamaTools(req.Tools)
 	}
 
+	if req.Format != nil {
+		body.Format = req.Format
+	}
+
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/provider/ollama_test.go
+++ b/internal/provider/ollama_test.go
@@ -839,7 +839,7 @@ func TestOllama_SendStream_RequestFormat(t *testing.T) {
 	stream, err := o.SendStream(context.Background(), &Request{
 		Model:    "llama3",
 		Messages: []Message{{Role: "user", Content: "Hi"}},
-		Format:   "json",
+		Format:   &ResponseFormat{Type: FormatJSON},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/provider/ollama_test.go
+++ b/internal/provider/ollama_test.go
@@ -817,6 +817,7 @@ func TestOllama_Send_ToolResultMessage(t *testing.T) {
 func TestOllama_SendStream_RequestFormat(t *testing.T) {
 	var gotMethod, gotPath string
 	var gotStream interface{}
+	var gotFormat interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
@@ -826,6 +827,7 @@ func TestOllama_SendStream_RequestFormat(t *testing.T) {
 		var req map[string]interface{}
 		_ = json.Unmarshal(body, &req)
 		gotStream = req["stream"]
+		gotFormat = req["format"]
 
 		// Return NDJSON: one text chunk then done
 		_, _ = fmt.Fprintln(w, `{"message":{"content":"hi"},"done":false}`)
@@ -837,6 +839,7 @@ func TestOllama_SendStream_RequestFormat(t *testing.T) {
 	stream, err := o.SendStream(context.Background(), &Request{
 		Model:    "llama3",
 		Messages: []Message{{Role: "user", Content: "Hi"}},
+		Format:   "json",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -862,6 +865,9 @@ func TestOllama_SendStream_RequestFormat(t *testing.T) {
 	}
 	if gotStream != true {
 		t.Errorf("expected stream=true, got %v", gotStream)
+	}
+	if gotFormat != "json" {
+		t.Errorf("expected format=json, got %v", gotFormat)
 	}
 }
 

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -59,13 +59,25 @@ func NewOpenAI(apiKey string, opts ...OpenAIOption) (*OpenAI, error) {
 
 // openaiRequest is the JSON body sent to the OpenAI Chat Completions API.
 type openaiRequest struct {
-	Model         string               `json:"model"`
-	Messages      []openaiMessage      `json:"messages"`
-	Temperature   *float64             `json:"temperature,omitempty"`
-	MaxTokens     *int                 `json:"max_completion_tokens,omitempty"`
-	Tools         []openaiToolDef      `json:"tools,omitempty"`
-	Stream        bool                 `json:"stream,omitempty"`
-	StreamOptions *openaiStreamOptions `json:"stream_options,omitempty"`
+	Model          string                `json:"model"`
+	Messages       []openaiMessage       `json:"messages"`
+	Temperature    *float64              `json:"temperature,omitempty"`
+	MaxTokens      *int                  `json:"max_completion_tokens,omitempty"`
+	Tools          []openaiToolDef       `json:"tools,omitempty"`
+	Stream         bool                  `json:"stream,omitempty"`
+	StreamOptions  *openaiStreamOptions  `json:"stream_options,omitempty"`
+	ResponseFormat *openaiResponseFormat `json:"response_format,omitempty"`
+}
+
+type openaiResponseFormat struct {
+	Type       string               `json:"type"`
+	JSONSchema *openaiJSONSchemaDef `json:"json_schema,omitempty"`
+}
+
+type openaiJSONSchemaDef struct {
+	Name   string                 `json:"name"`
+	Strict bool                   `json:"strict"`
+	Schema map[string]interface{} `json:"schema"`
 }
 
 // openaiMessage is the wire format for a message in the OpenAI API.
@@ -217,6 +229,11 @@ func convertToOpenAITools(tools []Tool) []openaiToolDef {
 	return result
 }
 
+// SupportsFormat returns true as OpenAI supports both JSON mode and JSON Schema.
+func (o *OpenAI) SupportsFormat(format *ResponseFormat) bool {
+	return true
+}
+
 // Send makes a completion request to the OpenAI Chat Completions API.
 func (o *OpenAI) Send(ctx context.Context, req *Request) (*Response, error) {
 	var messages []Message
@@ -242,6 +259,21 @@ func (o *OpenAI) Send(ctx context.Context, req *Request) (*Response, error) {
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &openaiResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &openaiResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &openaiJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -374,6 +406,21 @@ func (o *OpenAI) SendStream(ctx context.Context, req *Request) (*EventStream, er
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &openaiResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &openaiResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &openaiJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -56,6 +56,11 @@ func NewOpenCode(apiKey string, opts ...OpenCodeOption) (*OpenCode, error) {
 	return o, nil
 }
 
+// SupportsFormat returns true as OpenCode Zen routes to Claude or OpenAI formats, both are supported.
+func (o *OpenCode) SupportsFormat(format *ResponseFormat) bool {
+	return true
+}
+
 // Send dispatches the request to the appropriate Zen endpoint based on the model name prefix.
 func (o *OpenCode) Send(ctx context.Context, req *Request) (*Response, error) {
 	switch {
@@ -105,6 +110,22 @@ type ocAnthropicToolDef struct {
 	InputSchema ocAnthropicInputSchema `json:"input_schema"`
 }
 
+type ocAnthropicToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
+type ocResponseFormat struct {
+	Type       string           `json:"type"`
+	JSONSchema *ocJSONSchemaDef `json:"json_schema,omitempty"`
+}
+
+type ocJSONSchemaDef struct {
+	Name   string                 `json:"name"`
+	Strict bool                   `json:"strict"`
+	Schema map[string]interface{} `json:"schema"`
+}
+
 type ocAnthropicRequest struct {
 	Model       string               `json:"model"`
 	MaxTokens   int                  `json:"max_tokens"`
@@ -112,6 +133,7 @@ type ocAnthropicRequest struct {
 	System      string               `json:"system,omitempty"`
 	Temperature *float64             `json:"temperature,omitempty"`
 	Tools       []ocAnthropicToolDef `json:"tools,omitempty"`
+	ToolChoice  *ocAnthropicToolChoice `json:"tool_choice,omitempty"`
 }
 
 type ocAnthropicResponse struct {
@@ -205,6 +227,43 @@ func convertToOCAnthropicTools(tools []Tool) []ocAnthropicToolDef {
 	return defs
 }
 
+func convertToOCAnthropicJSONSchemaProps(schema map[string]interface{}) map[string]ocJSONSchemaProp {
+	propsRaw, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	props := make(map[string]ocJSONSchemaProp, len(propsRaw))
+	for name, val := range propsRaw {
+		valMap, ok := val.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		p := ocJSONSchemaProp{}
+		if t, ok := valMap["type"].(string); ok {
+			p.Type = t
+		}
+		if d, ok := valMap["description"].(string); ok {
+			p.Description = d
+		}
+		props[name] = p
+	}
+	return props
+}
+
+func convertToOCAnthropicRequiredProps(schema map[string]interface{}) []string {
+	reqRaw, ok := schema["required"].([]interface{})
+	if !ok {
+		return nil
+	}
+	req := make([]string, len(reqRaw))
+	for i, v := range reqRaw {
+		if s, ok := v.(string); ok {
+			req[i] = s
+		}
+	}
+	return req
+}
+
 func mapOCAnthropicHTTPError(status int, body []byte) *ProviderError {
 	var cat ErrorCategory
 	switch status {
@@ -249,6 +308,28 @@ func (o *OpenCode) sendClaude(ctx context.Context, req *Request) (*Response, err
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCAnthropicTools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatSchema {
+			// Add forced tool call for schema enforcement
+			body.Tools = append(body.Tools, ocAnthropicToolDef{
+				Name:        "print_output",
+				Description: "Outputs the response in the requested structured format.",
+				InputSchema: ocAnthropicInputSchema{
+					Type:       "object",
+					Properties: convertToOCAnthropicJSONSchemaProps(req.Format.Schema),
+					Required:   convertToOCAnthropicRequiredProps(req.Format.Schema),
+				},
+			})
+			body.ToolChoice = &ocAnthropicToolChoice{Type: "tool", Name: "print_output"}
+		} else if req.Format.Type == FormatJSON {
+			// Prompt injection for JSON mode
+			if body.System != "" {
+				body.System += "\n\n"
+			}
+			body.System += "You must output your response in valid JSON. Do not include any markdown formatting, preamble, or conversational text. Output only the JSON."
+		}
 	}
 
 	data, err := json.Marshal(body)
@@ -303,15 +384,22 @@ func (o *OpenCode) sendClaude(ctx context.Context, req *Request) (*Response, err
 		case "text":
 			result.Content += block.Text
 		case "tool_use":
-			args := make(map[string]string, len(block.Input))
-			for k, v := range block.Input {
-				args[k] = fmt.Sprintf("%v", v)
+			if req.Format != nil && req.Format.Type == FormatSchema && block.Name == "print_output" {
+				marshaled, _ := json.Marshal(block.Input)
+				result.Content = string(marshaled)
+				// Clear tool calls as this was a format enforcement tool
+				result.ToolCalls = nil
+			} else {
+				args := make(map[string]string, len(block.Input))
+				for k, v := range block.Input {
+					args[k] = fmt.Sprintf("%v", v)
+				}
+				result.ToolCalls = append(result.ToolCalls, ToolCall{
+					ID:        block.ID,
+					Name:      block.Name,
+					Arguments: args,
+				})
 			}
-			result.ToolCalls = append(result.ToolCalls, ToolCall{
-				ID:        block.ID,
-				Name:      block.Name,
-				Arguments: args,
-			})
 		}
 	}
 
@@ -343,6 +431,7 @@ type ocAnthropicStreamRequest struct {
 	System      string               `json:"system,omitempty"`
 	Temperature *float64             `json:"temperature,omitempty"`
 	Tools       []ocAnthropicToolDef `json:"tools,omitempty"`
+	ToolChoice  *ocAnthropicToolChoice `json:"tool_choice,omitempty"`
 	Stream      bool                 `json:"stream"`
 }
 
@@ -367,6 +456,28 @@ func (o *OpenCode) streamClaude(ctx context.Context, req *Request) (*EventStream
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCAnthropicTools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatSchema {
+			// Add forced tool call for schema enforcement
+			body.Tools = append(body.Tools, ocAnthropicToolDef{
+				Name:        "print_output",
+				Description: "Outputs the response in the requested structured format.",
+				InputSchema: ocAnthropicInputSchema{
+					Type:       "object",
+					Properties: convertToOCAnthropicJSONSchemaProps(req.Format.Schema),
+					Required:   convertToOCAnthropicRequiredProps(req.Format.Schema),
+				},
+			})
+			body.ToolChoice = &ocAnthropicToolChoice{Type: "tool", Name: "print_output"}
+		} else if req.Format.Type == FormatJSON {
+			// Prompt injection for JSON mode
+			if body.System != "" {
+				body.System += "\n\n"
+			}
+			body.System += "You must output your response in valid JSON. Do not include any markdown formatting, preamble, or conversational text. Output only the JSON."
+		}
 	}
 
 	data, err := json.Marshal(body)
@@ -492,13 +603,14 @@ func (o *OpenCode) streamClaude(ctx context.Context, req *Request) (*EventStream
 
 // --- GPT (OpenAI Responses API) streaming ---
 
-type ocResponsesStreamRequest struct {
+type ocGPTStreamRequest struct {
 	Model           string            `json:"model"`
 	Input           []interface{}     `json:"input"`
 	Temperature     *float64          `json:"temperature,omitempty"`
 	MaxOutputTokens *int              `json:"max_output_tokens,omitempty"`
 	Tools           []ocOpenAIToolDef `json:"tools,omitempty"`
 	Stream          bool              `json:"stream"`
+	ResponseFormat  *ocResponseFormat `json:"response_format,omitempty"`
 }
 
 type ocRespStreamEvent struct {
@@ -523,7 +635,7 @@ type ocRespStreamResponse struct {
 }
 
 func (o *OpenCode) streamGPT(ctx context.Context, req *Request) (*EventStream, error) {
-	body := ocResponsesStreamRequest{
+	body := ocGPTStreamRequest{
 		Model:  req.Model,
 		Input:  convertToOCResponsesMessages(req),
 		Stream: true,
@@ -541,6 +653,21 @@ func (o *OpenCode) streamGPT(ctx context.Context, req *Request) (*EventStream, e
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &ocResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &ocResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &ocJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	data, err := json.Marshal(body)
@@ -648,14 +775,15 @@ func (o *OpenCode) streamGPT(ctx context.Context, req *Request) (*EventStream, e
 
 // --- Chat Completions streaming ---
 
-type ocChatStreamRequest struct {
-	Model         string             `json:"model"`
-	Messages      []ocChatMessage    `json:"messages"`
-	Temperature   *float64           `json:"temperature,omitempty"`
-	MaxTokens     *int               `json:"max_tokens,omitempty"`
-	Tools         []ocOpenAIToolDef  `json:"tools,omitempty"`
-	Stream        bool               `json:"stream"`
-	StreamOptions *ocStreamOptions   `json:"stream_options,omitempty"`
+type ocChatCompletionsStreamRequest struct {
+	Model          string            `json:"model"`
+	Messages       []ocChatMessage   `json:"messages"`
+	Temperature    *float64          `json:"temperature,omitempty"`
+	MaxTokens      *int              `json:"max_tokens,omitempty"`
+	Tools          []ocOpenAIToolDef `json:"tools,omitempty"`
+	Stream         bool              `json:"stream"`
+	StreamOptions  *ocStreamOptions  `json:"stream_options,omitempty"`
+	ResponseFormat *ocResponseFormat `json:"response_format,omitempty"`
 }
 
 type ocStreamOptions struct {
@@ -663,7 +791,7 @@ type ocStreamOptions struct {
 }
 
 func (o *OpenCode) streamChatCompletions(ctx context.Context, req *Request) (*EventStream, error) {
-	body := ocChatStreamRequest{
+	body := ocChatCompletionsStreamRequest{
 		Model:         req.Model,
 		Messages:      convertToOCChatMessages(req),
 		Stream:        true,
@@ -682,6 +810,21 @@ func (o *OpenCode) streamChatCompletions(ctx context.Context, req *Request) (*Ev
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &ocResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &ocResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &ocJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	data, err := json.Marshal(body)
@@ -841,12 +984,13 @@ type ocResponsesAssistantMsg struct {
 	ToolCalls []ocToolCallWire `json:"tool_calls,omitempty"`
 }
 
-type ocResponsesRequest struct {
+type ocGPTRequest struct {
 	Model           string            `json:"model"`
 	Input           []interface{}     `json:"input"`
 	Temperature     *float64          `json:"temperature,omitempty"`
 	MaxOutputTokens *int              `json:"max_output_tokens,omitempty"`
 	Tools           []ocOpenAIToolDef `json:"tools,omitempty"`
+	ResponseFormat  *ocResponseFormat `json:"response_format,omitempty"`
 }
 
 type ocResponsesResponse struct {
@@ -962,7 +1106,7 @@ func convertToOCResponsesMessages(req *Request) []interface{} {
 }
 
 func (o *OpenCode) sendGPT(ctx context.Context, req *Request) (*Response, error) {
-	body := ocResponsesRequest{
+	body := ocGPTRequest{
 		Model: req.Model,
 		Input: convertToOCResponsesMessages(req),
 	}
@@ -979,6 +1123,21 @@ func (o *OpenCode) sendGPT(ctx context.Context, req *Request) (*Response, error)
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &ocResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &ocResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &ocJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	data, err := json.Marshal(body)
@@ -1066,12 +1225,13 @@ type ocChatMessage struct {
 	ToolCalls  []ocToolCallWire `json:"tool_calls,omitempty"`
 }
 
-type ocChatRequest struct {
-	Model       string            `json:"model"`
-	Messages    []ocChatMessage   `json:"messages"`
-	Temperature *float64          `json:"temperature,omitempty"`
-	MaxTokens   *int              `json:"max_tokens,omitempty"`
-	Tools       []ocOpenAIToolDef `json:"tools,omitempty"`
+type ocChatCompletionsRequest struct {
+	Model          string            `json:"model"`
+	Messages       []ocChatMessage   `json:"messages"`
+	Temperature    *float64          `json:"temperature,omitempty"`
+	MaxTokens      *int              `json:"max_tokens,omitempty"`
+	Tools          []ocOpenAIToolDef `json:"tools,omitempty"`
+	ResponseFormat *ocResponseFormat `json:"response_format,omitempty"`
 }
 
 type ocChatResponse struct {
@@ -1131,7 +1291,7 @@ func convertToOCChatMessages(req *Request) []ocChatMessage {
 }
 
 func (o *OpenCode) sendChatCompletions(ctx context.Context, req *Request) (*Response, error) {
-	body := ocChatRequest{
+	body := ocChatCompletionsRequest{
 		Model:    req.Model,
 		Messages: convertToOCChatMessages(req),
 	}
@@ -1148,6 +1308,21 @@ func (o *OpenCode) sendChatCompletions(ctx context.Context, req *Request) (*Resp
 
 	if len(req.Tools) > 0 {
 		body.Tools = convertToOCOpenAITools(req.Tools)
+	}
+
+	if req.Format != nil {
+		if req.Format.Type == FormatJSON {
+			body.ResponseFormat = &ocResponseFormat{Type: "json_object"}
+		} else if req.Format.Type == FormatSchema {
+			body.ResponseFormat = &ocResponseFormat{
+				Type: "json_schema",
+				JSONSchema: &ocJSONSchemaDef{
+					Name:   "structured_output",
+					Strict: true,
+					Schema: req.Format.Schema,
+				},
+			}
+		}
 	}
 
 	data, err := json.Marshal(body)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,6 +59,21 @@ type Message struct {
 	ToolResults []ToolResult // Tool results in a tool-result message (non-nil when role is "tool")
 }
 
+// FormatType defines the type of requested formatting.
+type FormatType string
+
+const (
+	FormatNone   FormatType = ""
+	FormatJSON   FormatType = "json"
+	FormatSchema FormatType = "schema"
+)
+
+// ResponseFormat represents the internal structured output requirement.
+type ResponseFormat struct {
+	Type   FormatType
+	Schema map[string]interface{}
+}
+
 // Request represents an LLM completion request.
 type Request struct {
 	Model       string
@@ -66,8 +81,8 @@ type Request struct {
 	Messages    []Message
 	Temperature float64
 	MaxTokens   int
-	Tools       []Tool      // Tool definitions to send to the LLM. If nil or empty, no tools are sent.
-	Format      interface{} // Optional: "json" for JSON mode, or a JSON Schema object for structured output (Ollama only).
+	Tools       []Tool          // Tool definitions to send to the LLM. If nil or empty, no tools are sent.
+	Format      *ResponseFormat // Optional: defines the requested response formatting.
 }
 
 // Response represents an LLM completion response.
@@ -83,6 +98,7 @@ type Response struct {
 // Provider defines the interface for LLM providers.
 type Provider interface {
 	Send(ctx context.Context, req *Request) (*Response, error)
+	SupportsFormat(format *ResponseFormat) bool
 }
 
 // ProviderError wraps provider-specific errors with categorization.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -66,7 +66,8 @@ type Request struct {
 	Messages    []Message
 	Temperature float64
 	MaxTokens   int
-	Tools       []Tool // Tool definitions to send to the LLM. If nil or empty, no tools are sent.
+	Tools       []Tool      // Tool definitions to send to the LLM. If nil or empty, no tools are sent.
+	Format      interface{} // Optional: "json" for JSON mode, or a JSON Schema object for structured output (Ollama only).
 }
 
 // Response represents an LLM completion response.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -67,6 +67,10 @@ func (m *mockProvider) Send(ctx context.Context, req *Request) (*Response, error
 	return nil, nil
 }
 
+func (m *mockProvider) SupportsFormat(format *ResponseFormat) bool {
+	return false
+}
+
 // --- Phase 1a: New struct zero-value tests ---
 
 func TestTool_ZeroValue(t *testing.T) {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -46,6 +46,11 @@ func (r *RetryProvider) Attempts() int {
 	return r.attempts
 }
 
+// SupportsFormat delegates format support checking to the inner provider.
+func (r *RetryProvider) SupportsFormat(format *ResponseFormat) bool {
+	return r.inner.SupportsFormat(format)
+}
+
 // Send delegates to the wrapped provider with retry logic.
 // When MaxRetries is 0, it passes through directly with no overhead.
 func (r *RetryProvider) Send(ctx context.Context, req *Request) (*Response, error) {

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -30,6 +30,10 @@ func (m *retryMockProvider) Send(ctx context.Context, req *Request) (*Response, 
 	return &Response{Content: "ok"}, nil
 }
 
+func (m *retryMockProvider) SupportsFormat(format *ResponseFormat) bool {
+	return false
+}
+
 // --- 2f: isRetriable tests ---
 
 func TestIsRetriable_RateLimit(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `format` field to `AgentConfig` (TOML: `format = "json"` or a JSON Schema table), `provider.Request`, and `ollamaRequest`. When set, `format` is passed as-is to Ollama's `format` parameter, enabling both JSON mode and schema-constrained structured output.

## Example

```toml
[format]
type = "object"
properties = { choice = { type = "integer" }, reason = { type = "string" } }
required = ["choice"]
```

## Test plan
- [ ] Set `format = "json"` in an agent TOML and verify Ollama returns valid JSON
- [ ] Set `format` to a JSON Schema table and verify output is schema-constrained
- [ ] Agents without `format` behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces provider-agnostic structured output support across the platform. It adds a `format` field to agent configuration that accepts either `"json"` for JSON mode or a JSON Schema table for schema-constrained output. A unified `ResponseFormat` type was implemented in the provider interface, with each provider implementing a `SupportsFormat` capability check. Format parameters are now validated at the CLI level, with early exit if the selected provider doesn't support the requested format. Provider-specific implementations handle format translation: OpenAI uses `response_format` with JSON object and JSON Schema modes; Anthropic uses prompt injection for JSON mode and forced tool calls for schemas; Gemini uses `ResponseMimeType` and `ResponseSchema` in generation config; Ollama passes the format field directly. Bedrock provider does not support structured output.

## Changelog

### Added
- `Format` field to `AgentConfig` supporting `"json"` string or JSON Schema `map[string]interface{}`
- `FormatType` enum (`FormatNone`, `FormatJSON`, `FormatSchema`) and `ResponseFormat` struct to provider interface
- `SupportsFormat(format *ResponseFormat) bool` method to `Provider` interface
- Format validation in CLI that aborts with exit code 2 if provider doesn't support requested format
- Provider-specific format support implementations for OpenAI (response_format with json_object and json_schema modes), Anthropic (tool forcing for schemas, prompt injection for JSON), Gemini (response_mime_type and response_schema), and Ollama (direct format passthrough)
- `TestRun_ProviderConfigValidation` consolidated test covering multiple configuration validation scenarios
- `TestScaffold_IncludesFormat` and `TestValidate_Format` to verify format field handling in agent configuration
- Format display in `agents show` command output

### Changed
- `Request` type now includes optional `Format *ResponseFormat` field
- Ollama request payload struct now includes `format` field
- OpenAI request payload now includes `response_format` field with wire-format structs for JSON and JSON Schema modes
- Anthropic request handling refactored to support tool choice forcing for schema-constrained output
- Gemini generation config extended with `ResponseMimeType` and `ResponseSchema` fields
- Agent configuration scaffold template updated with commented format example
- CLI validation refactored to use `SupportsFormat` method instead of hardcoded provider checks

### Removed
- `TestRun_InvalidModelFormat` standalone test (consolidated into `TestRun_ProviderConfigValidation`)
- `TestRun_UnsupportedProvider` standalone test (consolidated into `TestRun_ProviderConfigValidation`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->