### PR TITLE
feat: configurable max_turns via agent TOML (closes #66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ axe/
 
 ### CLI Commands (`cmd/`)
 
-- **run.go** - Main execution: loads agent, resolves context, calls provider, handles conversation loop (max 50 turns), executes tools (parallel by default), manages memory
+- **run.go** - Main execution: loads agent, resolves context, calls provider, handles conversation loop (`max_turns`, default 50), executes tools (parallel by default), manages memory
 - **agents.go** - Agent management: list, show, init (scaffold), edit (opens $EDITOR)
 - **config.go** - Config init (creates XDG dirs, embeds sample skill), path display
 - **gc.go** - Memory garbage collection with LLM-assisted pattern detection or fallback to max_entries
@@ -84,6 +84,7 @@ system_prompt = "..."            # Optional
 skill = "path/to/SKILL.md"       # Optional (absolute, relative to config dir, or bare name)
 files = ["**/*.go", "README.md"] # Optional (glob patterns)
 workdir = "/path/to/dir"         # Optional (default: cwd, supports ~ and $VAR)
+max_turns = 75                # Optional (default: 50 when unset)
 tools = ["read_file", "write_file"] # Optional (valid: list_directory, read_file, write_file, edit_file, run_command, url_fetch, web_search)
 sub_agents = ["agent1", "agent2"] # Optional (allowed sub-agent names)
 
@@ -172,7 +173,7 @@ region = "us-east-1"
 
 ### Conversation Loop
 
-- **Max 50 turns** - Hard limit in `cmd/run.go` `runAgent()`. Prevents infinite loops.
+- **Configurable max turns** - Set `max_turns` in agent TOML to cap tool-driven conversation loops. Defaults to 50 when unset.
 - **Stops on text response** - Loop exits when LLM returns text without tool calls.
 - **Parallel tool execution** - Default behavior. Set `sub_agents_config.parallel = false` for sequential.
 - **Tool call details** - Captured in JSON output with `--json` flag. Includes arguments, results, truncation status, errors.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ system_prompt = "You are a senior code reviewer. Be concise and actionable."
 skill = "skills/code-review/SKILL.md"
 files = ["src/**/*.go", "CONTRIBUTING.md"]
 workdir = "/home/user/projects/myapp"
+max_turns = 75                # optional; defaults to 50 when unset
 tools = ["read_file", "list_directory", "run_command"]
 sub_agents = ["test-runner", "lint-checker"]
 allowed_hosts = ["api.example.com", "docs.example.com"]
@@ -440,7 +441,7 @@ type = "object"
 
 ## Tools
 
-Agents can use built-in tools to interact with the filesystem and run commands. When tools are enabled, the agent enters a conversation loop — the LLM can make tool calls, receive results, and continue reasoning for up to 50 turns.
+Agents can use built-in tools to interact with the filesystem and run commands. When tools are enabled, the agent enters a conversation loop — the LLM can make tool calls, receive results, and continue reasoning for up to `max_turns` turns (default: 50).
 
 ### Built-in Tools
 

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -94,6 +94,9 @@ var agentsShowCmd = &cobra.Command{
 		if cfg.Timeout > 0 {
 			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Timeout:", cfg.Timeout)
 		}
+		if cfg.MaxTurns > 0 {
+			_, _ = fmt.Fprintf(w, "%-16s%d\n", "Max Turns:", cfg.MaxTurns)
+		}
 		if len(cfg.Tools) > 0 {
 			_, _ = fmt.Fprintf(w, "%-16s%s\n", "Tools:", strings.Join(cfg.Tools, ", "))
 		}

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -270,6 +270,33 @@ timeout = 120
 	}
 }
 
+func TestAgentsShow_MaxTurns(t *testing.T) {
+	agentsDir := setupTestAgentsDir(t)
+
+	toml := `name = "turn-limited"
+model = "anthropic/claude-sonnet-4-20250514"
+max_turns = 25
+`
+	writeTestAgent(t, agentsDir, "turn-limited", toml)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"agents", "show", "turn-limited"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	checks := []string{"Max Turns:", "25"}
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("show output missing %q\nfull output:\n%s", check, output)
+		}
+	}
+}
+
 func TestAgentsShow_NoSubAgentsConfig(t *testing.T) {
 	agentsDir := setupTestAgentsDir(t)
 	writeTestAgent(t, agentsDir, "nosubagents", "name = \"nosubagents\"\nmodel = \"openai/gpt-4o\"")

--- a/docs/src/tools/built-in.md
+++ b/docs/src/tools/built-in.md
@@ -1,6 +1,6 @@
 # Built-in Tools
 
-When tools are enabled, the agent enters a conversation loop — the LLM can make tool calls, receive results, and continue reasoning for up to 50 turns.
+When tools are enabled, the agent enters a conversation loop — the LLM can make tool calls, receive results, and continue reasoning for up to `max_turns` turns (default: 50).
 
 Enable tools by adding them to the agent's `tools` field:
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -124,6 +124,7 @@ type AgentConfig struct {
 	Files         []string          `toml:"files"`
 	Workdir       string            `toml:"workdir"`
 	Timeout       int               `toml:"timeout"`
+	MaxTurns      int               `toml:"max_turns"`
 	Stream        bool              `toml:"stream"`
 	Tools         []string          `toml:"tools"`
 	AllowedHosts  []string          `toml:"allowed_hosts"`
@@ -158,6 +159,9 @@ func Validate(cfg *AgentConfig) error {
 	}
 	if cfg.Timeout < 0 {
 		return &ValidationError{msg: "timeout must be non-negative"}
+	}
+	if cfg.MaxTurns < 0 {
+		return &ValidationError{msg: "max_turns must be non-negative"}
 	}
 	if cfg.Memory.LastN < 0 {
 		return &ValidationError{msg: "memory.last_n must be non-negative"}
@@ -395,6 +399,9 @@ model = "provider/model-name"
 
 # Run timeout in seconds (optional, default: 120)
 # timeout = 120
+
+# Maximum conversation turns when tools are enabled (optional, default: 50)
+# max_turns = 50
 
 # Enable streaming responses (optional, default: false)
 # stream = false

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -110,6 +110,7 @@ system_prompt = "You are helpful."
 skill = "skills/sample/SKILL.md"
 files = ["src/**/*.go", "README.md"]
 workdir = "/tmp/work"
+max_turns = 75
 sub_agents = ["helper", "reviewer"]
 
 [memory]
@@ -147,6 +148,9 @@ max_tokens = 4096
 	}
 	if cfg.Workdir != "/tmp/work" {
 		t.Errorf("Workdir = %q, want %q", cfg.Workdir, "/tmp/work")
+	}
+	if cfg.MaxTurns != 75 {
+		t.Errorf("MaxTurns = %d, want 75", cfg.MaxTurns)
 	}
 	if len(cfg.SubAgents) != 2 || cfg.SubAgents[0] != "helper" || cfg.SubAgents[1] != "reviewer" {
 		t.Errorf("SubAgents = %v, want [helper reviewer]", cfg.SubAgents)
@@ -1748,6 +1752,66 @@ func TestValidate_TopLevelTimeoutZeroAndPositive(t *testing.T) {
 	}
 }
 
+func TestLoad_TopLevelMaxTurns(t *testing.T) {
+	agentsDir := setupAgentsDir(t)
+
+	tomlContent := `
+name = "max-turns-agent"
+model = "openai/gpt-4o"
+max_turns = 75
+`
+	writeAgentFile(t, agentsDir, "max-turns-agent", tomlContent)
+
+	cfg, err := Load("max-turns-agent", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.MaxTurns != 75 {
+		t.Errorf("MaxTurns = %d, want 75", cfg.MaxTurns)
+	}
+}
+
+func TestValidate_TopLevelMaxTurnsNegative(t *testing.T) {
+	cfg := &AgentConfig{
+		Name:     "x",
+		Model:    "p/m",
+		MaxTurns: -1,
+	}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for max_turns=-1, got nil")
+	}
+	want := "max_turns must be non-negative"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidate_TopLevelMaxTurnsZeroAndPositive(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxTurns int
+	}{
+		{name: "zero", maxTurns: 0},
+		{name: "positive", maxTurns: 75},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &AgentConfig{
+				Name:     "x",
+				Model:    "p/m",
+				MaxTurns: tc.maxTurns,
+			}
+			err := Validate(cfg)
+			if err != nil {
+				t.Fatalf("expected no error for max_turns=%d, got %v", tc.maxTurns, err)
+			}
+		})
+	}
+}
+
 func TestScaffold_IncludesTopLevelTimeout(t *testing.T) {
 	out, err := Scaffold("test")
 	if err != nil {
@@ -1755,6 +1819,16 @@ func TestScaffold_IncludesTopLevelTimeout(t *testing.T) {
 	}
 	if !strings.Contains(out, "# timeout = 120") {
 		t.Errorf("scaffold output missing '# timeout = 120'\nfull output:\n%s", out)
+	}
+}
+
+func TestScaffold_IncludesTopLevelMaxTurns(t *testing.T) {
+	out, err := Scaffold("test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "# max_turns = 50") {
+		t.Errorf("scaffold output missing '# max_turns = 50'\nfull output:\n%s", out)
 	}
 }
 

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -22,8 +22,8 @@ import (
 // CallAgentToolName is the constant name for the sub-agent invocation tool.
 const CallAgentToolName = toolname.CallAgent
 
-// maxConversationTurns is the safety limit for the conversation loop.
-const maxConversationTurns = 50
+// defaultMaxConversationTurns is the default safety limit for the conversation loop.
+const defaultMaxConversationTurns = 50
 
 // ExecuteOptions holds configuration for executing a call_agent tool call.
 type ExecuteOptions struct {
@@ -363,6 +363,11 @@ func ExecuteCallAgent(ctx context.Context, call provider.ToolCall, opts ExecuteO
 // runConversationLoop runs the multi-turn conversation loop for a sub-agent.
 // If the sub-agent has no tools, this is a single-shot call.
 func runConversationLoop(ctx context.Context, prov provider.Provider, req *provider.Request, cfg *agent.AgentConfig, registry *Registry, depth int, opts ExecuteOptions, toolWorkdir string) (*provider.Response, error) {
+	maxConversationTurns := cfg.MaxTurns
+	if maxConversationTurns == 0 {
+		maxConversationTurns = defaultMaxConversationTurns
+	}
+
 	var lastResp *provider.Response
 	for turn := 0; turn < maxConversationTurns; turn++ {
 		// Check budget before making LLM call

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -463,6 +463,48 @@ func TestExecuteCallAgent_APIError(t *testing.T) {
 	}
 }
 
+func TestExecuteCallAgent_MaxTurnsConfigured(t *testing.T) {
+	agentsDir := setupToolTestAgentsDir(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":"msg_%d","type":"message","role":"assistant","content":[{"type":"text","text":"Tool call"},{"type":"tool_use","id":"tool_%d","name":"list_directory","input":{"path":"."}}],"model":"claude-sonnet-4-20250514","stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":20}}`, requestCount, requestCount)
+	}))
+	defer server.Close()
+
+	writeToolTestAgent(t, agentsDir, "helper", `name = "helper"
+model = "anthropic/claude-sonnet-4-20250514"
+max_turns = 2
+tools = ["list_directory"]
+`)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", server.URL)
+
+	call := provider.ToolCall{
+		ID:        "test-max-turns",
+		Name:      CallAgentToolName,
+		Arguments: map[string]string{"agent": "helper", "task": "loop until max turns"},
+	}
+	opts := ExecuteOptions{
+		AllowedAgents: []string{"helper"},
+		MaxDepth:      3,
+		Depth:         0,
+		GlobalConfig:  &config.GlobalConfig{},
+	}
+	result := ExecuteCallAgent(context.Background(), call, opts)
+	if !result.IsError {
+		t.Fatal("expected IsError=true for max turns exceeded")
+	}
+	if !strings.Contains(result.Content, "sub-agent exceeded maximum conversation turns (2)") {
+		t.Errorf("Content = %q, want configured max turns error", result.Content)
+	}
+	if requestCount != 2 {
+		t.Errorf("requestCount = %d, want 2", requestCount)
+	}
+}
+
 // TestExecuteCallAgent_DepthLimitNoTools verifies that a sub-agent at the depth limit
 // runs without tools injected, even when the sub-agent has sub_agents configured.
 // This tests Req 10.3: tools are only injected when newDepth < MaxDepth.

--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -29,8 +29,8 @@ import (
 // defaultUserMessage is sent when no stdin content is piped.
 const defaultUserMessage = "Execute the task described in your instructions."
 
-// maxConversationTurns is the safety limit for the conversation loop.
-const maxConversationTurns = 50
+// defaultMaxConversationTurns is the default safety limit for the conversation loop.
+const defaultMaxConversationTurns = 50
 
 const maxToolOutputBytes = 1024
 
@@ -74,6 +74,11 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	if opts.Skill != "" {
 		cfg.Skill = opts.Skill
+	}
+
+	maxConversationTurns := cfg.MaxTurns
+	if maxConversationTurns == 0 {
+		maxConversationTurns = defaultMaxConversationTurns
 	}
 
 	// Step 4: Parse model

--- a/pkg/runner/run_test.go
+++ b/pkg/runner/run_test.go
@@ -957,7 +957,7 @@ enabled = true
 
 func TestRun_MaxTurnsExceeded(t *testing.T) {
 	// Mock always returns a tool call, never a text response.
-	// Need 50 responses (one per max turn).
+	// Need 50 responses (one per default max turn).
 	responses := make([]testutil.MockLLMResponse, 50)
 	for i := range responses {
 		responses[i] = testutil.AnthropicToolUseResponse("Tool call", []testutil.MockToolCall{
@@ -996,6 +996,51 @@ tools = ["list_directory"]
 	}
 	if !strings.Contains(err.Error(), "exceeded maximum conversation turns") {
 		t.Errorf("error message missing 'exceeded maximum conversation turns': %v", err)
+	}
+}
+
+func TestRun_MaxTurnsConfigured(t *testing.T) {
+	responses := make([]testutil.MockLLMResponse, 2)
+	for i := range responses {
+		responses[i] = testutil.AnthropicToolUseResponse("Tool call", []testutil.MockToolCall{
+			{ID: fmt.Sprintf("tool_%d", i), Name: "list_directory", Input: map[string]string{"path": "."}},
+		})
+	}
+	mock := testutil.NewMockLLMServer(t, responses)
+
+	setupTestEnv(t,
+		`[providers.anthropic]
+api_key = "fake-key"
+`,
+		"test-agent",
+		`name = "test-agent"
+model = "anthropic/claude-sonnet-4-20250514"
+max_turns = 2
+tools = ["list_directory"]
+`,
+	)
+
+	t.Setenv("AXE_ANTHROPIC_BASE_URL", mock.URL())
+
+	stdout, stderr := newMockStdoutStderr()
+	opts := Options{
+		AgentName: "test-agent",
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Run() expected error for configured max turns exceeded, got nil")
+	}
+	if !IsRuntimeError(err) {
+		t.Fatalf("expected RuntimeError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "exceeded maximum conversation turns (2)") {
+		t.Errorf("expected configured max turns in error, got: %v", err)
+	}
+	if got := mock.RequestCount(); got != 2 {
+		t.Errorf("RequestCount = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
Closes #66

## Changes
- Added max_turns to AgentConfig struct
- Default to 50 when unset (0)
- Validate() rejects negative values
- Updated cmd/run.go to read from config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes the agent conversation limit configurable through `max_turns` in agent TOML files. The default remains 50 turns when unset or zero. Negative values are rejected, and configured limits are displayed and enforced.

## Changelog

### Added

- `max_turns` to `AgentConfig`.
- `Max Turns` output in `axe agents show`.
- `max_turns` to the agent scaffold template.
- Tests for configuration loading, validation, display, and enforcement.

### Changed

- Conversation loops now use `cfg.MaxTurns` with a 50-turn fallback.
- Documentation now describes `max_turns` and its default.
- README provider documentation now includes Atlas Cloud.
- Scaffold tests now verify the `max_turns` setting.

### Removed

- `TestScaffold_IncludesTopLevelTimeout`, replaced by max-turns coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->