### PR TITLE
Feat: Add Artifacts Default Write Option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,11 @@ path = "/custom/path" # Optional (default: $XDG_DATA_HOME/axe/memory/{agent-name
 temperature = 0.7  # Default: 0 (omitted if 0)
 max_tokens = 4096  # Default: 0 (provider default)
 
+[artifacts]
+enabled = true
+dir = "output"
+default_write = true  # When true, write_file without explicit artifact arg writes to artifact dir
+
 [[mcp_servers]]
 name = "server-name"
 transport = "stdio"  # or "http", "https"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -909,21 +909,22 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 	results := make([]toolExecResult, len(toolCalls))
 
 	execOpts := tool.ExecuteOptions{
-		AllowedAgents:   cfg.SubAgents,
-		ParentModel:     cfg.Model,
-		Depth:           depth,
-		MaxDepth:        maxDepth,
-		Timeout:         cfg.SubAgentsConf.Timeout,
-		GlobalConfig:    globalCfg,
-		MCPRouter:       mcpRouter,
-		Verbose:         verbose,
-		Stderr:          stderr,
-		BudgetTracker:   budgetTracker,
-		AgentsDir:       agentsDir,
-		AgentsBase:      agentsBase,
-		AllowedHosts:    cfg.AllowedHosts,
-		ArtifactDir:     artifactDir,
-		ArtifactTracker: artifactTracker,
+		AllowedAgents:        cfg.SubAgents,
+		ParentModel:          cfg.Model,
+		Depth:                depth,
+		MaxDepth:             maxDepth,
+		Timeout:              cfg.SubAgentsConf.Timeout,
+		GlobalConfig:         globalCfg,
+		MCPRouter:            mcpRouter,
+		Verbose:              verbose,
+		Stderr:               stderr,
+		BudgetTracker:        budgetTracker,
+		AgentsDir:            agentsDir,
+		AgentsBase:           agentsBase,
+		AllowedHosts:         cfg.AllowedHosts,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      artifactTracker,
+		DefaultArtifactWrite: cfg.Artifacts.DefaultWrite,
 	}
 
 	if len(toolCalls) == 1 || !parallel {
@@ -932,11 +933,11 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 			start := time.Now()
 			var r provider.ToolResult
 			if mcpRouter != nil && mcpRouter.Has(tc.Name) {
-				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
 			} else if tc.Name == tool.CallAgentToolName {
 				r = tool.ExecuteCallAgent(ctx, tc, execOpts)
 			} else {
-				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
 			}
 			results[i] = toolExecResult{Result: r, Duration: time.Since(start)}
 		}
@@ -952,11 +953,11 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 				start := time.Now()
 				var res provider.ToolResult
 				if mcpRouter != nil && mcpRouter.Has(call.Name) {
-					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
 				} else if call.Name == tool.CallAgentToolName {
 					res = tool.ExecuteCallAgent(ctx, call, execOpts)
 				} else {
-					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker)
+					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
 				}
 				ch <- indexedResult{index: idx, result: toolExecResult{Result: res, Duration: time.Since(start)}}
 			}(i, tc)
@@ -970,7 +971,7 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 	return results
 }
 
-func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.Registry, mcpRouter *mcpclient.Router, verbose bool, stderr io.Writer, workdir string, allowedHosts []string, artifactDir string, artifactTracker *artifact.Tracker) provider.ToolResult {
+func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.Registry, mcpRouter *mcpclient.Router, verbose bool, stderr io.Writer, workdir string, allowedHosts []string, artifactDir string, artifactTracker *artifact.Tracker, defaultArtifactWrite bool) provider.ToolResult {
 	if mcpRouter != nil && mcpRouter.Has(tc.Name) {
 		if verbose && stderr != nil {
 			if serverName, ok := mcpRouter.ServerName(tc.Name); ok {
@@ -985,12 +986,13 @@ func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.
 	}
 
 	result, dispatchErr := registry.Dispatch(ctx, tc, tool.ExecContext{
-		Workdir:         workdir,
-		Stderr:          stderr,
-		Verbose:         verbose,
-		AllowedHosts:    allowedHosts,
-		ArtifactDir:     artifactDir,
-		ArtifactTracker: artifactTracker,
+		Workdir:              workdir,
+		Stderr:               stderr,
+		Verbose:              verbose,
+		AllowedHosts:         allowedHosts,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      artifactTracker,
+		DefaultArtifactWrite: defaultArtifactWrite,
 	})
 	if dispatchErr != nil {
 		return provider.ToolResult{CallID: tc.ID, Content: dispatchErr.Error(), IsError: true}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -927,17 +927,27 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 		DefaultArtifactWrite: cfg.Artifacts.DefaultWrite,
 	}
 
+	toolExecCtx := tool.ExecContext{
+		Workdir:              workdir,
+		Stderr:               stderr,
+		Verbose:              verbose,
+		AllowedHosts:         cfg.AllowedHosts,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      artifactTracker,
+		DefaultArtifactWrite: cfg.Artifacts.DefaultWrite,
+	}
+
 	if len(toolCalls) == 1 || !parallel {
 		// Sequential execution (also used for single call)
 		for i, tc := range toolCalls {
 			start := time.Now()
 			var r provider.ToolResult
 			if mcpRouter != nil && mcpRouter.Has(tc.Name) {
-				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, toolExecCtx)
 			} else if tc.Name == tool.CallAgentToolName {
 				r = tool.ExecuteCallAgent(ctx, tc, execOpts)
 			} else {
-				r = dispatchToolCall(ctx, tc, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
+				r = dispatchToolCall(ctx, tc, registry, mcpRouter, toolExecCtx)
 			}
 			results[i] = toolExecResult{Result: r, Duration: time.Since(start)}
 		}
@@ -953,11 +963,11 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 				start := time.Now()
 				var res provider.ToolResult
 				if mcpRouter != nil && mcpRouter.Has(call.Name) {
-					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
+					res = dispatchToolCall(ctx, call, registry, mcpRouter, toolExecCtx)
 				} else if call.Name == tool.CallAgentToolName {
 					res = tool.ExecuteCallAgent(ctx, call, execOpts)
 				} else {
-					res = dispatchToolCall(ctx, call, registry, mcpRouter, verbose, stderr, workdir, cfg.AllowedHosts, artifactDir, artifactTracker, cfg.Artifacts.DefaultWrite)
+					res = dispatchToolCall(ctx, call, registry, mcpRouter, toolExecCtx)
 				}
 				ch <- indexedResult{index: idx, result: toolExecResult{Result: res, Duration: time.Since(start)}}
 			}(i, tc)
@@ -971,11 +981,11 @@ func executeToolCalls(ctx context.Context, toolCalls []provider.ToolCall, cfg *a
 	return results
 }
 
-func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.Registry, mcpRouter *mcpclient.Router, verbose bool, stderr io.Writer, workdir string, allowedHosts []string, artifactDir string, artifactTracker *artifact.Tracker, defaultArtifactWrite bool) provider.ToolResult {
+func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.Registry, mcpRouter *mcpclient.Router, ec tool.ExecContext) provider.ToolResult {
 	if mcpRouter != nil && mcpRouter.Has(tc.Name) {
-		if verbose && stderr != nil {
+		if ec.Verbose && ec.Stderr != nil {
 			if serverName, ok := mcpRouter.ServerName(tc.Name); ok {
-				_, _ = fmt.Fprintf(stderr, "[mcp] Routing tool %q to server %q\n", tc.Name, serverName)
+				_, _ = fmt.Fprintf(ec.Stderr, "[mcp] Routing tool %q to server %q\n", tc.Name, serverName)
 			}
 		}
 		result, err := mcpRouter.Dispatch(ctx, tc)
@@ -985,15 +995,7 @@ func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *tool.
 		return result
 	}
 
-	result, dispatchErr := registry.Dispatch(ctx, tc, tool.ExecContext{
-		Workdir:              workdir,
-		Stderr:               stderr,
-		Verbose:              verbose,
-		AllowedHosts:         allowedHosts,
-		ArtifactDir:          artifactDir,
-		ArtifactTracker:      artifactTracker,
-		DefaultArtifactWrite: defaultArtifactWrite,
-	})
+	result, dispatchErr := registry.Dispatch(ctx, tc, ec)
 	if dispatchErr != nil {
 		return provider.ToolResult{CallID: tc.ID, Content: dispatchErr.Error(), IsError: true}
 	}

--- a/cmd/run_integration_test.go
+++ b/cmd/run_integration_test.go
@@ -2326,3 +2326,128 @@ tools = ["write_file"]
 		t.Errorf("expected second request body to contain 'artifact directory not configured for this agent', got: %s", body1)
 	}
 }
+
+// --- Group E: Default Artifact Write Tests ---
+
+func TestIntegration_DefaultArtifactWrite(t *testing.T) {
+	resetRunCmd(t)
+
+	artifactDir := t.TempDir()
+
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicToolUseResponse("Writing file.", []testutil.MockToolCall{
+			{ID: "tc_dw1", Name: "write_file", Input: map[string]string{"path": "output.txt", "content": "default artifact content"}},
+		}),
+		testutil.AnthropicResponse("File written."),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	writeAgentConfig(t, configDir, "default-artifact-write", fmt.Sprintf(`name = "default-artifact-write"
+model = "anthropic/claude-sonnet-4-20250514"
+tools = ["write_file"]
+[artifacts]
+enabled = true
+dir = %q
+default_write = true
+`, artifactDir))
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "default-artifact-write", "--json"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	// Verify file on disk in artifact dir
+	artifactFile := filepath.Join(artifactDir, "output.txt")
+	data, readErr := os.ReadFile(artifactFile)
+	if readErr != nil {
+		t.Fatalf("expected artifact file %q to exist on disk, got error: %v", artifactFile, readErr)
+	}
+	if !strings.Contains(string(data), "default artifact content") {
+		t.Errorf("expected artifact content %q, got %q", "default artifact content", string(data))
+	}
+
+	// Verify JSON output contains artifacts
+	var result map[string]interface{}
+	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("expected valid JSON output, got parse error: %v\nraw: %q", jsonErr, buf.String())
+	}
+
+	artifactsRaw, ok := result["artifacts"]
+	if !ok {
+		t.Fatalf("expected JSON output to contain 'artifacts' key")
+	}
+	artifacts, ok := artifactsRaw.([]interface{})
+	if !ok {
+		t.Fatalf("expected artifacts to be array, got %T", artifactsRaw)
+	}
+	if len(artifacts) < 1 {
+		t.Errorf("expected at least 1 artifact entry, got %d", len(artifacts))
+	}
+
+	// Verify tool result contains "(artifact)" marker
+	body1 := mock.Requests[1].Body
+	if !strings.Contains(body1, "(artifact)") {
+		t.Errorf("expected second request body to contain '(artifact)', got: %s", body1)
+	}
+}
+
+func TestIntegration_DefaultArtifactWrite_FlagOverride(t *testing.T) {
+	resetRunCmd(t)
+
+	artifactDir := t.TempDir()
+
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicToolUseResponse("Writing file.", []testutil.MockToolCall{
+			{ID: "tc_fo1", Name: "write_file", Input: map[string]string{"path": "flag-output.txt", "content": "flag artifact content"}},
+		}),
+		testutil.AnthropicResponse("File written."),
+	})
+
+	configDir, _ := testutil.SetupXDGDirs(t)
+	writeAgentConfig(t, configDir, "flag-override-artifact", `name = "flag-override-artifact"
+model = "anthropic/claude-sonnet-4-20250514"
+tools = ["write_file"]
+[artifacts]
+enabled = false
+default_write = true
+`)
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"run", "flag-override-artifact", "--artifact-dir", artifactDir})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	// Verify file on disk in artifact dir (the one from --artifact-dir flag)
+	artifactFile := filepath.Join(artifactDir, "flag-output.txt")
+	data, readErr := os.ReadFile(artifactFile)
+	if readErr != nil {
+		t.Fatalf("expected artifact file %q to exist on disk, got error: %v", artifactFile, readErr)
+	}
+	if !strings.Contains(string(data), "flag artifact content") {
+		t.Errorf("expected artifact content %q, got %q", "flag artifact content", string(data))
+	}
+
+	// Verify tool result contains "(artifact)" marker
+	body1 := mock.Requests[1].Body
+	if !strings.Contains(body1, "(artifact)") {
+		t.Errorf("expected second request body to contain '(artifact)', got: %s", body1)
+	}
+}

--- a/docs/plans/042_artifact_management_spec.md
+++ b/docs/plans/042_artifact_management_spec.md
@@ -113,6 +113,7 @@ A new optional `[artifacts]` configuration table must be supported in agent TOML
 |-------|------|---------|-------------|
 | `enabled` | boolean | `false` | Whether the artifact system is active for this agent. Must be `true` for auto-generated temp dirs to be created. |
 | `dir` | string | `""` | Path to a persistent artifact directory. Supports `~` and `$VAR` expansion. When empty and `enabled` is `true`, an auto-generated temp directory is used. |
+| `default_write` | boolean | `false` | When `true` and the artifact system is active, `write_file` tool calls without an explicit `artifact` argument default to writing to the artifact directory. Explicit `artifact` arguments always override this default. |
 
 **Validation rules:**
 - `dir` set to a non-empty value while `enabled` is `false` (or absent) is a validation error: `"artifacts.dir is set but artifacts.enabled is false"`.
@@ -130,6 +131,14 @@ enabled = true
 [artifacts]
 enabled = true
 dir = "~/project-artifacts"
+```
+
+**Example — default write to artifact directory:**
+```toml
+[artifacts]
+enabled = true
+dir = "output"
+default_write = true
 ```
 
 ### 2.2 CLI Flag Overrides

--- a/docs/plans/047_artifacts_default_write_implement.md
+++ b/docs/plans/047_artifacts_default_write_implement.md
@@ -1,0 +1,144 @@
+# 047 — Artifact Default Write: Implementation Guide
+
+**Spec:** `docs/plans/047_artifacts_default_write_spec.md`
+**Parent milestone:** `docs/plans/042_artifact_management_spec.md`
+
+---
+
+## Section 1: Context Summary
+
+When an agent has the artifact system active (`[artifacts] enabled = true` or `--artifact-dir`), the LLM must explicitly pass `artifact = "true"` in every `write_file` call for the file to land in the artifact directory. If omitted, the file goes to workdir — rarely the intended behavior. Users work around this by adding prompt instructions like "always set artifact = true", which is fragile and context-wasteful. This implementation adds a `default_write` boolean to the `[artifacts]` TOML block so agents can declare the default deterministically. The default only applies when the `artifact` argument is absent/empty AND the artifact system is active. Explicit `artifact` arguments always override the default. Backward compatibility is non-negotiable: omitting `default_write` or setting it to `false` produces identical behavior to today.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Group A — Agent Config (no dependencies, can start immediately)
+
+- [x] **A1: Add `DefaultWrite` field to `ArtifactsConfig`**
+  `internal/agent/agent.go` — `ArtifactsConfig` struct (line 96)
+  Add `DefaultWrite bool \`toml:"default_write"\`` as the third field after `Dir`.
+
+- [x] **A2: Update `Scaffold()` template**
+  `internal/agent/agent.go` — `Scaffold()` function (line 449)
+  Add `# default_write = false\n` after `# dir = ""\n` inside the `[artifacts]` comment block.
+
+- [x] **A3: Test that `Scaffold()` includes `default_write`**
+  `internal/agent/agent_test.go` — `TestScaffold_IncludesArtifactsConfig` (line 1810)
+  Add `# default_write = false` to the `checks` slice so the test asserts the new line is present.
+
+- [x] **A4: Test TOML round-trip parsing of `default_write`**
+  `internal/agent/agent_test.go` — add new test `TestLoad_ArtifactsDefaultWrite`
+  Write a temp TOML file with `[artifacts] enabled = true, default_write = true`, call `loadFromPath()`, assert `cfg.Artifacts.DefaultWrite == true`. Also test the zero-value case (field omitted → `false`).
+
+### Group B — Tool Execution Context (no dependencies, can start immediately, parallel with Group A)
+
+- [x] **B1: Add `DefaultArtifactWrite` to `ExecContext`**
+  `internal/tool/registry.go` — `ExecContext` struct (line 14)
+  Add `DefaultArtifactWrite bool` as the last field.
+
+- [x] **B2: Add `DefaultArtifactWrite` to `ExecuteOptions`**
+  `internal/tool/tool.go` — `ExecuteOptions` struct (line 29)
+  Add `DefaultArtifactWrite bool` as the last field.
+
+- [x] **B3: Thread `DefaultArtifactWrite` through sub-agent `dispatchToolCall`**
+  `internal/tool/tool.go` — `dispatchToolCall()` function (line 447)
+  Add `DefaultArtifactWrite: opts.DefaultArtifactWrite` to the `ExecContext` literal (line 456).
+
+### Group C — Write File Logic (depends on A1 + B1)
+
+- [x] **C1: Implement default_write resolution in `writeFileExecute`**
+  `internal/tool/write_file.go` — `writeFileExecute()` function (line 101–104)
+  Replace the current single `if`:
+  ```go
+  if strings.EqualFold(call.Arguments["artifact"], "true") {
+      return writeFileArtifact(ctx, call, ec, path)
+  }
+  ```
+  with:
+  ```go
+  artifactArg := call.Arguments["artifact"]
+  useArtifact := strings.EqualFold(artifactArg, "true")
+  if !useArtifact && artifactArg == "" && ec.DefaultArtifactWrite {
+      useArtifact = true
+  }
+  if useArtifact {
+      return writeFileArtifact(ctx, call, ec, path)
+  }
+  ```
+  This preserves all existing behavior: explicit `"true"` → artifact, explicit non-empty non-`"true"` → workdir. The new path only fires when the arg is absent/empty AND the default is on.
+
+- [x] **C2: Test `DefaultArtifactWrite = true` with absent `artifact` arg writes to artifact dir**
+  `internal/tool/write_file_test.go` — add test `TestWriteFile_DefaultArtifactWrite_True`
+  Call `writeFileExecute` with `ExecContext{Workdir: tmpdir, ArtifactDir: artifactDir, ArtifactTracker: tracker, DefaultArtifactWrite: true}` and no `artifact` key in arguments. Assert file lands in `artifactDir`, not `tmpdir`. Assert result content contains `"(artifact)"`.
+
+- [x] **C3: Test `DefaultArtifactWrite = true` with explicit `artifact = "false"` writes to workdir**
+  `internal/tool/write_file_test.go` — add test `TestWriteFile_DefaultArtifactWrite_ExplicitFalse`
+  Same setup as C2 but set `Arguments["artifact"] = "false"`. Assert file lands in `tmpdir`, not `artifactDir`.
+
+- [x] **C4: Test `DefaultArtifactWrite = false` with absent `artifact` arg writes to workdir**
+  `internal/tool/write_file_test.go` — add test `TestWriteFile_DefaultArtifactWrite_False`
+  Call with `ExecContext{Workdir: tmpdir, ArtifactDir: artifactDir, DefaultArtifactWrite: false}` and no `artifact` key. Assert file lands in `tmpdir` (existing behavior preserved).
+
+- [x] **C5: Test `DefaultArtifactWrite = true` with `artifact = "no"` writes to workdir**
+  `internal/tool/write_file_test.go` — add test `TestWriteFile_DefaultArtifactWrite_NonTrueValue`
+  Call with `DefaultArtifactWrite: true` and `Arguments["artifact"] = "no"`. Assert file lands in workdir (non-empty, non-"true" value overrides default).
+
+- [x] **C6: Test `DefaultArtifactWrite = true` but no artifact dir returns error**
+  `internal/tool/write_file_test.go` — add test `TestWriteFile_DefaultArtifactWrite_NoArtifactDir`
+  Call with `ExecContext{Workdir: tmpdir, DefaultArtifactWrite: true}` (no `ArtifactDir` set). Assert `IsError == true` and content contains `"artifact directory not configured"`.
+
+### Group D — Wiring in cmd/run.go (depends on A1 + B1 + B2 + C1)
+
+- [x] **D1: Pass `DefaultArtifactWrite` into `ExecContext` in `dispatchToolCall`**
+  `cmd/run.go` — `dispatchToolCall()` function (line 987)
+  Add `DefaultArtifactWrite` parameter to the function signature and pass it into the `tool.ExecContext` literal.
+
+- [x] **D2: Pass `DefaultArtifactWrite` into `ExecuteOptions` in `executeToolCalls`**
+  `cmd/run.go` — `executeToolCalls()` function (line 908)
+  Add `cfg.Artifacts.DefaultWrite` as `DefaultArtifactWrite` in the `tool.ExecuteOptions` literal (line 911).
+
+- [x] **D3: Pass `DefaultArtifactWrite` to all `dispatchToolCall` call sites in `executeToolCalls`**
+  `cmd/run.go` — `executeToolCalls()` function (lines 935, 939, 955, 959)
+  Add `cfg.Artifacts.DefaultWrite` as the new argument to each `dispatchToolCall()` call.
+
+- [x] **D4: Pass `DefaultArtifactWrite` to `dispatchToolCall` call site in conversation loop**
+  `cmd/run.go` — conversation loop (line 682)
+  The `executeToolCalls` call at line 682 does not need a signature change — `executeToolCalls` reads from `cfg.Artifacts.DefaultWrite` internally (D2). Verify no other `dispatchToolCall` call sites exist outside `executeToolCalls`.
+
+- [x] **D5: Verify all `dispatchToolCall` callers compile**
+  Run `go build ./...` after D1–D4 to confirm all call sites are updated.
+
+### Group E — Integration Tests (depends on Group D)
+
+- [x] **E1: Integration test — agent with `default_write = true`, `write_file` without `artifact` arg**
+  `cmd/run_integration_test.go` — add test `TestIntegration_DefaultArtifactWrite`
+  Create a test agent TOML with `[artifacts] enabled = true, default_write = true`. Use `--json` flag. The agent's system prompt instructs it to call `write_file` with only `path` and `content` (no `artifact` arg). Assert the file appears in the artifact directory and the JSON output includes the artifact entry.
+
+- [x] **E2: Integration test — `default_write = true` with `enabled = false` but `--artifact-dir` flag**
+  `cmd/run_integration_test.go` — add test `TestIntegration_DefaultArtifactWrite_FlagOverride`
+  Agent TOML has `[artifacts] enabled = false, default_write = true`. Run with `--artifact-dir <tmpdir>`. The flag activates the artifact system. Assert `write_file` without `artifact` arg writes to the artifact directory.
+
+### Group F — Documentation (can proceed in parallel with Groups D and E)
+
+- [x] **F1: Update `AGENTS.md` with `default_write` field**
+  `AGENTS.md` — `[artifacts]` TOML example section
+  Add `default_write = true` to the example and a one-line description of the field.
+
+- [x] **F2: Update spec 042 with `default_write` field**
+  `docs/plans/042_artifact_management_spec.md` — Section 2.1 (Agent TOML Configuration)
+  Add `default_write` to the fields table and update the TOML examples.
+
+### Parallelism Summary
+
+```
+Group A ─┐
+         ├──→ Group C ──→ Group D ──→ Group E
+Group B ─┘                      ──→ Group F (parallel with D+E)
+```
+
+- **A** and **B** can proceed in parallel immediately.
+- **C** depends on A1 + B1 (new field on the struct it reads from).
+- **D** depends on A1 + B1 + B2 + C1 (all structs and logic must exist before wiring).
+- **E** depends on D (needs the full pipeline working).
+- **F** can proceed in parallel with D and E.

--- a/docs/plans/047_artifacts_default_write_spec.md
+++ b/docs/plans/047_artifacts_default_write_spec.md
@@ -1,0 +1,156 @@
+# 047 — Artifact Default Write: Configurable `artifact = "true"` Default for `write_file`
+
+**Milestone document:** `docs/plans/042_artifact_management_spec.md`
+
+**Priority:** Medium
+**Status:** Spec
+
+---
+
+## Section 1: Context & Constraints
+
+### Associated Feature
+
+When an agent has the artifact system active (`[artifacts] enabled = true` or `--artifact-dir` flag), the LLM must explicitly pass `artifact = "true"` in every `write_file` tool call for the file to land in the artifact directory. If the LLM omits the parameter, the file is written to the workdir instead — which is rarely the intended behavior for agents configured with artifacts.
+
+Users currently work around this by adding instructions like "When using write_file, always set artifact = 'true'" to the system prompt. This is fragile: it depends on the LLM following instructions rather than on deterministic tool behavior.
+
+### Codebase Structure Relevant to This Feature
+
+- **`ArtifactsConfig` in `internal/agent/agent.go`** currently has two fields: `Enabled bool` and `Dir string`. A new `DefaultWrite bool` field follows the established pattern of nested config blocks.
+
+- **`ExecContext` in `internal/tool/registry.go`** holds `Workdir`, `Stderr`, `Verbose`, `AllowedHosts`, `ArtifactDir`, and `ArtifactTracker`. This struct is passed to all tool executors. A new `DefaultArtifactWrite bool` field will carry the agent's default setting.
+
+- **`ExecuteOptions` in `internal/tool/tool.go`** holds configuration for sub-agent execution, including `ArtifactDir` and `ArtifactTracker`. A new `DefaultArtifactWrite bool` field will carry the setting through to sub-agent tool dispatch.
+
+- **`writeFileExecute` in `internal/tool/write_file.go`** currently checks `call.Arguments["artifact"]` with `strings.EqualFold`. The artifact decision logic is a single `if` statement at the top of the function. The default_write logic extends this exact check.
+
+- **`dispatchToolCall` in `cmd/run.go`** constructs `tool.ExecContext` with `ArtifactDir` and `ArtifactTracker`. It must also pass `DefaultArtifactWrite`.
+
+- **`executeToolCalls` in `cmd/run.go`** constructs `tool.ExecuteOptions` for sub-agent delegation. It must also pass `DefaultArtifactWrite`.
+
+- **`dispatchToolCall` in `internal/tool/tool.go`** (sub-agent conversation loop) constructs `ExecContext` for tool dispatch within sub-agents. It must also pass `DefaultArtifactWrite`.
+
+- **`Scaffold()` in `internal/agent/agent.go`** generates a commented TOML template for new agents. The `[artifacts]` block must include the new field.
+
+- **`Validate()` in `internal/agent/agent.go`** checks constraints on all config blocks. No new validation rules are needed for `default_write` — it is a simple boolean with sensible fallback behavior.
+
+### Decisions Already Made
+
+1. **Configurable per agent, not global.** The `default_write` setting lives in the agent's TOML `[artifacts]` block. This preserves backward compatibility — existing agents without the setting continue to behave identically.
+
+2. **`default_write` only takes effect when the artifact system is active.** If `[artifacts] enabled = false` and no `--artifact-dir` flag is provided, `default_write = true` is silently ignored. The user must still opt into the artifact system explicitly. This keeps concerns separate: `enabled` controls whether the artifact system exists; `default_write` controls the default tool behavior when it does exist.
+
+3. **Explicit `artifact` arguments always override the default.** If the LLM passes `artifact = "false"`, the file is written to the workdir regardless of `default_write`. Only an absent/empty `artifact` argument triggers the default.
+
+4. **`default_write = false` is the implicit default.** When the field is omitted from TOML, behavior is identical to today. No backward compatibility break.
+
+### Approaches Ruled Out
+
+- **Unconditional default to `artifact = "true"`:** Would break backward compatibility for all existing agents that use `write_file` without the `artifact` parameter. Rejected.
+- **System prompt injection:** Adding "always use artifact = true" to the system prompt automatically. This is fragile (LLMs may not follow it) and pollutes the context window. Deterministic tool behavior is superior.
+- **Separate tool (e.g., `write_artifact`):** Adds unnecessary API surface. The `artifact` parameter already exists on `write_file`. The feature is about changing its default, not adding a new tool.
+- **`default_write = true` implying `enabled = true`:** Would couple two concerns. The user might want to set `default_write = true` as a template value without enabling artifacts in every environment. Keeping them separate gives the user control.
+
+### Constraints and Assumptions
+
+- **Backward compatibility is non-negotiable.** Any agent TOML without `default_write` (or with `default_write = false`) must behave identically to today.
+- **`ToolCall.Arguments` values are always strings.** The `artifact` parameter is a string. The absence of the key (or an empty string value) is the trigger for the default — not a boolean zero value.
+- **Sub-agents load their own TOML.** A sub-agent's `default_write` comes from its own TOML, not the parent's. This follows the existing "sub-agents are opaque" principle.
+- **The `--artifact-dir` flag activates the artifact system.** When `--artifact-dir` is passed, the artifact system is active even without `[artifacts] enabled = true` in TOML. In this case, the TOML `default_write` value still applies (it's read from the agent config, not from the flag).
+
+---
+
+## Section 2: Requirements
+
+### 2.1 Agent TOML Configuration
+
+A new optional field must be added to the `[artifacts]` configuration table.
+
+**Fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default_write` | boolean | `false` | When `true` and the artifact system is active, `write_file` tool calls without an explicit `artifact` argument default to writing to the artifact directory. |
+
+**No new validation rules.** The field is a simple boolean. The following scenarios are valid:
+- `default_write = true` with `enabled = true` — active default.
+- `default_write = true` with `enabled = false` — silently ignored (artifact system inactive).
+- `default_write = true` with no `[artifacts]` table — silently ignored (artifact system inactive).
+- `default_write = false` or omitted — existing behavior (backward compatible).
+
+**Example:**
+```toml
+[artifacts]
+enabled = true
+dir = "output"
+default_write = true
+```
+
+### 2.2 Tool Behavior Change: `write_file`
+
+The `write_file` tool must apply the `default_write` setting when the `artifact` argument is absent or empty.
+
+**Artifact resolution logic:**
+
+1. If the `artifact` argument is explicitly `"true"` (case-insensitive) → write to artifact directory.
+2. If the `artifact` argument is explicitly set to any non-empty, non-`"true"` value (e.g., `"false"`, `"no"`) → write to workdir.
+3. If the `artifact` argument is absent or empty **and** `DefaultArtifactWrite` is `true` **and** the artifact system is active → write to artifact directory.
+4. If the `artifact` argument is absent or empty **and** `DefaultArtifactWrite` is `false` (or the artifact system is inactive) → write to workdir.
+
+This preserves the existing behavior for all cases while adding the new default path.
+
+### 2.3 Configuration Threading
+
+The `default_write` value from the agent TOML must be propagated to all tool execution contexts.
+
+**Propagation path:**
+
+1. `cfg.Artifacts.DefaultWrite` is read from the loaded agent config.
+2. It is passed into `tool.ExecContext.DefaultArtifactWrite` for direct tool dispatch in `cmd/run.go`.
+3. It is passed into `tool.ExecuteOptions.DefaultArtifactWrite` for sub-agent delegation in `cmd/run.go`.
+4. Inside `internal/tool/tool.go`, the `dispatchToolCall` function must pass `opts.DefaultArtifactWrite` into `ExecContext.DefaultArtifactWrite` for sub-agent tool dispatch.
+
+**Sub-agent behavior:** A sub-agent loads its own TOML config. Its own `default_write` value applies to its own tool calls. The parent's `default_write` is never inherited.
+
+### 2.4 Scaffold Template
+
+The `axe agents init` scaffold template must include the new field in the commented-out `[artifacts]` block:
+
+```toml
+# [artifacts]
+# enabled = false
+# dir = ""
+# default_write = false
+```
+
+### 2.5 Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Agent TOML has no `[artifacts]` table, no `--artifact-dir` flag | Artifact system inactive. `default_write` is irrelevant. Zero behavior change. |
+| `[artifacts] enabled = false`, `default_write = true`, no flag | Artifact system inactive. `default_write` silently ignored. `write_file` without `artifact` arg writes to workdir. |
+| `[artifacts] enabled = true`, `default_write = true`, `write_file` called without `artifact` arg | File written to artifact directory. |
+| `[artifacts] enabled = true`, `default_write = true`, `write_file` called with `artifact = "false"` | File written to workdir. Explicit argument overrides default. |
+| `[artifacts] enabled = true`, `default_write = true`, `write_file` called with `artifact = "true"` | File written to artifact directory. Same as today. |
+| `[artifacts] enabled = true`, `default_write = false` (or omitted), `write_file` called without `artifact` arg | File written to workdir. Same as today. |
+| `--artifact-dir /tmp/out` with no TOML `[artifacts]` table, `default_write` not in TOML | Artifact system active (flag). `default_write` defaults to `false`. `write_file` without `artifact` arg writes to workdir. |
+| `--artifact-dir /tmp/out` with TOML `default_write = true` but `enabled = false` | Artifact system active (flag). `default_write = true` from TOML applies. `write_file` without `artifact` arg writes to artifact directory. |
+| Sub-agent with `default_write = true` in its own TOML | Sub-agent's `write_file` defaults to artifact mode. Independent of parent. |
+| Sub-agent with no `[artifacts]` in its TOML, parent has `default_write = true` | Sub-agent has no artifact access and no `default_write`. Parent setting does not propagate. |
+| `default_write = true`, artifact system active, `write_file` called with `artifact = "TRUE"` | File written to artifact directory. Case-insensitive match preserved. |
+| `default_write = true`, artifact system active, `write_file` called with `artifact = "no"` | File written to workdir. Non-empty, non-"true" value overrides default. |
+
+### 2.6 Parallel Work
+
+The following work items can proceed in parallel after this spec is approved:
+
+1. **Agent config changes** (`internal/agent/agent.go`, `agent_test.go`, scaffold template) — adding `DefaultWrite` field and updating scaffold.
+2. **Tool execution context changes** (`internal/tool/registry.go`, `internal/tool/tool.go`) — adding `DefaultArtifactWrite` to `ExecContext` and `ExecuteOptions`.
+3. **Write file logic change** (`internal/tool/write_file.go`, `write_file_test.go`) — depends on items 1 and 2 being complete.
+
+Items 1 and 2 are independent of each other. Item 3 depends on both. After all three are complete, the integration work can proceed:
+
+4. **Wiring in cmd/run.go** — depends on items 1, 2, and 3.
+5. **Integration tests** (`cmd/run_integration_test.go`) — depends on item 4.
+6. **Documentation updates** (`AGENTS.md`, `docs/plans/042_artifact_management_spec.md`) — can proceed in parallel with items 4 and 5.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -94,8 +94,9 @@ type BudgetConfig struct {
 
 // ArtifactsConfig holds artifact sub-configuration for an agent.
 type ArtifactsConfig struct {
-	Enabled bool   `toml:"enabled"`
-	Dir     string `toml:"dir"`
+	Enabled      bool   `toml:"enabled"`
+	Dir          string `toml:"dir"`
+	DefaultWrite bool   `toml:"default_write"`
 }
 
 // SubAgentsConfig holds sub-agent execution configuration for an agent.
@@ -449,6 +450,7 @@ model = "provider/model-name"
 # [artifacts]
 # enabled = false
 # dir = ""
+# default_write = false
 `
 	return tmpl, nil
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1816,12 +1816,60 @@ func TestScaffold_IncludesArtifactsConfig(t *testing.T) {
 		"# [artifacts]",
 		"# enabled = false",
 		"# dir = \"\"",
+		"# default_write = false",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
 			t.Errorf("scaffold output missing %q\nfull output:\n%s", check, out)
 		}
 	}
+}
+
+func TestLoad_ArtifactsDefaultWrite(t *testing.T) {
+	t.Run("default_write true", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.toml")
+		content := `name = "test"
+model = "openai/gpt-4o"
+
+[artifacts]
+enabled = true
+dir = "output"
+default_write = true
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cfg.Artifacts.DefaultWrite {
+			t.Error("expected DefaultWrite true, got false")
+		}
+	})
+
+	t.Run("default_write omitted defaults to false", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.toml")
+		content := `name = "test"
+model = "openai/gpt-4o"
+
+[artifacts]
+enabled = true
+dir = "output"
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write: %v", err)
+		}
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Artifacts.DefaultWrite {
+			t.Error("expected DefaultWrite false, got true")
+		}
+	})
 }
 
 // --- Phase 1 Multi-Directory Search Tests ---

--- a/internal/tool/registry.go
+++ b/internal/tool/registry.go
@@ -12,12 +12,13 @@ import (
 
 // ExecContext holds the minimal context needed by generic tool executors.
 type ExecContext struct {
-	Workdir         string
-	Stderr          io.Writer
-	Verbose         bool
-	AllowedHosts    []string
-	ArtifactDir     string
-	ArtifactTracker *artifact.Tracker
+	Workdir              string
+	Stderr               io.Writer
+	Verbose              bool
+	AllowedHosts         []string
+	ArtifactDir          string
+	ArtifactTracker      *artifact.Tracker
+	DefaultArtifactWrite bool
 }
 
 // ToolEntry holds a tool's definition and executor functions.

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -27,21 +27,22 @@ const maxConversationTurns = 50
 
 // ExecuteOptions holds configuration for executing a call_agent tool call.
 type ExecuteOptions struct {
-	AllowedAgents   []string
-	ParentModel     string
-	Depth           int
-	MaxDepth        int
-	Timeout         int
-	GlobalConfig    *config.GlobalConfig
-	MCPRouter       *mcpclient.Router
-	Verbose         bool
-	Stderr          io.Writer
-	BudgetTracker   *budget.BudgetTracker
-	AgentsDir       string // value of --agents-dir flag (may be empty)
-	AgentsBase      string // parent agent's resolved workdir (for auto-discovery)
-	AllowedHosts    []string
-	ArtifactDir     string
-	ArtifactTracker *artifact.Tracker
+	AllowedAgents        []string
+	ParentModel          string
+	Depth                int
+	MaxDepth             int
+	Timeout              int
+	GlobalConfig         *config.GlobalConfig
+	MCPRouter            *mcpclient.Router
+	Verbose              bool
+	Stderr               io.Writer
+	BudgetTracker        *budget.BudgetTracker
+	AgentsDir            string // value of --agents-dir flag (may be empty)
+	AgentsBase           string // parent agent's resolved workdir (for auto-discovery)
+	AllowedHosts         []string
+	ArtifactDir          string
+	ArtifactTracker      *artifact.Tracker
+	DefaultArtifactWrite bool
 }
 
 // CallAgentTool returns the call_agent tool definition for LLM tool calling.
@@ -454,12 +455,13 @@ func dispatchToolCall(ctx context.Context, tc provider.ToolCall, registry *Regis
 	}
 
 	execCtx := ExecContext{
-		Workdir:         toolWorkdir,
-		Stderr:          opts.Stderr,
-		Verbose:         opts.Verbose,
-		AllowedHosts:    opts.AllowedHosts,
-		ArtifactDir:     opts.ArtifactDir,
-		ArtifactTracker: opts.ArtifactTracker,
+		Workdir:              toolWorkdir,
+		Stderr:               opts.Stderr,
+		Verbose:              opts.Verbose,
+		AllowedHosts:         opts.AllowedHosts,
+		ArtifactDir:          opts.ArtifactDir,
+		ArtifactTracker:      opts.ArtifactTracker,
+		DefaultArtifactWrite: opts.DefaultArtifactWrite,
 	}
 	result, dispatchErr := registry.Dispatch(ctx, tc, execCtx)
 	if dispatchErr != nil {

--- a/internal/tool/write_file.go
+++ b/internal/tool/write_file.go
@@ -98,8 +98,12 @@ func writeFileExecute(ctx context.Context, call provider.ToolCall, ec ExecContex
 		toolVerboseLog(ec, toolname.WriteFile, result, summary)
 	}()
 
-	// Check if artifact mode is requested.
-	if strings.EqualFold(call.Arguments["artifact"], "true") {
+	artifactArg := call.Arguments["artifact"]
+	useArtifact := strings.EqualFold(artifactArg, "true")
+	if !useArtifact && artifactArg == "" && ec.DefaultArtifactWrite {
+		useArtifact = true
+	}
+	if useArtifact {
 		return writeFileArtifact(ctx, call, ec, path)
 	}
 

--- a/internal/tool/write_file.go
+++ b/internal/tool/write_file.go
@@ -79,7 +79,7 @@ func writeFileDefinition() provider.Tool {
 			"artifact": {
 				Type:        "string",
 				Required:    false,
-				Description: `When "true", write to the artifact directory instead of the working directory.`,
+				Description: `When "true", write to the artifact directory; when "false", write to the working directory. If omitted, respects the agent-level default_write setting.`,
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func writeFileExecute(ctx context.Context, call provider.ToolCall, ec ExecContex
 
 	artifactArg := call.Arguments["artifact"]
 	useArtifact := strings.EqualFold(artifactArg, "true")
-	if !useArtifact && artifactArg == "" && ec.DefaultArtifactWrite {
+	if artifactArg == "" && ec.DefaultArtifactWrite {
 		useArtifact = true
 	}
 	if useArtifact {

--- a/internal/tool/write_file_test.go
+++ b/internal/tool/write_file_test.go
@@ -335,6 +335,198 @@ func TestWriteFile_Artifact_VerboseLogging(t *testing.T) {
 	}
 }
 
+func TestWriteFile_DefaultArtifactWrite_True(t *testing.T) {
+	tmpdir := t.TempDir()
+	artifactDir := t.TempDir()
+	tracker := artifact.NewTracker()
+
+	entry := writeFileEntry()
+	result := entry.Execute(context.Background(), provider.ToolCall{
+		ID:   "wf-default-artifact",
+		Name: "write_file",
+		Arguments: map[string]string{
+			"path":    "test.txt",
+			"content": "hello default artifact",
+		},
+	}, ExecContext{
+		Workdir:              tmpdir,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      tracker,
+		DefaultArtifactWrite: true,
+	})
+
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content)
+	}
+
+	if !strings.Contains(result.Content, "(artifact)") {
+		t.Errorf("expected artifact marker in content, got %q", result.Content)
+	}
+
+	data, err := os.ReadFile(filepath.Join(artifactDir, "test.txt"))
+	if err != nil {
+		t.Fatalf("file not found in artifact dir: %v", err)
+	}
+	if string(data) != "hello default artifact" {
+		t.Errorf("artifact content: got %q, want %q", string(data), "hello default artifact")
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpdir, "test.txt")); err == nil {
+		t.Error("file should not exist in workdir when DefaultArtifactWrite=true")
+	}
+}
+
+func TestWriteFile_DefaultArtifactWrite_ExplicitFalse(t *testing.T) {
+	tmpdir := t.TempDir()
+	artifactDir := t.TempDir()
+	tracker := artifact.NewTracker()
+
+	entry := writeFileEntry()
+	result := entry.Execute(context.Background(), provider.ToolCall{
+		ID:   "wf-default-artifact-false",
+		Name: "write_file",
+		Arguments: map[string]string{
+			"path":     "test.txt",
+			"content":  "hello workdir",
+			"artifact": "false",
+		},
+	}, ExecContext{
+		Workdir:              tmpdir,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      tracker,
+		DefaultArtifactWrite: true,
+	})
+
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content)
+	}
+
+	if strings.Contains(result.Content, "(artifact)") {
+		t.Errorf("did not expect artifact marker in content, got %q", result.Content)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpdir, "test.txt"))
+	if err != nil {
+		t.Fatalf("file not found in workdir: %v", err)
+	}
+	if string(data) != "hello workdir" {
+		t.Errorf("workdir content: got %q, want %q", string(data), "hello workdir")
+	}
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "test.txt")); err == nil {
+		t.Error("file should not exist in artifact dir when artifact=false")
+	}
+}
+
+func TestWriteFile_DefaultArtifactWrite_False(t *testing.T) {
+	tmpdir := t.TempDir()
+	artifactDir := t.TempDir()
+	tracker := artifact.NewTracker()
+
+	entry := writeFileEntry()
+	result := entry.Execute(context.Background(), provider.ToolCall{
+		ID:   "wf-default-artifact-false",
+		Name: "write_file",
+		Arguments: map[string]string{
+			"path":    "test.txt",
+			"content": "hello workdir",
+		},
+	}, ExecContext{
+		Workdir:              tmpdir,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      tracker,
+		DefaultArtifactWrite: false,
+	})
+
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content)
+	}
+
+	if strings.Contains(result.Content, "(artifact)") {
+		t.Errorf("did not expect artifact marker in content, got %q", result.Content)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpdir, "test.txt"))
+	if err != nil {
+		t.Fatalf("file not found in workdir: %v", err)
+	}
+	if string(data) != "hello workdir" {
+		t.Errorf("workdir content: got %q, want %q", string(data), "hello workdir")
+	}
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "test.txt")); err == nil {
+		t.Error("file should not exist in artifact dir when DefaultArtifactWrite=false")
+	}
+}
+
+func TestWriteFile_DefaultArtifactWrite_NonTrueValue(t *testing.T) {
+	tmpdir := t.TempDir()
+	artifactDir := t.TempDir()
+	tracker := artifact.NewTracker()
+
+	entry := writeFileEntry()
+	result := entry.Execute(context.Background(), provider.ToolCall{
+		ID:   "wf-default-artifact-no",
+		Name: "write_file",
+		Arguments: map[string]string{
+			"path":     "test.txt",
+			"content":  "hello workdir",
+			"artifact": "no",
+		},
+	}, ExecContext{
+		Workdir:              tmpdir,
+		ArtifactDir:          artifactDir,
+		ArtifactTracker:      tracker,
+		DefaultArtifactWrite: true,
+	})
+
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content)
+	}
+
+	if strings.Contains(result.Content, "(artifact)") {
+		t.Errorf("did not expect artifact marker in content, got %q", result.Content)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpdir, "test.txt"))
+	if err != nil {
+		t.Fatalf("file not found in workdir: %v", err)
+	}
+	if string(data) != "hello workdir" {
+		t.Errorf("workdir content: got %q, want %q", string(data), "hello workdir")
+	}
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "test.txt")); err == nil {
+		t.Error("file should not exist in artifact dir when artifact=no")
+	}
+}
+
+func TestWriteFile_DefaultArtifactWrite_NoArtifactDir(t *testing.T) {
+	tmpdir := t.TempDir()
+	tracker := artifact.NewTracker()
+
+	entry := writeFileEntry()
+	result := entry.Execute(context.Background(), provider.ToolCall{
+		ID:   "wf-default-artifact-no-dir",
+		Name: "write_file",
+		Arguments: map[string]string{
+			"path":    "test.txt",
+			"content": "hello default artifact",
+		},
+	}, ExecContext{
+		Workdir:              tmpdir,
+		ArtifactTracker:      tracker,
+		DefaultArtifactWrite: true,
+	})
+
+	if !result.IsError {
+		t.Fatal("expected error, got success")
+	}
+	if !strings.Contains(result.Content, "artifact directory not configured") {
+		t.Errorf("error content %q should contain 'artifact directory not configured'", result.Content)
+	}
+}
+
 func TestWriteFile_Artifact(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Adds an agent-level artifacts default-write option and threads it through tool execution so write_file calls without an explicit artifact argument can default to writing into the configured artifact directory. Includes documentation, config parsing, runtime propagation, tool behavior changes, and tests (unit + integration) to validate the new default-write semantics and artifact directory handling.

## Changelog

### Added
- `[artifacts].default_write` documented in AGENTS.md and shown in the agent scaffold example.
- Artifacts `default_write` TOML field: `ArtifactsConfig.DefaultWrite bool`.
- `DefaultArtifactWrite` flag on tool execution contexts: added to `internal/tool.ExecContext` and `internal/tool.ExecuteOptions`.
- Integration tests verifying default artifact writing behavior and artifact-dir override handling.
- Unit tests covering `DefaultArtifactWrite` scenarios for write_file (omitted arg, explicit false, errors when artifact dir missing, file placement).

### Changed
- Propagate agent artifact default into tool execution:
  - `executeToolCalls` now forwards `cfg.Artifacts.DefaultWrite` into tool execution options / ExecContext.
  - Tool dispatch flow updated to use a shared `tool.ExecContext` (including `DefaultArtifactWrite`) when calling registry dispatchors.
- `write_file` behavior:
  - `writeFileExecute` computes artifact mode using explicit `artifact="true"` OR omitted `artifact` with `DefaultArtifactWrite=true`.
  - Parameter docs updated to explain omitted behavior and agent-level default semantics.
- Tool registry and execute option structs updated to include `DefaultArtifactWrite`.
- Tests and scaffolding updated to cover and display the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->