### PR TITLE
ISS-83: Add Prompt Caching Read/Write Tokens

### DIFF
--- a/docs/plans/049_prompt_caching_implement.md
+++ b/docs/plans/049_prompt_caching_implement.md
@@ -1,0 +1,108 @@
+# Prompt Caching Support
+
+## Section 1: Context Summary
+
+Axe’s multi-turn agent runner re-transmits the full system prompt (skill + files + memory), tool definitions, and message history on every API call. No provider currently sends cache hints, so users pay full input-token costs for static content on every turn. This implementation adds provider-side prompt caching: explicit `cache_control` hints for Anthropic/Bedrock, automatic cache-hit reporting for OpenAI, and cumulative cache-token observability in the runner. Gemini context caching is out of scope; Ollama and OpenCode routes need no changes. Backward compatibility is required: existing agent TOML must work unchanged.
+
+---
+
+## Section 2: Implementation Checklist
+
+### Phase 1: Shared Types (blocks all provider work)
+
+- [x] `internal/provider/provider.go`: Add `CacheReadTokens int` and `CacheWriteTokens int` to `Response` struct.
+- [x] `internal/provider/provider.go`: Add `CacheConfig` field to `Request` struct (or equivalent boolean flags) so the runner can signal that caching is desired. Keep it provider-agnostic.
+- [x] `pkg/runner/run.go`: Update `Result` type to include `CacheReadTokens` and `CacheWriteTokens` (cumulative across turns).
+- [x] `pkg/runner/run.go`: Update `Result` JSON marshaling to include new cache fields.
+
+**Test:** `internal/provider/provider_test.go`: Verify `Response` and `Request` struct composition includes new fields.
+
+---
+
+### Phase 2: Anthropic Provider (explicit cache_control)
+
+- [x] `internal/provider/anthropic.go`: Change `anthropicRequest.System` from `string` to `interface{}` (or add a separate content-block system field) so it can emit either a string or an array of content blocks with `cache_control`.
+- [x] `internal/provider/anthropic.go`: Add `cache_control` field to `anthropicContentBlock` struct (type `map[string]string` or dedicated struct).
+- [x] `internal/provider/anthropic.go`: `Send()` — when `req.CacheConfig` indicates caching, convert system prompt into content block(s) with `cache_control: {type: "ephemeral"}` on the last block instead of sending as plain string.
+- [x] `internal/provider/anthropic.go`: ` anthropicResponse.Usage` struct — add `cache_creation_input_tokens` and `cache_read_input_tokens` fields.
+- [x] `internal/provider/anthropic.go`: `Send()` — populate `Response.CacheReadTokens` and `Response.CacheWriteTokens` from new usage fields.
+- [x] `internal/provider/anthropic.go`: `SendStream()` — same system-prompt caching logic and usage parsing in streaming path.
+- [x] `internal/provider/anthropic.go`: Bump API version constant to a version that supports prompt caching, or verify `2023-06-01` works; update `anthropicVersion` if needed.
+
+**Test:** `internal/provider/anthropic_test.go`:
+- Test that cached system prompt emits array of content blocks with `cache_control` on the last block.
+- Test that non-cached system prompt still emits plain string.
+- Test response parsing with cache usage fields.
+- Test streaming response parsing with cache usage fields.
+
+---
+
+### Phase 3: OpenAI Provider (automatic cache reporting)
+
+- [x] `internal/provider/openai.go`: `openaiResponse.Usage` struct — add `prompt_tokens_details` nested struct with `cached_tokens int`.
+- [x] `internal/provider/openai.go`: `Send()` — map `cached_tokens` to `Response.CacheReadTokens`. No request changes needed.
+- [x] `internal/provider/openai.go`: `openaiStreamUsage` struct — add `prompt_tokens_details` for streaming usage chunk.
+- [x] `internal/provider/openai.go`: `SendStream()` — map cached tokens from final usage chunk to `StreamEvent`/`Response`.
+
+**Test:** `internal/provider/openai_test.go`:
+- Test response parsing when cached_tokens is present.
+- Test response parsing when cached_tokens is absent (graceful zero).
+- Test streaming final usage chunk with cached_tokens.
+
+---
+
+### Phase 4: Bedrock Provider (cachePoint)
+
+- [x] `internal/provider/bedrock.go`: Add `cachePoint` struct for the Converse API wire format.
+- [x] `internal/provider/bedrock.go`: `bedrockSystemBlock` — add optional `cachePoint` field so system prompt blocks can carry cache hints.
+- [x] `internal/provider/bedrock.go`: `bedrockToolConfig` or `bedrockToolDef` — add optional `cachePoint` field if Bedrock supports caching tool definitions (Claude via Bedrock). Verify exact API shape.
+- [x] `internal/provider/bedrock.go`: `buildBedrockRequest()` — when caching is enabled, add `cachePoint` to the last system block and/or tool config block.
+- [x] `internal/provider/bedrock.go`: `bedrockUsage` — add `cacheReadInputTokens` and `cacheWriteInputTokens` fields.
+- [x] `internal/provider/bedrock.go`: `parseBedrockResponse()` — map new usage fields to `Response.CacheReadTokens` and `Response.CacheWriteTokens`.
+
+**Test:** `internal/provider/bedrock_test.go`:
+- Test request construction includes `cachePoint` in system blocks when caching enabled.
+- Test response parsing with cache usage fields.
+- Test graceful handling when provider omits cache fields.
+
+---
+
+### Phase 5: Runner Integration
+
+- [x] `pkg/runner/run.go`: In the request builder, set `req.CacheConfig` (or equivalent) to indicate caching should be used. This should happen unconditionally for all providers that support it; unsupported providers will ignore the flag.
+- [x] `pkg/runner/run.go`: Add `cacheReadTokens` and `cacheWriteTokens` local variables, accumulate them across conversation turns.
+- [x] `pkg/runner/run.go`: In verbose logging, print cache read/write token counts alongside input/output counts (e.g., `Cache: X read, Y written`).
+- [x] `pkg/runner/run.go`: Ensure sub-agent runs (`tool.ExecuteCallAgent`) do not inherit or share parent cache state (each builds its own `Request`). R9 is already satisfied by current architecture; verify no new shared state is introduced.
+
+**Test:** `pkg/runner/run_test.go` (or integration tests):
+- Verify that runner sets cache config on provider requests.
+- Verify cumulative cache token tracking across turns.
+- Verify JSON output contains cache token fields.
+
+---
+
+### Phase 6: Observability & Output
+
+- [x] `pkg/runner/run.go`: Update verbose `stderr` output format to include cache token line.
+- [x] `pkg/runner/run.go`: Ensure `Result` struct and its JSON serialization include `cache_read_tokens` and `cache_write_tokens`.
+
+**Test:** Update golden tests / JSON output tests if they test exact JSON shape.
+
+---
+
+### Phase 7: MiniMax Provider (inherits Anthropic)
+
+- [x] `internal/provider/minimax.go`: Verify that MiniMax inherits Anthropic caching changes automatically because it reuses the `Anthropic` struct and `anthropicRequest` types. No separate work expected unless MiniMax does not support the Anthropic caching API.
+
+---
+
+## Parallel Workstreams
+
+After **Phase 1** (shared types) is complete, the following can proceed in parallel:
+
+- **Phase 2** (Anthropic) + **Phase 3** (OpenAI) — independent providers.
+- **Phase 4** (Bedrock) — independent, though depends on exact Bedrock/Claude cachePoint docs.
+- **Phase 5** (Runner) — depends on Phase 1 only; can be merged before provider phases if the runner sets cache flags that providers currently ignore.
+- **Phase 6** (Observability) — depends on Phase 1 and Phase 5.
+
+**Recommended order:** Phase 1 → Phase 2 + Phase 3 (in parallel) → Phase 4 → Phase 5 → Phase 6 → Phase 7 (verification only).

--- a/docs/plans/049_prompt_caching_spec.md
+++ b/docs/plans/049_prompt_caching_spec.md
@@ -1,0 +1,88 @@
+# Prompt Caching Support
+
+## Section 1: Context & Constraints
+
+### What Exists Today
+
+Axe's runner (`pkg/runner/run.go`) constructs a fresh provider request on every turn of a multi-turn conversation. The request payload includes:
+
+1. The full system prompt (agent `system_prompt` + SKILL.md contents + inlined file contents + memory entries).
+2. The complete set of tool definitions.
+3. The full message history (user message + prior assistant tool calls + tool results).
+
+No provider in the codebase sends explicit cache hints. The Anthropic provider uses API version `2023-06-01` and does not include `cache_control` blocks. The OpenAI provider does not read `usage.prompt_tokens_details.cached_tokens`. The Bedrock provider does not include `cachePoint` blocks. As a result, users pay full input-token costs for the system prompt and tool definitions on every single turn.
+
+### Why This Matters
+
+Multi-turn tool-use is axe's primary execution mode. A typical agent run resends the same large system context and tool schema 3–10 times per run. Provider-side prompt caching reduces input-token costs for repeated prefixes by 50–90% on cache hits.
+
+### Provider Landscape
+
+| Provider | Mechanism | Explicit Control | Notes |
+|---|---|---|---|
+| Anthropic | `cache_control: {type: "ephemeral"}` on content blocks | Yes | Available on Claude 3.5 Sonnet and newer. Usage returns `cache_creation_input_tokens` and `cache_read_input_tokens`. |
+| OpenAI | Automatic prefix caching | No (automatic) | `usage.prompt_tokens_details.cached_tokens` reports cache hits. No request changes needed. |
+| Bedrock (Claude) | `cachePoint` blocks in system/messages/tool config | Yes | Only for supported Claude models via Converse API. Usage returns `cacheReadInputTokens` / `cacheWriteInputTokens`. |
+| Gemini | Context caching API (`cachedContent`) | Yes (stateful) | Requires creating a cache object via a separate API call and referencing it by name in subsequent requests. Conflicts with axe's stateless per-request model. |
+| Ollama | N/A | N/A | Local inference; prompt caching is irrelevant. |
+| OpenCode | Pass-through | Partial | Claude and GPT routes may inherit upstream caching behavior. No explicit gateway-level control assumed. |
+| MiniMax | Pass-through | Partial | Uses Anthropic-compatible API; may inherit Anthropic changes. |
+
+### Constraints
+
+- **Backward compatibility is non-negotiable.** Existing agent TOML files must behave identically when caching is unsupported or unavailable.
+- **No global state.** Axe passes dependencies explicitly. Any cache hint must travel through the existing `provider.Request` abstraction.
+- **Sub-agents are opaque.** A parent agent never sees a sub-agent's internal turns. Cache state must not leak across the sub-agent boundary.
+- **Stateless request model.** The runner builds a new `Request` each turn. We will not introduce cross-request client-side cache state (e.g., Gemini context caching) in this milestone.
+- **Test coverage is required.** Table-driven tests, mock servers, and golden files follow existing patterns.
+- **No TOML changes required for the default path.** Cache hints should be applied automatically where supported. Users should not need to touch agent config to benefit.
+
+### Decisions Already Made / Approaches Ruled Out
+
+- **Gemini context caching is out of scope for this milestone.** It requires a stateful two-phase API (create cache → reference cache in request) that does not fit axe's per-turn request builder.
+- **Stateless design preserved.** We will not hold a long-lived cache reference ID in the runner. Each request is self-contained with inline cache hints.
+
+---
+
+## Section 2: Requirements
+
+### R1: Cache annotations in provider requests
+The provider request abstraction must support attaching cache-control metadata to content blocks. The metadata is opaque to the runner and provider-agnostic at the type level; each provider maps it to its native wire format where applicable.
+
+### R2: Cache metrics in provider responses
+The provider response abstraction must expose cache-related token counts (at minimum: tokens read from cache, tokens written to cache) in addition to standard input and output tokens. Numeric zero values mean "not reported by the provider."
+
+### R3: Anthropic provider caching
+When calling Anthropic models, the provider must send explicit cache-control hints on the system prompt blocks and tool definition blocks. It must parse cache-related usage fields from the API response.
+
+### R4: OpenAI provider cache reporting
+The OpenAI provider must parse `usage.prompt_tokens_details.cached_tokens` (or equivalent) from the API response and surface it as cache read tokens. No request-level changes are required because OpenAI caching is automatic.
+
+### R5: Bedrock provider caching
+When calling Claude models through AWS Bedrock, the provider must send `cachePoint` hints on stable content blocks (system prompt, tool config, message prefixes). It must parse cache usage fields from the Converse API response.
+
+### R6: Runner automatically applies cache hints
+The agent runner must automatically annotate the system prompt and tool definitions with cache hints on every provider request. This must happen without agent TOML changes and without user configuration.
+
+### R7: Observability
+Cache read and write token counts must be:
+- Tracked cumulatively across all turns of a conversation.
+- Included in the JSON output envelope when `--json` is used.
+- Printed in verbose mode alongside input/output token counts.
+
+### R8: Graceful degradation
+If a provider or model does not support caching, if the API rejects a cache hint, or if the response omits cache usage fields, the agent run must continue without error. Cache-related behavior must be silent and safe to ignore.
+
+### R9: Sub-agent isolation
+Each sub-agent invocation is an independent provider request with its own system prompt and tools. Cache hints must be generated independently per sub-agent. No cache state or cache IDs may be shared between parent and child agents.
+
+---
+
+## Parallel Work
+
+The following workstreams can proceed in parallel once the core cache abstraction (R1, R2) is defined:
+
+1. **Anthropic provider** (R3) + **OpenAI provider** (R4) — implemented by the same owner or in parallel.
+2. **Bedrock provider** (R5) — depends on the same abstraction; can proceed concurrently with Anthropic/OpenAI.
+3. **Runner integration** (R6) + **Observability** (R7) — depends on the abstraction; can be developed in parallel with provider implementations.
+4. **Test coverage** — mock server updates, table-driven unit tests, and integration tests can be written in parallel for each provider.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -76,6 +76,7 @@ func (r ResponseFormatConfig) IsSet() bool {
 type ParamsConfig struct {
 	Temperature    float64              `toml:"temperature"`
 	MaxTokens      int                  `toml:"max_tokens"`
+	CacheEnabled   *bool                `toml:"cache_enabled"`
 	ResponseFormat ResponseFormatConfig `toml:"response_format"`
 }
 

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -66,7 +66,7 @@ type anthropicRequest struct {
 	Model       string             `json:"model"`
 	MaxTokens   int                `json:"max_tokens"`
 	Messages    []anthropicMessage `json:"messages"`
-	System      string             `json:"system,omitempty"`
+	System      interface{}        `json:"system,omitempty"`
 	Temperature *float64           `json:"temperature,omitempty"`
 	Tools       []anthropicToolDef `json:"tools,omitempty"`
 	Stream      bool               `json:"stream,omitempty"`
@@ -82,14 +82,15 @@ type anthropicMessage struct {
 // Note: We use pointers/interfaces for optional fields so that omitempty works
 // correctly. For tool_result blocks, is_error must always be present.
 type anthropicContentBlock struct {
-	Type      string                 `json:"type"`
-	Text      string                 `json:"text,omitempty"`
-	ID        string                 `json:"id,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Input     map[string]interface{} `json:"input,omitempty"`
-	ToolUseID string                 `json:"tool_use_id,omitempty"`
-	Content   string                 `json:"content,omitempty"`
-	IsError   *bool                  `json:"is_error,omitempty"`
+	Type         string                 `json:"type"`
+	Text         string                 `json:"text,omitempty"`
+	ID           string                 `json:"id,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	Input        map[string]interface{} `json:"input,omitempty"`
+	ToolUseID    string                 `json:"tool_use_id,omitempty"`
+	Content      string                 `json:"content,omitempty"`
+	IsError      *bool                  `json:"is_error,omitempty"`
+	CacheControl map[string]interface{} `json:"cache_control,omitempty"`
 }
 
 // anthropicToolDef is the wire format for a tool definition in the Anthropic API.
@@ -111,8 +112,10 @@ type anthropicResponse struct {
 	Model      string `json:"model"`
 	StopReason string `json:"stop_reason"`
 	Usage      struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 	} `json:"usage"`
 }
 
@@ -178,9 +181,9 @@ func convertToAnthropicMessages(msgs []Message) []anthropicMessage {
 }
 
 // convertToAnthropicTools converts provider Tools to the Anthropic wire format.
-func convertToAnthropicTools(tools []Tool) []anthropicToolDef {
+func convertToAnthropicTools(tools []Tool, cacheEnabled bool) []anthropicToolDef {
 	var result []anthropicToolDef
-	for _, tool := range tools {
+	for i, tool := range tools {
 		properties := make(map[string]interface{})
 		var required []string
 		for name, param := range tool.Parameters {
@@ -201,13 +204,38 @@ func convertToAnthropicTools(tools []Tool) []anthropicToolDef {
 			schema["required"] = required
 		}
 
-		result = append(result, anthropicToolDef{
+		td := anthropicToolDef{
 			Name:        tool.Name,
 			Description: tool.Description,
 			InputSchema: schema,
-		})
+		}
+		if cacheEnabled && i == len(tools)-1 {
+			td.InputSchema = schema // cache on input_schema is unsupported; skip for now
+		}
+		result = append(result, td)
 	}
 	return result
+}
+
+// buildAnthropicSystem builds the system field for an Anthropic request.
+// When cacheEnabled is true, it returns a content block array with cache_control
+// on the last block. Otherwise, it returns the plain string.
+func buildAnthropicSystem(system string, cacheEnabled bool) interface{} {
+	if system == "" {
+		return nil // nil omits the field with omitempty
+	}
+	if !cacheEnabled {
+		return system
+	}
+	return []map[string]interface{}{
+		{
+			"type": "text",
+			"text": system,
+			"cache_control": map[string]interface{}{
+				"type": "ephemeral",
+			},
+		},
+	}
 }
 
 // Send makes a completion request to the Anthropic Messages API.
@@ -221,7 +249,7 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 		Model:     req.Model,
 		MaxTokens: maxTokens,
 		Messages:  convertToAnthropicMessages(req.Messages),
-		System:    req.System,
+		System:    buildAnthropicSystem(req.System, req.CacheConfig),
 	}
 
 	if req.Temperature != 0 {
@@ -230,7 +258,7 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	if len(req.Tools) > 0 {
-		body.Tools = convertToAnthropicTools(req.Tools)
+		body.Tools = convertToAnthropicTools(req.Tools, req.CacheConfig)
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -314,12 +342,14 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	return &Response{
-		Content:      textContent,
-		Model:        apiResp.Model,
-		InputTokens:  apiResp.Usage.InputTokens,
-		OutputTokens: apiResp.Usage.OutputTokens,
-		StopReason:   apiResp.StopReason,
-		ToolCalls:    toolCalls,
+		Content:          textContent,
+		Model:            apiResp.Model,
+		InputTokens:      apiResp.Usage.InputTokens,
+		OutputTokens:     apiResp.Usage.OutputTokens,
+		CacheReadTokens:  apiResp.Usage.CacheReadInputTokens,
+		CacheWriteTokens: apiResp.Usage.CacheCreationInputTokens,
+		StopReason:       apiResp.StopReason,
+		ToolCalls:        toolCalls,
 	}, nil
 }
 
@@ -357,7 +387,7 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 		Model:     req.Model,
 		MaxTokens: maxTokens,
 		Messages:  convertToAnthropicMessages(req.Messages),
-		System:    req.System,
+		System:    buildAnthropicSystem(req.System, req.CacheConfig),
 		Stream:    true,
 	}
 
@@ -367,7 +397,7 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 	}
 
 	if len(req.Tools) > 0 {
-		body.Tools = convertToAnthropicTools(req.Tools)
+		body.Tools = convertToAnthropicTools(req.Tools, req.CacheConfig)
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -515,15 +545,19 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 				if event.Delta != nil {
 					stopReason = event.Delta.StopReason
 				}
-				var outputTokens int
+				var outputTokens, cacheReadTokens, cacheWriteTokens int
 				if event.Usage != nil {
 					outputTokens = event.Usage.OutputTokens
+					cacheReadTokens = event.Usage.CacheReadInputTokens
+					cacheWriteTokens = event.Usage.CacheCreationInputTokens
 				}
 				return StreamEvent{
-					Type:         StreamEventDone,
-					StopReason:   stopReason,
-					InputTokens:  inputTokens,
-					OutputTokens: outputTokens,
+					Type:             StreamEventDone,
+					StopReason:       stopReason,
+					InputTokens:      inputTokens,
+					OutputTokens:     outputTokens,
+					CacheReadTokens:  cacheReadTokens,
+					CacheWriteTokens: cacheWriteTokens,
 				}, nil
 
 			case "message_stop":

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -181,9 +181,9 @@ func convertToAnthropicMessages(msgs []Message) []anthropicMessage {
 }
 
 // convertToAnthropicTools converts provider Tools to the Anthropic wire format.
-func convertToAnthropicTools(tools []Tool, cacheEnabled bool) []anthropicToolDef {
+func convertToAnthropicTools(tools []Tool) []anthropicToolDef {
 	var result []anthropicToolDef
-	for i, tool := range tools {
+	for _, tool := range tools {
 		properties := make(map[string]interface{})
 		var required []string
 		for name, param := range tool.Parameters {
@@ -208,9 +208,6 @@ func convertToAnthropicTools(tools []Tool, cacheEnabled bool) []anthropicToolDef
 			Name:        tool.Name,
 			Description: tool.Description,
 			InputSchema: schema,
-		}
-		if cacheEnabled && i == len(tools)-1 {
-			td.InputSchema = schema // cache on input_schema is unsupported; skip for now
 		}
 		result = append(result, td)
 	}
@@ -258,7 +255,7 @@ func (a *Anthropic) Send(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	if len(req.Tools) > 0 {
-		body.Tools = convertToAnthropicTools(req.Tools, req.CacheConfig)
+		body.Tools = convertToAnthropicTools(req.Tools)
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -397,7 +394,7 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 	}
 
 	if len(req.Tools) > 0 {
-		body.Tools = convertToAnthropicTools(req.Tools, req.CacheConfig)
+		body.Tools = convertToAnthropicTools(req.Tools)
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -445,6 +442,8 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 
 	parser := NewSSEParser(httpResp.Body)
 	var inputTokens int
+	var cacheReadTokens int
+	var cacheWriteTokens int
 	blocks := make(map[int]anthropicBlockInfo)
 
 	nextFunc := func() (StreamEvent, error) {
@@ -481,6 +480,8 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 			case "message_start":
 				if event.Message != nil && event.Message.Usage != nil {
 					inputTokens = event.Message.Usage.InputTokens
+					cacheReadTokens = event.Message.Usage.CacheReadInputTokens
+					cacheWriteTokens = event.Message.Usage.CacheCreationInputTokens
 				}
 				continue
 
@@ -545,11 +546,9 @@ func (a *Anthropic) SendStream(ctx context.Context, req *Request) (*EventStream,
 				if event.Delta != nil {
 					stopReason = event.Delta.StopReason
 				}
-				var outputTokens, cacheReadTokens, cacheWriteTokens int
+				var outputTokens int
 				if event.Usage != nil {
 					outputTokens = event.Usage.OutputTokens
-					cacheReadTokens = event.Usage.CacheReadInputTokens
-					cacheWriteTokens = event.Usage.CacheCreationInputTokens
 				}
 				return StreamEvent{
 					Type:             StreamEventDone,

--- a/internal/provider/anthropic_stream_test.go
+++ b/internal/provider/anthropic_stream_test.go
@@ -211,6 +211,57 @@ func TestAnthropic_SendStream_ContextCancelled(t *testing.T) {
 
 // --- Task 2.6: Text streaming ---
 
+func TestAnthropic_SendStream_CacheUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSE(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":100,"cache_creation_input_tokens":80,"cache_read_input_tokens":10}}}`)
+		writeSSE(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+		writeSSE(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from cached prompt"}}`)
+		writeSSE(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSE(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`)
+		writeSSE(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	stream, err := a.SendStream(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		CacheConfig: true,
+		Messages:    []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var gotDone StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ev.Type == StreamEventDone {
+			gotDone = ev
+		}
+	}
+
+	if gotDone.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", gotDone.InputTokens)
+	}
+	if gotDone.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", gotDone.OutputTokens)
+	}
+	if gotDone.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens = %d, want 10", gotDone.CacheReadTokens)
+	}
+	if gotDone.CacheWriteTokens != 80 {
+		t.Errorf("CacheWriteTokens = %d, want 80", gotDone.CacheWriteTokens)
+	}
+}
+
 func TestAnthropic_SendStream_TextDeltas(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/provider/anthropic_stream_types.go
+++ b/internal/provider/anthropic_stream_types.go
@@ -16,8 +16,10 @@ type anthropicStreamMessage struct {
 }
 
 type anthropicStreamUsage struct {
-	InputTokens  int `json:"input_tokens,omitempty"`
-	OutputTokens int `json:"output_tokens,omitempty"`
+	InputTokens              int `json:"input_tokens,omitempty"`
+	OutputTokens             int `json:"output_tokens,omitempty"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 }
 
 type anthropicStreamContentBlock struct {

--- a/internal/provider/anthropic_test.go
+++ b/internal/provider/anthropic_test.go
@@ -890,3 +890,161 @@ func TestAnthropic_Send_AssistantToolCallMessage(t *testing.T) {
 		t.Error("assistant message missing tool_use content block")
 	}
 }
+
+// --- Prompt Caching Tests ---
+
+func TestAnthropic_Send_CachedSystemPrompt_EmitsContentBlocks(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content":     []map[string]string{{"type": "text", "text": "ok"}},
+			"model":       "claude-sonnet-4-20250514",
+			"usage":       map[string]int{"input_tokens": 1, "output_tokens": 1},
+			"stop_reason": "end_turn",
+		})
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	_, _ = a.Send(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		System:      "You are a helpful assistant.",
+		CacheConfig: true,
+		Messages:    []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	sysRaw, ok := gotBody["system"].([]interface{})
+	if !ok {
+		t.Fatalf("system should be array when CacheConfig=true, got %T", gotBody["system"])
+	}
+	if len(sysRaw) != 1 {
+		t.Fatalf("system blocks count = %d, want 1", len(sysRaw))
+	}
+	block := sysRaw[0].(map[string]interface{})
+	if block["type"] != "text" {
+		t.Errorf("block.type = %q, want %q", block["type"], "text")
+	}
+	if block["text"] != "You are a helpful assistant." {
+		t.Errorf("block.text = %q, want %q", block["text"], "You are a helpful assistant.")
+	}
+	cacheCtrl, ok := block["cache_control"].(map[string]interface{})
+	if !ok {
+		t.Fatal("cache_control missing on system block")
+	}
+	if cacheCtrl["type"] != "ephemeral" {
+		t.Errorf("cache_control.type = %q, want %q", cacheCtrl["type"], "ephemeral")
+	}
+}
+
+func TestAnthropic_Send_NonCachedSystemPrompt_PlainString(t *testing.T) {
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content":     []map[string]string{{"type": "text", "text": "ok"}},
+			"model":       "claude-sonnet-4-20250514",
+			"usage":       map[string]int{"input_tokens": 1, "output_tokens": 1},
+			"stop_reason": "end_turn",
+		})
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	_, _ = a.Send(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		System:      "You are a helpful assistant.",
+		CacheConfig: false,
+		Messages:    []Message{{Role: "user", Content: "Hi"}},
+	})
+
+	sysRaw, ok := gotBody["system"].(string)
+	if !ok {
+		t.Fatalf("system should be plain string when CacheConfig=false, got %T", gotBody["system"])
+	}
+	if sysRaw != "You are a helpful assistant." {
+		t.Errorf("system = %q, want %q", sysRaw, "You are a helpful assistant.")
+	}
+}
+
+func TestAnthropic_Send_CacheUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content":     []map[string]string{{"type": "text", "text": "Hello from Claude"}},
+			"model":       "claude-sonnet-4-20250514",
+			"stop_reason": "end_turn",
+			"usage": map[string]interface{}{
+				"input_tokens":                100,
+				"output_tokens":               5,
+				"cache_creation_input_tokens": 80,
+				"cache_read_input_tokens":     10,
+			},
+		})
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	resp, err := a.Send(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		CacheConfig: true,
+		Messages:    []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", resp.InputTokens)
+	}
+	if resp.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", resp.OutputTokens)
+	}
+	if resp.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens = %d, want 10", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 80 {
+		t.Errorf("CacheWriteTokens = %d, want 80", resp.CacheWriteTokens)
+	}
+}
+
+func TestAnthropic_Send_CacheUsageOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"content":     []map[string]string{{"type": "text", "text": "Hello"}},
+			"model":       "claude-sonnet-4-20250514",
+			"stop_reason": "end_turn",
+			"usage": map[string]int{
+				"input_tokens":  50,
+				"output_tokens": 5,
+			},
+		})
+	}))
+	defer server.Close()
+
+	a, _ := NewAnthropic("key", WithBaseURL(server.URL))
+	resp, err := a.Send(context.Background(), &Request{
+		Model:       "claude-sonnet-4-20250514",
+		CacheConfig: true,
+		Messages:    []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.CacheReadTokens != 0 {
+		t.Errorf("CacheReadTokens = %d, want 0", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 0 {
+		t.Errorf("CacheWriteTokens = %d, want 0", resp.CacheWriteTokens)
+	}
+}

--- a/internal/provider/bedrock.go
+++ b/internal/provider/bedrock.go
@@ -104,9 +104,15 @@ type bedrockToolResultContent struct {
 	Text string `json:"text,omitempty"`
 }
 
+// bedrockCachePoint is the cache point sentinel used for prompt caching.
+type bedrockCachePoint struct {
+	Type string `json:"type"`
+}
+
 // bedrockSystemBlock is a system prompt block in the Bedrock API.
 type bedrockSystemBlock struct {
-	Text string `json:"text"`
+	Text       string               `json:"text"`
+	CachePoint *bedrockCachePoint `json:"cachePoint,omitempty"`
 }
 
 // bedrockInferenceConfig holds temperature and max token settings.
@@ -117,7 +123,8 @@ type bedrockInferenceConfig struct {
 
 // bedrockToolConfig wraps the tool definitions sent to Bedrock.
 type bedrockToolConfig struct {
-	Tools []bedrockToolDef `json:"tools"`
+	Tools      []bedrockToolDef   `json:"tools"`
+	CachePoint *bedrockCachePoint `json:"cachePoint,omitempty"`
 }
 
 // bedrockToolDef is the wire format for a tool definition in the Bedrock API.
@@ -146,8 +153,10 @@ type bedrockOutput struct {
 
 // bedrockUsage contains token usage information from the Bedrock response.
 type bedrockUsage struct {
-	InputTokens  int `json:"inputTokens"`
-	OutputTokens int `json:"outputTokens"`
+	InputTokens            int `json:"inputTokens"`
+	OutputTokens           int `json:"outputTokens"`
+	CacheReadInputTokens   int `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens  int `json:"cacheWriteInputTokens"`
 }
 
 // bedrockErrorResponse represents a Bedrock API error response.
@@ -177,6 +186,14 @@ func buildBedrockRequest(req *Request) bedrockRequest {
 	}
 	if len(req.Tools) > 0 {
 		br.ToolConfig = &bedrockToolConfig{Tools: convertTools(req.Tools)}
+	}
+	if req.CacheConfig {
+		if len(br.System) > 0 {
+			br.System[len(br.System)-1].CachePoint = &bedrockCachePoint{Type: "default"}
+		}
+		if br.ToolConfig != nil {
+			br.ToolConfig.CachePoint = &bedrockCachePoint{Type: "default"}
+		}
 	}
 	return br
 }
@@ -243,10 +260,12 @@ func convertTools(tools []Tool) []bedrockToolDef {
 // parseBedrockResponse converts a Bedrock API response to a provider Response.
 func parseBedrockResponse(resp *bedrockResponse, model string) *Response {
 	r := &Response{
-		Model:        model,
-		StopReason:   resp.StopReason,
-		InputTokens:  resp.Usage.InputTokens,
-		OutputTokens: resp.Usage.OutputTokens,
+		Model:            model,
+		StopReason:       resp.StopReason,
+		InputTokens:      resp.Usage.InputTokens,
+		OutputTokens:     resp.Usage.OutputTokens,
+		CacheReadTokens:  resp.Usage.CacheReadInputTokens,
+		CacheWriteTokens: resp.Usage.CacheWriteInputTokens,
 	}
 	if resp.Output.Message == nil {
 		return r

--- a/internal/provider/bedrock_test.go
+++ b/internal/provider/bedrock_test.go
@@ -283,98 +283,141 @@ func TestBedrock_Send_Temperature(t *testing.T) {
 	}
 }
 
-func TestBedrock_Send_CachePointInSystem(t *testing.T) {
-	var receivedReq bedrockRequest
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&receivedReq)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(bedrockResponse{
-			Output:     bedrockOutput{Message: &bedrockMessage{Role: "assistant", Content: []bedrockBlock{{Text: "ok"}}}},
-			StopReason: "end_turn",
-		})
-	}))
-	defer server.Close()
-
-	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
-	_, _ = b.Send(context.Background(), &Request{
-		Model:       "test-model",
-		System:      "You are helpful.",
-		CacheConfig: true,
-		Messages:    []Message{{Role: "user", Content: "hi"}},
-	})
-
-	if len(receivedReq.System) != 1 {
-		t.Fatalf("expected 1 system block, got %d", len(receivedReq.System))
-	}
-	if receivedReq.System[0].CachePoint == nil {
-		t.Fatal("expected cachePoint on system block")
-	}
-	if receivedReq.System[0].CachePoint.Type != "default" {
-		t.Errorf("cachePoint.type = %q, want %q", receivedReq.System[0].CachePoint.Type, "default")
-	}
-}
-
-func TestBedrock_Send_CacheUsageParsing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(bedrockResponse{
-			Output: bedrockOutput{Message: &bedrockMessage{
-				Role:    "assistant",
-				Content: []bedrockBlock{{Text: "Hello with cache"}},
-			}},
-			StopReason: "end_turn",
-			Usage: bedrockUsage{
-				InputTokens:           100,
-				OutputTokens:          5,
-				CacheReadInputTokens:  10,
-				CacheWriteInputTokens: 80,
+func TestBedrock_Send_Cache(t *testing.T) {
+	cases := []struct {
+		name                 string
+		setupRequest         func() *Request
+		serverResponse       bedrockResponse
+		wantSystemCachePoint bool
+		wantToolCachePoint   bool
+		wantCacheReadTokens  int
+		wantCacheWriteTokens int
+	}{
+		{
+			name: "system block gets cache point",
+			setupRequest: func() *Request {
+				return &Request{
+					Model:       "test-model",
+					System:      "You are helpful.",
+					CacheConfig: true,
+					Messages:    []Message{{Role: "user", Content: "hi"}},
+				}
 			},
+			serverResponse: bedrockResponse{
+				Output:     bedrockOutput{Message: &bedrockMessage{Role: "assistant", Content: []bedrockBlock{{Text: "ok"}}}},
+				StopReason: "end_turn",
+			},
+			wantSystemCachePoint: true,
+		},
+		{
+			name: "tool config gets cache point when tools present",
+			setupRequest: func() *Request {
+				return &Request{
+					Model:       "test-model",
+					CacheConfig: true,
+					Messages:    []Message{{Role: "user", Content: "hi"}},
+					Tools: []Tool{{
+						Name:        "read_file",
+						Description: "Read a file",
+						Parameters:  map[string]ToolParameter{"path": {Type: "string", Description: "File path", Required: true}},
+					}},
+				}
+			},
+			serverResponse: bedrockResponse{
+				Output:     bedrockOutput{Message: &bedrockMessage{Role: "assistant", Content: []bedrockBlock{{Text: "ok"}}}},
+				StopReason: "end_turn",
+			},
+			wantToolCachePoint: true,
+		},
+		{
+			name: "cache usage parsing",
+			setupRequest: func() *Request {
+				return &Request{
+					Model:    "test-model",
+					Messages: []Message{{Role: "user", Content: "hi"}},
+				}
+			},
+			serverResponse: bedrockResponse{
+				Output: bedrockOutput{Message: &bedrockMessage{
+					Role:    "assistant",
+					Content: []bedrockBlock{{Text: "Hello with cache"}},
+				}},
+				StopReason: "end_turn",
+				Usage: bedrockUsage{
+					InputTokens:           100,
+					OutputTokens:          5,
+					CacheReadInputTokens:  10,
+					CacheWriteInputTokens: 80,
+				},
+			},
+			wantCacheReadTokens:  10,
+			wantCacheWriteTokens: 80,
+		},
+		{
+			name: "cache usage omitted",
+			setupRequest: func() *Request {
+				return &Request{
+					Model:    "test-model",
+					Messages: []Message{{Role: "user", Content: "hi"}},
+				}
+			},
+			serverResponse: bedrockResponse{
+				Output: bedrockOutput{Message: &bedrockMessage{
+					Role:    "assistant",
+					Content: []bedrockBlock{{Text: "Hello"}},
+				}},
+				StopReason: "end_turn",
+				Usage:      bedrockUsage{InputTokens: 10, OutputTokens: 5},
+			},
+			wantCacheReadTokens:  0,
+			wantCacheWriteTokens: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedReq bedrockRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&receivedReq)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tc.serverResponse)
+			}))
+			defer server.Close()
+
+			b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
+			resp, err := b.Send(context.Background(), tc.setupRequest())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.wantSystemCachePoint {
+				if len(receivedReq.System) != 1 {
+					t.Fatalf("expected 1 system block, got %d", len(receivedReq.System))
+				}
+				if receivedReq.System[0].CachePoint == nil {
+					t.Fatal("expected cachePoint on system block")
+				}
+				if receivedReq.System[0].CachePoint.Type != "default" {
+					t.Errorf("cachePoint.type = %q, want %q", receivedReq.System[0].CachePoint.Type, "default")
+				}
+			}
+			if tc.wantToolCachePoint {
+				if receivedReq.ToolConfig == nil {
+					t.Fatal("expected ToolConfig when tools present")
+				}
+				if receivedReq.ToolConfig.CachePoint == nil {
+					t.Fatal("expected cachePoint on ToolConfig")
+				}
+				if receivedReq.ToolConfig.CachePoint.Type != "default" {
+					t.Errorf("toolConfig cachePoint.type = %q, want %q", receivedReq.ToolConfig.CachePoint.Type, "default")
+				}
+			}
+			if resp.CacheReadTokens != tc.wantCacheReadTokens {
+				t.Errorf("CacheReadTokens = %d, want %d", resp.CacheReadTokens, tc.wantCacheReadTokens)
+			}
+			if resp.CacheWriteTokens != tc.wantCacheWriteTokens {
+				t.Errorf("CacheWriteTokens = %d, want %d", resp.CacheWriteTokens, tc.wantCacheWriteTokens)
+			}
 		})
-	}))
-	defer server.Close()
-
-	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
-	resp, err := b.Send(context.Background(), &Request{
-		Model:    "test-model",
-		Messages: []Message{{Role: "user", Content: "hi"}},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.CacheReadTokens != 10 {
-		t.Errorf("CacheReadTokens = %d, want 10", resp.CacheReadTokens)
-	}
-	if resp.CacheWriteTokens != 80 {
-		t.Errorf("CacheWriteTokens = %d, want 80", resp.CacheWriteTokens)
-	}
-}
-
-func TestBedrock_Send_CacheUsageOmitted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(bedrockResponse{
-			Output: bedrockOutput{Message: &bedrockMessage{
-				Role:    "assistant",
-				Content: []bedrockBlock{{Text: "Hello"}},
-			}},
-			StopReason: "end_turn",
-			Usage:      bedrockUsage{InputTokens: 10, OutputTokens: 5},
-		})
-	}))
-	defer server.Close()
-
-	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
-	resp, err := b.Send(context.Background(), &Request{
-		Model:    "test-model",
-		Messages: []Message{{Role: "user", Content: "hi"}},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.CacheReadTokens != 0 {
-		t.Errorf("CacheReadTokens = %d, want 0", resp.CacheReadTokens)
-	}
-	if resp.CacheWriteTokens != 0 {
-		t.Errorf("CacheWriteTokens = %d, want 0", resp.CacheWriteTokens)
 	}
 }

--- a/internal/provider/bedrock_test.go
+++ b/internal/provider/bedrock_test.go
@@ -282,3 +282,99 @@ func TestBedrock_Send_Temperature(t *testing.T) {
 		t.Error("expected max_tokens 100")
 	}
 }
+
+func TestBedrock_Send_CachePointInSystem(t *testing.T) {
+	var receivedReq bedrockRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedReq)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(bedrockResponse{
+			Output:     bedrockOutput{Message: &bedrockMessage{Role: "assistant", Content: []bedrockBlock{{Text: "ok"}}}},
+			StopReason: "end_turn",
+		})
+	}))
+	defer server.Close()
+
+	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
+	_, _ = b.Send(context.Background(), &Request{
+		Model:       "test-model",
+		System:      "You are helpful.",
+		CacheConfig: true,
+		Messages:    []Message{{Role: "user", Content: "hi"}},
+	})
+
+	if len(receivedReq.System) != 1 {
+		t.Fatalf("expected 1 system block, got %d", len(receivedReq.System))
+	}
+	if receivedReq.System[0].CachePoint == nil {
+		t.Fatal("expected cachePoint on system block")
+	}
+	if receivedReq.System[0].CachePoint.Type != "default" {
+		t.Errorf("cachePoint.type = %q, want %q", receivedReq.System[0].CachePoint.Type, "default")
+	}
+}
+
+func TestBedrock_Send_CacheUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(bedrockResponse{
+			Output: bedrockOutput{Message: &bedrockMessage{
+				Role:    "assistant",
+				Content: []bedrockBlock{{Text: "Hello with cache"}},
+			}},
+			StopReason: "end_turn",
+			Usage: bedrockUsage{
+				InputTokens:           100,
+				OutputTokens:          5,
+				CacheReadInputTokens:  10,
+				CacheWriteInputTokens: 80,
+			},
+		})
+	}))
+	defer server.Close()
+
+	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
+	resp, err := b.Send(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens = %d, want 10", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 80 {
+		t.Errorf("CacheWriteTokens = %d, want 80", resp.CacheWriteTokens)
+	}
+}
+
+func TestBedrock_Send_CacheUsageOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(bedrockResponse{
+			Output: bedrockOutput{Message: &bedrockMessage{
+				Role:    "assistant",
+				Content: []bedrockBlock{{Text: "Hello"}},
+			}},
+			StopReason: "end_turn",
+			Usage:      bedrockUsage{InputTokens: 10, OutputTokens: 5},
+		})
+	}))
+	defer server.Close()
+
+	b, _ := NewBedrock("us-east-1", WithBedrockBaseURL(server.URL), withBedrockCreds(testCreds()))
+	resp, err := b.Send(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CacheReadTokens != 0 {
+		t.Errorf("CacheReadTokens = %d, want 0", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 0 {
+		t.Errorf("CacheWriteTokens = %d, want 0", resp.CacheWriteTokens)
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -127,8 +127,11 @@ type openaiResponse struct {
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
+		PromptTokens        int `json:"prompt_tokens"`
+		CompletionTokens    int `json:"completion_tokens"`
+		PromptTokensDetails struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
 	} `json:"usage"`
 }
 
@@ -345,12 +348,13 @@ func (o *OpenAI) Send(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	return &Response{
-		Content:      content,
-		Model:        apiResp.Model,
-		InputTokens:  apiResp.Usage.PromptTokens,
-		OutputTokens: apiResp.Usage.CompletionTokens,
-		StopReason:   apiResp.Choices[0].FinishReason,
-		ToolCalls:    toolCalls,
+		Content:         content,
+		Model:           apiResp.Model,
+		InputTokens:     apiResp.Usage.PromptTokens,
+		OutputTokens:    apiResp.Usage.CompletionTokens,
+		CacheReadTokens: apiResp.Usage.PromptTokensDetails.CachedTokens,
+		StopReason:      apiResp.Choices[0].FinishReason,
+		ToolCalls:       toolCalls,
 	}, nil
 }
 
@@ -533,10 +537,11 @@ func (o *OpenAI) SendStream(ctx context.Context, req *Request) (*EventStream, er
 				if chunk.Usage != nil {
 					gotUsage = true
 					return StreamEvent{
-						Type:         StreamEventDone,
-						InputTokens:  chunk.Usage.PromptTokens,
-						OutputTokens: chunk.Usage.CompletionTokens,
-						StopReason:   finishReason,
+						Type:            StreamEventDone,
+						InputTokens:     chunk.Usage.PromptTokens,
+						OutputTokens:    chunk.Usage.CompletionTokens,
+						CacheReadTokens: chunk.Usage.PromptTokensDetails.CachedTokens,
+						StopReason:      finishReason,
 					}, nil
 				}
 				continue
@@ -637,8 +642,11 @@ type openaiStreamToolCallFunction struct {
 
 // openaiStreamUsage holds token usage info from the streaming usage chunk.
 type openaiStreamUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
 }
 
 // openaiStreamOptions controls streaming behavior in the request.

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1665,97 +1665,82 @@ func TestOpenAI_Send_JsonSchemaWithoutSchemaReturnsError(t *testing.T) {
 	}
 }
 
-// --- Cache usage tests ---
+func TestOpenAI_CacheUsage(t *testing.T) {
+	cases := []struct {
+		name            string
+		isStream        bool
+		responsePayload []byte
+		wantCacheRead   int
+	}{
+		{
+			name: "send with cached_tokens",
+			responsePayload: []byte(`{
+				"model": "gpt-4o",
+				"choices": [{"message": {"content": "Hello from cached prompt"}, "finish_reason": "stop"}],
+				"usage": {"prompt_tokens": 100, "completion_tokens": 5, "prompt_tokens_details": {"cached_tokens": 80}}
+			}`),
+			wantCacheRead: 80,
+		},
+		{
+			name: "send without cached_tokens",
+			responsePayload: []byte(`{
+				"model": "gpt-4o",
+				"choices": [{"message": {"content": "Hello"}, "finish_reason": "stop"}],
+				"usage": {"prompt_tokens": 10, "completion_tokens": 5}
+			}`),
+			wantCacheRead: 0,
+		},
+		{
+			name:     "stream with cached_tokens",
+			isStream: true,
+			responsePayload: []byte(
+				"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+					"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"prompt_tokens_details\":{\"cached_tokens\":60}}}\n\n" +
+					"data: [DONE]\n\n"),
+			wantCacheRead: 60,
+		},
+	}
 
-func TestOpenAI_Send_CacheUsageParsing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := `{
-			"model": "gpt-4o",
-			"choices": [{
-				"message": {"content": "Hello from cached prompt"},
-				"finish_reason": "stop"
-			}],
-			"usage": {
-				"prompt_tokens": 100,
-				"completion_tokens": 5,
-				"prompt_tokens_details": {"cached_tokens": 80}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.isStream {
+					w.Header().Set("Content-Type", "text/event-stream")
+				}
+				_, _ = w.Write(tc.responsePayload)
+			}))
+			defer server.Close()
+
+			o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+			req := &Request{Model: "gpt-4o", Messages: []Message{{Role: "user", Content: "Hi"}}}
+
+			var got int
+			if tc.isStream {
+				stream, err := o.SendStream(context.Background(), req)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				defer func() { _ = stream.Close() }()
+				// Read the first (and only) event with usage
+				ev, err := stream.Next()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if ev.Type != StreamEventDone {
+					t.Fatalf("expected StreamEventDone, got %q", ev.Type)
+				}
+				got = ev.CacheReadTokens
+			} else {
+				resp, err := o.Send(context.Background(), req)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got = resp.CacheReadTokens
 			}
-		}`
-		_, _ = w.Write([]byte(resp))
-	}))
-	defer server.Close()
 
-	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
-	resp, err := o.Send(context.Background(), &Request{
-		Model:    "gpt-4o",
-		Messages: []Message{{Role: "user", Content: "Hi"}},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.CacheReadTokens != 80 {
-		t.Errorf("CacheReadTokens = %d, want 80", resp.CacheReadTokens)
-	}
-}
-
-func TestOpenAI_Send_CacheUsageOmitted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := `{
-			"model": "gpt-4o",
-			"choices": [{
-				"message": {"content": "Hello"},
-				"finish_reason": "stop"
-			}],
-			"usage": {
-				"prompt_tokens": 10,
-				"completion_tokens": 5
+			if got != tc.wantCacheRead {
+				t.Errorf("CacheReadTokens = %d, want %d", got, tc.wantCacheRead)
 			}
-		}`
-		_, _ = w.Write([]byte(resp))
-	}))
-	defer server.Close()
-
-	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
-	resp, err := o.Send(context.Background(), &Request{
-		Model:    "gpt-4o",
-		Messages: []Message{{Role: "user", Content: "Hi"}},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.CacheReadTokens != 0 {
-		t.Errorf("CacheReadTokens = %d, want 0", resp.CacheReadTokens)
-	}
-}
-
-func TestOpenAI_SendStream_CacheUsageParsing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
-		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"prompt_tokens_details\":{\"cached_tokens\":60}}}\n\n"))
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
-	}))
-	defer server.Close()
-
-	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
-	stream, err := o.SendStream(context.Background(), &Request{
-		Model:    "gpt-4o",
-		Messages: []Message{{Role: "user", Content: "Hi"}},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer func() { _ = stream.Close() }()
-
-	// Skip the done-without-usage event (first finish_reason)
-	ev, err := stream.Next()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if ev.Type != StreamEventDone {
-		t.Fatalf("expected StreamEventDone, got %q", ev.Type)
-	}
-	if ev.CacheReadTokens != 60 {
-		t.Errorf("CacheReadTokens = %d, want 60", ev.CacheReadTokens)
+		})
 	}
 }

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1664,3 +1664,98 @@ func TestOpenAI_Send_JsonSchemaWithoutSchemaReturnsError(t *testing.T) {
 		t.Errorf("expected ErrCategoryBadRequest, got %s", provErr.Category)
 	}
 }
+
+// --- Cache usage tests ---
+
+func TestOpenAI_Send_CacheUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := `{
+			"model": "gpt-4o",
+			"choices": [{
+				"message": {"content": "Hello from cached prompt"},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 100,
+				"completion_tokens": 5,
+				"prompt_tokens_details": {"cached_tokens": 80}
+			}
+		}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	resp, err := o.Send(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CacheReadTokens != 80 {
+		t.Errorf("CacheReadTokens = %d, want 80", resp.CacheReadTokens)
+	}
+}
+
+func TestOpenAI_Send_CacheUsageOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := `{
+			"model": "gpt-4o",
+			"choices": [{
+				"message": {"content": "Hello"},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 10,
+				"completion_tokens": 5
+			}
+		}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	resp, err := o.Send(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CacheReadTokens != 0 {
+		t.Errorf("CacheReadTokens = %d, want 0", resp.CacheReadTokens)
+	}
+}
+
+func TestOpenAI_SendStream_CacheUsageParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"prompt_tokens_details\":{\"cached_tokens\":60}}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	o, _ := NewOpenAI("key", WithOpenAIBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// Skip the done-without-usage event (first finish_reason)
+	ev, err := stream.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Type != StreamEventDone {
+		t.Fatalf("expected StreamEventDone, got %q", ev.Type)
+	}
+	if ev.CacheReadTokens != 60 {
+		t.Errorf("CacheReadTokens = %d, want 60", ev.CacheReadTokens)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -80,20 +80,23 @@ type Request struct {
 	Messages       []Message
 	Temperature    float64
 	MaxTokens      int
+	CacheConfig    bool
 	Tools          []Tool         // Tool definitions to send to the LLM. If nil or empty, no tools are sent.
 	ResponseFormat ResponseFormat // Optional structured output constraint.
 }
 
 // Response represents an LLM completion response.
 type Response struct {
-	Content      string
-	Model        string
-	InputTokens  int
-	OutputTokens int
-	Cost         float64
-	StopReason   string
-	CacheStatus  string
-	ToolCalls    []ToolCall // Tool calls requested by the LLM. Empty if no tools called.
+	Content          string
+	Model            string
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
+	CacheWriteTokens int
+	Cost             float64
+	StopReason       string
+	CacheStatus      string
+	ToolCalls        []ToolCall // Tool calls requested by the LLM. Empty if no tools called.
 }
 
 // Provider defines the interface for LLM providers.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -186,3 +186,27 @@ func TestMessage_ToolResultsField(t *testing.T) {
 		t.Error("ToolResults[1].IsError = false, want true")
 	}
 }
+
+func TestResponse_CacheTokens(t *testing.T) {
+	resp := &Response{
+		Content:          "hello",
+		CacheReadTokens:  42,
+		CacheWriteTokens: 7,
+	}
+	if resp.CacheReadTokens != 42 {
+		t.Errorf("CacheReadTokens = %d, want 42", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 7 {
+		t.Errorf("CacheWriteTokens = %d, want 7", resp.CacheWriteTokens)
+	}
+}
+
+func TestRequest_CacheConfig(t *testing.T) {
+	req := &Request{
+		Model:       "anthropic/claude-sonnet-4-20250514",
+		CacheConfig: true,
+	}
+	if !req.CacheConfig {
+		t.Error("CacheConfig = false, want true")
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -188,25 +188,61 @@ func TestMessage_ToolResultsField(t *testing.T) {
 }
 
 func TestResponse_CacheTokens(t *testing.T) {
-	resp := &Response{
-		Content:          "hello",
-		CacheReadTokens:  42,
-		CacheWriteTokens: 7,
+	cases := []struct {
+		name             string
+		resp             *Response
+		wantReadTokens   int
+		wantWriteTokens  int
+	}{
+		{
+			name:            "both cache tokens populated",
+			resp:            &Response{Content: "hello", CacheReadTokens: 42, CacheWriteTokens: 7},
+			wantReadTokens:  42,
+			wantWriteTokens: 7,
+		},
+		{
+			name:            "zero values",
+			resp:            &Response{Content: "hello"},
+			wantReadTokens:  0,
+			wantWriteTokens: 0,
+		},
 	}
-	if resp.CacheReadTokens != 42 {
-		t.Errorf("CacheReadTokens = %d, want 42", resp.CacheReadTokens)
-	}
-	if resp.CacheWriteTokens != 7 {
-		t.Errorf("CacheWriteTokens = %d, want 7", resp.CacheWriteTokens)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.resp.CacheReadTokens != tc.wantReadTokens {
+				t.Errorf("CacheReadTokens = %d, want %d", tc.resp.CacheReadTokens, tc.wantReadTokens)
+			}
+			if tc.resp.CacheWriteTokens != tc.wantWriteTokens {
+				t.Errorf("CacheWriteTokens = %d, want %d", tc.resp.CacheWriteTokens, tc.wantWriteTokens)
+			}
+		})
 	}
 }
 
 func TestRequest_CacheConfig(t *testing.T) {
-	req := &Request{
-		Model:       "anthropic/claude-sonnet-4-20250514",
-		CacheConfig: true,
+	cases := []struct {
+		name            string
+		req             *Request
+		wantCacheConfig bool
+	}{
+		{
+			name:            "cache enabled",
+			req:             &Request{Model: "anthropic/claude-sonnet-4-20250514", CacheConfig: true},
+			wantCacheConfig: true,
+		},
+		{
+			name:            "cache disabled",
+			req:             &Request{Model: "anthropic/claude-sonnet-4-20250514", CacheConfig: false},
+			wantCacheConfig: false,
+		},
 	}
-	if !req.CacheConfig {
-		t.Error("CacheConfig = false, want true")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.req.CacheConfig != tc.wantCacheConfig {
+				t.Errorf("CacheConfig = %v, want %v", tc.req.CacheConfig, tc.wantCacheConfig)
+			}
+		})
 	}
 }

--- a/internal/provider/stream.go
+++ b/internal/provider/stream.go
@@ -15,16 +15,18 @@ const (
 )
 
 type StreamEvent struct {
-	Type         string
-	Text         string
-	ToolCallID   string
-	ToolName     string
-	ToolInput    string
-	InputTokens  int
-	OutputTokens int
-	Cost         float64
-	StopReason   string
-	CacheStatus  string
+	Type             string  // one of the constants above
+	Text             string
+	ToolCallID       string
+	ToolName         string
+	ToolInput        string
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
+	CacheWriteTokens int
+	Cost             float64
+	StopReason       string
+	CacheStatus      string
 }
 
 type EventStream struct {

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -130,6 +130,12 @@ func (m *MockLLMServer) RequestCount() int {
 	return m.callIndex
 }
 
+// AnthropicResponseWithCacheTokens returns a MockLLMResponse with cache token counts.
+func AnthropicResponseWithCacheTokens(text string, inputTokens, outputTokens, cacheRead, cacheWrite int) MockLLMResponse {
+	body := fmt.Sprintf(`{"id":"msg_mock","type":"message","role":"assistant","content":[{"type":"text","text":%s}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":%d,"output_tokens":%d,"cache_creation_input_tokens":%d,"cache_read_input_tokens":%d}}`, jsonString(text), inputTokens, outputTokens, cacheWrite, cacheRead)
+	return MockLLMResponse{StatusCode: 200, Body: body}
+}
+
 // AnthropicResponse returns a MockLLMResponse with a valid Anthropic messages API
 // response containing the given text.
 func AnthropicResponse(text string) MockLLMResponse {
@@ -169,6 +175,20 @@ func AnthropicToolUseResponseWithTokens(text string, toolCalls []MockToolCall, i
 	}
 
 	body := fmt.Sprintf(`{"id":"msg_mock","type":"message","role":"assistant","content":[%s],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":%d,"output_tokens":%d}}`, strings.Join(blocks, ","), inputTokens, outputTokens)
+	return MockLLMResponse{StatusCode: 200, Body: body}
+}
+
+// AnthropicToolUseResponseWithCacheTokens returns a MockLLMResponse with tool calls and cache token counts.
+func AnthropicToolUseResponseWithCacheTokens(text string, toolCalls []MockToolCall, inputTokens, outputTokens, cacheRead, cacheWrite int) MockLLMResponse {
+	var blocks []string
+	blocks = append(blocks, fmt.Sprintf(`{"type":"text","text":%s}`, jsonString(text)))
+
+	for _, tc := range toolCalls {
+		inputJSON, _ := json.Marshal(tc.Input)
+		blocks = append(blocks, fmt.Sprintf(`{"type":"tool_use","id":%s,"name":%s,"input":%s}`, jsonString(tc.ID), jsonString(tc.Name), string(inputJSON)))
+	}
+
+	body := fmt.Sprintf(`{"id":"msg_mock","type":"message","role":"assistant","content":[%s],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":%d,"output_tokens":%d,"cache_creation_input_tokens":%d,"cache_read_input_tokens":%d}}`, strings.Join(blocks, ","), inputTokens, outputTokens, cacheWrite, cacheRead)
 	return MockLLMResponse{StatusCode: 200, Body: body}
 }
 

--- a/pkg/runner/result.go
+++ b/pkg/runner/result.go
@@ -51,23 +51,25 @@ type DryRunInfo struct {
 
 // Result captures all outputs of a completed agent run.
 type Result struct {
-	Content         string           `json:"content"`
-	Model           string           `json:"model"`
-	InputTokens     int              `json:"input_tokens"`
-	OutputTokens    int              `json:"output_tokens"`
-	Cost            float64          `json:"cost"`
-	StopReason      string           `json:"stop_reason"`
-	CacheStatus     string           `json:"cache_status"`
-	ToolCalls       int              `json:"tool_calls"`
-	ToolCallDetails []ToolCallDetail `json:"tool_call_details"`
-	DurationMs      int64            `json:"duration_ms"`
-	Refused         bool             `json:"refused"`
-	RetryAttempts   int              `json:"retry_attempts"`
-	Budget          BudgetState      `json:"budget"`
-	Artifacts       []ArtifactInfo   `json:"artifacts"`
-	DryRun          bool             `json:"dry_run"`
-	DryRunInfo      *DryRunInfo      `json:"-"`
-	Messages        []Message        `json:"messages"`
+	Content          string           `json:"content"`
+	Model            string           `json:"model"`
+	InputTokens      int              `json:"input_tokens"`
+	OutputTokens     int              `json:"output_tokens"`
+	CacheReadTokens  int              `json:"cache_read_tokens"`
+	CacheWriteTokens int              `json:"cache_write_tokens"`
+	Cost             float64          `json:"cost"`
+	StopReason       string           `json:"stop_reason"`
+	CacheStatus      string           `json:"cache_status"`
+	ToolCalls        int              `json:"tool_calls"`
+	ToolCallDetails  []ToolCallDetail `json:"tool_call_details"`
+	DurationMs       int64            `json:"duration_ms"`
+	Refused          bool             `json:"refused"`
+	RetryAttempts    int              `json:"retry_attempts"`
+	Budget           BudgetState      `json:"budget"`
+	Artifacts        []ArtifactInfo   `json:"artifacts"`
+	DryRun           bool             `json:"dry_run"`
+	DryRunInfo       *DryRunInfo      `json:"-"`
+	Messages         []Message        `json:"messages"`
 }
 
 // MarshalJSON produces JSON output that matches the legacy CLI format:
@@ -121,6 +123,12 @@ func (r Result) MarshalJSON() ([]byte, error) {
 	}
 	if r.CacheStatus != "" {
 		m["cache_status"] = r.CacheStatus
+	}
+	if r.CacheReadTokens != 0 {
+		m["cache_read_tokens"] = r.CacheReadTokens
+	}
+	if r.CacheWriteTokens != 0 {
+		m["cache_write_tokens"] = r.CacheWriteTokens
 	}
 	m["duration_ms"] = r.DurationMs
 	m["input_tokens"] = r.InputTokens

--- a/pkg/runner/result_test.go
+++ b/pkg/runner/result_test.go
@@ -62,11 +62,11 @@ func TestResultMarshalJSON_TableDriven(t *testing.T) {
 
 func TestResultMarshalJSON_WithMessages(t *testing.T) {
 	result := Result{
-		Content:     "Hello",
-		InputTokens: 10,
+		Content:      "Hello",
+		InputTokens:  10,
 		OutputTokens: 5,
-		Model:       "openai/gpt-4",
-		StopReason:  "stop",
+		Model:        "openai/gpt-4",
+		StopReason:   "stop",
 		Messages: []Message{
 			{Role: "user", Content: "hi"},
 			{Role: "assistant", Content: "Hello"},
@@ -106,11 +106,11 @@ func TestResultMarshalJSON_WithMessages(t *testing.T) {
 
 func TestResultMarshalJSON_WithMessagesAndToolCalls(t *testing.T) {
 	result := Result{
-		Content:     "Done",
-		InputTokens: 10,
+		Content:      "Done",
+		InputTokens:  10,
 		OutputTokens: 5,
-		Model:       "openai/gpt-4",
-		StopReason:  "stop",
+		Model:        "openai/gpt-4",
+		StopReason:   "stop",
 		Messages: []Message{
 			{Role: "user", Content: "list"},
 			{
@@ -222,5 +222,55 @@ func TestToolCallDetailJSON(t *testing.T) {
 	}
 	if inputMap2["mode"] != "full" {
 		t.Fatalf("expected input.mode=full, got %v", inputMap2["mode"])
+	}
+}
+
+func TestResultMarshalJSON_CacheTokens(t *testing.T) {
+	result := Result{
+		Content:          "Hello",
+		InputTokens:      10,
+		OutputTokens:     5,
+		Model:            "openai/gpt-4",
+		StopReason:       "stop",
+		CacheReadTokens:  42,
+		CacheWriteTokens: 7,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if r, ok := parsed["cache_read_tokens"].(float64); !ok || r != 42 {
+		t.Errorf("cache_read_tokens = %v, want 42", parsed["cache_read_tokens"])
+	}
+	if w, ok := parsed["cache_write_tokens"].(float64); !ok || w != 7 {
+		t.Errorf("cache_write_tokens = %v, want 7", parsed["cache_write_tokens"])
+	}
+}
+
+func TestResultMarshalJSON_CacheTokensOmittedWhenZero(t *testing.T) {
+	result := Result{
+		Content:      "Hello",
+		InputTokens:  10,
+		OutputTokens: 5,
+		Model:        "openai/gpt-4",
+		StopReason:   "stop",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if _, ok := parsed["cache_read_tokens"]; ok {
+		t.Error("expected cache_read_tokens to be omitted")
+	}
+	if _, ok := parsed["cache_write_tokens"]; ok {
+		t.Error("expected cache_write_tokens to be omitted")
 	}
 }

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -552,10 +552,10 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			_, _ = fmt.Fprintf(stderr, "Duration: %dms\n", time.Since(start).Milliseconds())
 			if tracker.Max() > 0 {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output (cumulative, budget: %d/%d)\n", resp.InputTokens, resp.OutputTokens, tracker.Used(), tracker.Max())
+				_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", resp.CacheReadTokens, resp.CacheWriteTokens)
 			} else {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output\n", resp.InputTokens, resp.OutputTokens)
 			}
-			_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", resp.CacheReadTokens, resp.CacheWriteTokens)
 			_, _ = fmt.Fprintf(stderr, "Stop:     %s\n", resp.StopReason)
 		}
 	} else {
@@ -680,10 +680,10 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			_, _ = fmt.Fprintf(stderr, "Duration: %dms\n", time.Since(start).Milliseconds())
 			if tracker.Max() > 0 {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output (cumulative, budget: %d/%d)\n", totalInputTokens, totalOutputTokens, tracker.Used(), tracker.Max())
+				_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", totalCacheReadTokens, totalCacheWriteTokens)
 			} else {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output (cumulative)\n", totalInputTokens, totalOutputTokens)
 			}
-			_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", totalCacheReadTokens, totalCacheWriteTokens)
 			_, _ = fmt.Fprintf(stderr, "Stop:     %s\n", resp.StopReason)
 		}
 	}

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -368,13 +368,19 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		messages = []provider.Message{{Role: "user", Content: userMessage}}
 	}
 
+	// cacheEnabled defaults to true; agent TOML can opt out via params.cache_enabled.
+	cacheEnabled := true
+	if cfg.Params.CacheEnabled != nil {
+		cacheEnabled = *cfg.Params.CacheEnabled
+	}
+
 	req := &provider.Request{
 		Model:       modelName,
 		System:      systemPrompt,
 		Messages:    messages,
 		Temperature: cfg.Params.Temperature,
 		MaxTokens:   cfg.Params.MaxTokens,
-		CacheConfig: true,
+		CacheConfig: cacheEnabled,
 	}
 
 	if cfg.Params.ResponseFormat.IsSet() {

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -374,6 +374,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		Messages:    messages,
 		Temperature: cfg.Params.Temperature,
 		MaxTokens:   cfg.Params.MaxTokens,
+		CacheConfig: true,
 	}
 
 	if cfg.Params.ResponseFormat.IsSet() {
@@ -492,7 +493,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	// Step 18: Run execution
 	var resp *provider.Response
-	var totalInputTokens, totalOutputTokens, totalToolCalls int
+	var totalInputTokens, totalOutputTokens, totalCacheReadTokens, totalCacheWriteTokens, totalToolCalls int
 	var allToolCallDetails []ToolCallDetail
 	var streamedText bool
 
@@ -539,6 +540,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		})
 		totalInputTokens = resp.InputTokens
 		totalOutputTokens = resp.OutputTokens
+		totalCacheReadTokens = resp.CacheReadTokens
+		totalCacheWriteTokens = resp.CacheWriteTokens
 		tracker.Add(resp.InputTokens, resp.OutputTokens)
 
 		if tracker.Exceeded() {
@@ -552,6 +555,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			} else {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output\n", resp.InputTokens, resp.OutputTokens)
 			}
+			_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", resp.CacheReadTokens, resp.CacheWriteTokens)
 			_, _ = fmt.Fprintf(stderr, "Stop:     %s\n", resp.StopReason)
 		}
 	} else {
@@ -591,6 +595,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 			totalInputTokens += resp.InputTokens
 			totalOutputTokens += resp.OutputTokens
+			totalCacheReadTokens += resp.CacheReadTokens
+			totalCacheWriteTokens += resp.CacheWriteTokens
 			tracker.Add(resp.InputTokens, resp.OutputTokens)
 
 			if opts.Verbose {
@@ -677,6 +683,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			} else {
 				_, _ = fmt.Fprintf(stderr, "Tokens:   %d input, %d output (cumulative)\n", totalInputTokens, totalOutputTokens)
 			}
+			_, _ = fmt.Fprintf(stderr, "Cache:    %d read, %d written\n", totalCacheReadTokens, totalCacheWriteTokens)
 			_, _ = fmt.Fprintf(stderr, "Stop:     %s\n", resp.StopReason)
 		}
 	}
@@ -685,18 +692,20 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	// Build result
 	result := &Result{
-		Content:         resp.Content,
-		Model:           resp.Model,
-		InputTokens:     totalInputTokens,
-		OutputTokens:    totalOutputTokens,
-		Cost:            resp.Cost,
-		StopReason:      resp.StopReason,
-		CacheStatus:     resp.CacheStatus,
-		ToolCalls:       totalToolCalls,
-		ToolCallDetails: allToolCallDetails,
-		DurationMs:      durationMs,
-		Refused:         refusal.Detect(resp.Content),
-		RetryAttempts:   retryProv.Attempts(),
+		Content:          resp.Content,
+		Model:            resp.Model,
+		InputTokens:      totalInputTokens,
+		OutputTokens:     totalOutputTokens,
+		Cost:             resp.Cost,
+		StopReason:       resp.StopReason,
+		CacheStatus:      resp.CacheStatus,
+		CacheReadTokens:  totalCacheReadTokens,
+		CacheWriteTokens: totalCacheWriteTokens,
+		ToolCalls:        totalToolCalls,
+		ToolCallDetails:  allToolCallDetails,
+		DurationMs:       durationMs,
+		Refused:          refusal.Detect(resp.Content),
+		RetryAttempts:    retryProv.Attempts(),
 		Budget: BudgetState{
 			Max:      tracker.Max(),
 			Used:     tracker.Used(),
@@ -769,6 +778,7 @@ func drainEventStream(stream *provider.EventStream, w io.Writer) (*provider.Resp
 	var content strings.Builder
 	var toolCalls []provider.ToolCall
 	var inputTokens, outputTokens int
+	var cacheReadTokens, cacheWriteTokens int
 	var cost float64
 	var stopReason string
 	var cacheStatus string
@@ -834,17 +844,21 @@ func drainEventStream(stream *provider.EventStream, w io.Writer) (*provider.Resp
 			cost = ev.Cost
 			stopReason = ev.StopReason
 			cacheStatus = ev.CacheStatus
+			cacheReadTokens = ev.CacheReadTokens
+			cacheWriteTokens = ev.CacheWriteTokens
 		}
 	}
 
 	return &provider.Response{
-		Content:      content.String(),
-		ToolCalls:    toolCalls,
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-		Cost:         cost,
-		StopReason:   stopReason,
-		CacheStatus:  cacheStatus,
+		Content:          content.String(),
+		ToolCalls:        toolCalls,
+		InputTokens:      inputTokens,
+		OutputTokens:     outputTokens,
+		CacheReadTokens:  cacheReadTokens,
+		CacheWriteTokens: cacheWriteTokens,
+		Cost:             cost,
+		StopReason:       stopReason,
+		CacheStatus:      cacheStatus,
 	}, nil
 }
 

--- a/pkg/runner/run_test.go
+++ b/pkg/runner/run_test.go
@@ -93,6 +93,88 @@ model = "anthropic/claude-sonnet-4-20250514"
 	}
 }
 
+func TestRun_SingleShot_CacheTokens(t *testing.T) {
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicResponseWithCacheTokens("Hello with cache", 10, 5, 8, 2),
+	})
+
+	setupTestEnv(t,
+		`[providers.anthropic]
+api_key = "fake-key"
+`,
+		"test-agent",
+		`name = "test-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+`,
+	)
+
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	stdout, stderr := newMockStdoutStderr()
+
+	opts := Options{
+		AgentName: "test-agent",
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+
+	result, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.CacheReadTokens != 8 {
+		t.Errorf("CacheReadTokens = %d, want 8", result.CacheReadTokens)
+	}
+	if result.CacheWriteTokens != 2 {
+		t.Errorf("CacheWriteTokens = %d, want 2", result.CacheWriteTokens)
+	}
+}
+
+func TestRun_ConversationLoop_CacheTokensAccumulate(t *testing.T) {
+	// First response: tool call with cache tokens
+	// Second response: final text with different cache tokens
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicToolUseResponseWithCacheTokens("Let me list", []testutil.MockToolCall{
+			{ID: "tool_1", Name: "list_directory", Input: map[string]string{"path": "."}},
+		}, 20, 10, 15, 5),
+		testutil.AnthropicResponseWithCacheTokens("Done", 8, 4, 3, 1),
+	})
+
+	setupTestEnv(t,
+		`[providers.anthropic]
+api_key = "fake-key"
+`,
+		"test-agent",
+		`name = "test-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+tools = ["list_directory"]
+`,
+	)
+
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	stdout, stderr := newMockStdoutStderr()
+
+	opts := Options{
+		AgentName: "test-agent",
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+
+	result, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.CacheReadTokens != 18 {
+		t.Errorf("CacheReadTokens = %d, want 18 (15+3)", result.CacheReadTokens)
+	}
+	if result.CacheWriteTokens != 6 {
+		t.Errorf("CacheWriteTokens = %d, want 6 (5+1)", result.CacheWriteTokens)
+	}
+}
+
 func TestRun_ConversationLoop_OneToolCall(t *testing.T) {
 	// First response: tool call for list_directory
 	// Second response: final text
@@ -535,6 +617,53 @@ model = "anthropic/claude-sonnet-4-20250514"
 	}
 	if mock.RequestCount() != 3 {
 		t.Errorf("RequestCount = %d, want 3", mock.RequestCount())
+	}
+}
+
+func TestRun_JSONOutput_CacheTokens(t *testing.T) {
+	mock := testutil.NewMockLLMServer(t, []testutil.MockLLMResponse{
+		testutil.AnthropicResponseWithCacheTokens("JSON cache test", 10, 5, 8, 2),
+	})
+
+	setupTestEnv(t,
+		`[providers.anthropic]
+api_key = "fake-key"
+`,
+		"test-agent",
+		`name = "test-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+`,
+	)
+
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	stdout, stderr := newMockStdoutStderr()
+
+	opts := Options{
+		AgentName: "test-agent",
+		JSON:      true,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+
+	result, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.CacheReadTokens != 8 {
+		t.Errorf("CacheReadTokens = %d, want 8", result.CacheReadTokens)
+	}
+	if result.CacheWriteTokens != 2 {
+		t.Errorf("CacheWriteTokens = %d, want 2", result.CacheWriteTokens)
+	}
+
+	// Verify JSON output includes cache fields
+	out := stdout.String()
+	if !strings.Contains(out, `"cache_read_tokens"`) {
+		t.Errorf("JSON missing cache_read_tokens: %q", out)
+	}
+	if !strings.Contains(out, `"cache_write_tokens"`) {
+		t.Errorf("JSON missing cache_write_tokens: %q", out)
 	}
 }
 

--- a/pkg/runner/stream_test.go
+++ b/pkg/runner/stream_test.go
@@ -243,3 +243,29 @@ func TestDrainEventStream_EOFWithoutDone(t *testing.T) {
 		t.Errorf("StopReason = %q, want empty", resp.StopReason)
 	}
 }
+
+func TestDrainEventStream_CacheTokensFromDone(t *testing.T) {
+	stream := makeStream([]provider.StreamEvent{
+		{Type: provider.StreamEventDone, InputTokens: 10, OutputTokens: 5, CacheReadTokens: 8, CacheWriteTokens: 2, StopReason: "end_turn"},
+	})
+
+	resp, err := drainEventStream(stream, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.InputTokens != 10 {
+		t.Errorf("InputTokens = %d, want 10", resp.InputTokens)
+	}
+	if resp.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", resp.OutputTokens)
+	}
+	if resp.CacheReadTokens != 8 {
+		t.Errorf("CacheReadTokens = %d, want 8", resp.CacheReadTokens)
+	}
+	if resp.CacheWriteTokens != 2 {
+		t.Errorf("CacheWriteTokens = %d, want 2", resp.CacheWriteTokens)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", resp.StopReason)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
This update adds prompt caching across Anthropic, Bedrock, and OpenAI. It propagates cache token counts through providers, streaming events, run results, and JSON output. It also adds cache and conversation turn configuration.

## Changelog
### Added
- Prompt caching for Anthropic, Bedrock, and OpenAI.
- Cache read/write token fields on responses, stream events, and results.
- `cache_enabled` and `max_turns` agent settings.
- Tests for provider, runner, streaming, and JSON behavior.

### Changed
- Caching is enabled by default and can be disabled with `cache_enabled`.
- Anthropic uses cache-controlled system blocks when caching is enabled.
- Bedrock adds cache points to system prompts and tool configuration.
- OpenAI parses `prompt_tokens_details.cached_tokens`.
- Runner totals accumulate cache tokens across conversation turns.
- Result JSON omits zero-valued cache token fields.
- Conversation loops use `max_turns`, defaulting to 50.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

satisfies #83 