### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ var knownAPIKeyEnvVars = map[string]string{
 	"google":     "GEMINI_API_KEY",
 	"minimax":    "MINIMAX_API_KEY",
 	"openrouter": "OPENROUTER_API_KEY",
+	"requesty":   "REQUESTY_API_KEY",
 }
 
 // APIKeyEnvVar returns the environment variable name used to resolve the API key

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -12,6 +12,7 @@ var supportedProviders = map[string]bool{
 	"minimax":    true,
 	"bedrock":    true,
 	"openrouter": true,
+	"requesty":   true,
 }
 
 // Supported reports whether providerName is a known provider.
@@ -76,8 +77,15 @@ func New(providerName, apiKey, baseURL string) (Provider, error) {
 		}
 		return NewOpenRouter(apiKey, opts...)
 
+	case "requesty":
+		var opts []RequestyOption
+		if baseURL != "" {
+			opts = append(opts, WithRequestyBaseURL(baseURL))
+		}
+		return NewRequesty(apiKey, opts...)
+
 	default:
-		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, openai, ollama, opencode, google, minimax, bedrock, openrouter", providerName)
+		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, openai, ollama, opencode, google, minimax, bedrock, openrouter, requesty", providerName)
 	}
 }
 
@@ -97,4 +105,19 @@ func NewOpenRouterProvider(apiKey, baseURL, referer, title, categories string) (
 		opts = append(opts, WithCategories(categories))
 	}
 	return NewOpenRouter(apiKey, opts...)
+}
+
+// NewRequestyProvider creates a Requesty provider with attribution headers.
+func NewRequestyProvider(apiKey, baseURL, referer, title string) (Provider, error) {
+	var opts []RequestyOption
+	if baseURL != "" {
+		opts = append(opts, WithRequestyBaseURL(baseURL))
+	}
+	if referer != "" {
+		opts = append(opts, WithRequestyReferer(referer))
+	}
+	if title != "" {
+		opts = append(opts, WithRequestyTitle(title))
+	}
+	return NewRequesty(apiKey, opts...)
 }

--- a/internal/provider/requesty.go
+++ b/internal/provider/requesty.go
@@ -1,0 +1,508 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+)
+
+const (
+	// defaultRequestyBaseURL is the default Requesty API base URL.
+	defaultRequestyBaseURL = "https://router.requesty.ai/v1"
+)
+
+// RequestyOption is a functional option for configuring the Requesty provider.
+type RequestyOption func(*Requesty)
+
+// WithRequestyBaseURL sets a custom base URL for the Requesty provider.
+func WithRequestyBaseURL(url string) RequestyOption {
+	return func(o *Requesty) {
+		o.baseURL = url
+	}
+}
+
+// WithRequestyReferer sets the HTTP-Referer header for Requesty app attribution.
+func WithRequestyReferer(referer string) RequestyOption {
+	return func(o *Requesty) {
+		o.referer = referer
+	}
+}
+
+// WithRequestyTitle sets the X-Title header for Requesty app attribution.
+func WithRequestyTitle(title string) RequestyOption {
+	return func(o *Requesty) {
+		o.title = title
+	}
+}
+
+// Requesty implements the Provider interface for the Requesty API.
+type Requesty struct {
+	apiKey  string
+	baseURL string
+	referer string
+	title   string
+	client  *http.Client
+}
+
+// NewRequesty creates a new Requesty provider. Returns an error if apiKey is empty.
+func NewRequesty(apiKey string, opts ...RequestyOption) (*Requesty, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+
+	o := &Requesty{
+		apiKey:  apiKey,
+		baseURL: defaultRequestyBaseURL,
+		client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o, nil
+}
+
+// requestyResponse represents the JSON response from the Requesty API.
+// It extends the OpenAI response shape with Requesty-specific fields.
+type requestyResponse struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Content   *string              `json:"content"`
+			ToolCalls []openaiToolCallWire `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason       string `json:"finish_reason"`
+		NativeFinishReason string `json:"native_finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int     `json:"prompt_tokens"`
+		CompletionTokens int     `json:"completion_tokens"`
+		Cost             float64 `json:"cost"`
+	} `json:"usage"`
+}
+
+// requestyErrorResponse represents a Requesty API error response.
+type requestyErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+// requestyStreamUsage holds token usage info from the streaming usage chunk,
+// including Requesty-specific cost.
+type requestyStreamUsage struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	Cost             float64 `json:"cost"`
+}
+
+// requestyStreamChunk represents a single SSE chunk from Requesty streaming API.
+type requestyStreamChunk struct {
+	Model   string               `json:"model"`
+	Choices []openaiStreamChoice `json:"choices"`
+	Usage   *requestyStreamUsage `json:"usage,omitempty"`
+}
+
+// Send makes a completion request to the Requesty API.
+func (o *Requesty) Send(ctx context.Context, req *Request) (*Response, error) {
+	var messages []Message
+	if req.System != "" {
+		messages = append(messages, Message{Role: "system", Content: req.System})
+	}
+	messages = append(messages, req.Messages...)
+
+	body := openaiRequest{
+		Model:    req.Model,
+		Messages: convertToOpenAIMessages(messages),
+	}
+
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		body.Temperature = &temp
+	}
+
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		body.MaxTokens = &mt
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOpenAITools(req.Tools)
+	}
+
+	if req.ResponseFormat.IsSet() {
+		rf, rfErr := buildOpenAIResponseFormat(req.ResponseFormat)
+		if rfErr != nil {
+			return nil, rfErr
+		}
+		body.ResponseFormat = rf
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	if o.referer != "" {
+		httpReq.Header.Set("HTTP-Referer", o.referer)
+	}
+	if o.title != "" {
+		httpReq.Header.Set("X-Title", o.title)
+	}
+
+	httpResp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	respBody, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, o.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	var apiResp requestyResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  fmt.Sprintf("failed to parse response: %s", err),
+			Err:      err,
+		}
+	}
+
+	if len(apiResp.Choices) == 0 {
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  "response contains no choices",
+		}
+	}
+
+	// Parse content (may be null for tool-call responses)
+	var content string
+	if apiResp.Choices[0].Message.Content != nil {
+		content = *apiResp.Choices[0].Message.Content
+	}
+
+	// Parse tool calls from response
+	var toolCalls []ToolCall
+	for _, tc := range apiResp.Choices[0].Message.ToolCalls {
+		args := make(map[string]string)
+		var rawArgs map[string]interface{}
+		if err := json.Unmarshal([]byte(tc.Function.Arguments), &rawArgs); err == nil {
+			for k, v := range rawArgs {
+				args[k] = fmt.Sprintf("%v", v)
+			}
+		}
+		toolCalls = append(toolCalls, ToolCall{
+			ID:        tc.ID,
+			Name:      tc.Function.Name,
+			Arguments: args,
+		})
+	}
+
+	// Determine stop reason: prefer native if available, else normalized
+	stopReason := apiResp.Choices[0].FinishReason
+	if apiResp.Choices[0].NativeFinishReason != "" {
+		stopReason = apiResp.Choices[0].NativeFinishReason
+	}
+
+	cacheStatus := httpResp.Header.Get("X-OpenRouter-Cache-Status")
+
+	return &Response{
+		Content:      content,
+		Model:        apiResp.Model,
+		InputTokens:  apiResp.Usage.PromptTokens,
+		OutputTokens: apiResp.Usage.CompletionTokens,
+		Cost:         apiResp.Usage.Cost,
+		StopReason:   stopReason,
+		CacheStatus:  cacheStatus,
+		ToolCalls:    toolCalls,
+	}, nil
+}
+
+// SendStream makes a streaming completion request to the Requesty API.
+func (o *Requesty) SendStream(ctx context.Context, req *Request) (*EventStream, error) {
+	var messages []Message
+	if req.System != "" {
+		messages = append(messages, Message{Role: "system", Content: req.System})
+	}
+	messages = append(messages, req.Messages...)
+
+	body := openaiRequest{
+		Model:         req.Model,
+		Messages:      convertToOpenAIMessages(messages),
+		Stream:        true,
+		StreamOptions: &openaiStreamOptions{IncludeUsage: true},
+	}
+
+	if req.Temperature != 0 {
+		temp := req.Temperature
+		body.Temperature = &temp
+	}
+
+	if req.MaxTokens != 0 {
+		mt := req.MaxTokens
+		body.MaxTokens = &mt
+	}
+
+	if len(req.Tools) > 0 {
+		body.Tools = convertToOpenAITools(req.Tools)
+	}
+
+	if req.ResponseFormat.IsSet() {
+		rf, rfErr := buildOpenAIResponseFormat(req.ResponseFormat)
+		if rfErr != nil {
+			return nil, rfErr
+		}
+		body.ResponseFormat = rf
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	if o.referer != "" {
+		httpReq.Header.Set("HTTP-Referer", o.referer)
+	}
+	if o.title != "" {
+		httpReq.Header.Set("X-Title", o.title)
+	}
+
+	httpResp, err := o.client.Do(httpReq)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryTimeout,
+				Message:  ctx.Err().Error(),
+				Err:      ctx.Err(),
+			}
+		}
+		return nil, &ProviderError{
+			Category: ErrCategoryServer,
+			Message:  err.Error(),
+			Err:      err,
+		}
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		respBody, err := io.ReadAll(httpResp.Body)
+		_ = httpResp.Body.Close()
+		if err != nil {
+			return nil, &ProviderError{
+				Category: ErrCategoryServer,
+				Message:  fmt.Sprintf("failed to read error response: %s", err),
+				Err:      err,
+			}
+		}
+		return nil, o.handleErrorResponse(httpResp.StatusCode, respBody)
+	}
+
+	cacheStatus := httpResp.Header.Get("X-OpenRouter-Cache-Status")
+
+	parser := NewSSEParser(httpResp.Body)
+	toolCalls := make(map[int]struct{ id, name string })
+	var finishReason string
+	var gotUsage bool
+	var pendingToolEvents []StreamEvent
+	var pendingToolEnds []StreamEvent
+
+	nextFunc := func() (StreamEvent, error) {
+		for {
+			if len(pendingToolEvents) > 0 {
+				ev := pendingToolEvents[0]
+				pendingToolEvents = pendingToolEvents[1:]
+				return ev, nil
+			}
+
+			if len(pendingToolEnds) > 0 {
+				ev := pendingToolEnds[0]
+				pendingToolEnds = pendingToolEnds[1:]
+				return ev, nil
+			}
+
+			sseEvent, err := parser.Next()
+			if err != nil {
+				if ctx.Err() != nil {
+					return StreamEvent{}, &ProviderError{
+						Category: ErrCategoryTimeout,
+						Message:  ctx.Err().Error(),
+						Err:      ctx.Err(),
+					}
+				}
+				if err == io.EOF {
+					return StreamEvent{}, io.EOF
+				}
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("stream read error: %s", err),
+					Err:      err,
+				}
+			}
+
+			if sseEvent.Data == "[DONE]" {
+				if !gotUsage {
+					return StreamEvent{
+						Type:        StreamEventDone,
+						StopReason:  finishReason,
+						CacheStatus: cacheStatus,
+					}, nil
+				}
+				return StreamEvent{}, io.EOF
+			}
+
+			var chunk requestyStreamChunk
+			if err := json.Unmarshal([]byte(sseEvent.Data), &chunk); err != nil {
+				return StreamEvent{}, &ProviderError{
+					Category: ErrCategoryServer,
+					Message:  fmt.Sprintf("failed to parse streaming chunk: %s", err),
+					Err:      err,
+				}
+			}
+
+			if len(chunk.Choices) == 0 {
+				if chunk.Usage != nil {
+					gotUsage = true
+					return StreamEvent{
+						Type:         StreamEventDone,
+						InputTokens:  chunk.Usage.PromptTokens,
+						OutputTokens: chunk.Usage.CompletionTokens,
+						Cost:         chunk.Usage.Cost,
+						StopReason:   finishReason,
+						CacheStatus:  cacheStatus,
+					}, nil
+				}
+				continue
+			}
+
+			choice := chunk.Choices[0]
+
+			if choice.Delta.Content != nil && *choice.Delta.Content != "" {
+				return StreamEvent{
+					Type: StreamEventText,
+					Text: *choice.Delta.Content,
+				}, nil
+			}
+
+			if len(choice.Delta.ToolCalls) > 0 {
+				for _, tc := range choice.Delta.ToolCalls {
+					if tc.ID != "" {
+						toolCalls[tc.Index] = struct{ id, name string }{id: tc.ID, name: tc.Function.Name}
+						pendingToolEvents = append(pendingToolEvents, StreamEvent{
+							Type:       StreamEventToolStart,
+							ToolCallID: tc.ID,
+							ToolName:   tc.Function.Name,
+						})
+					} else {
+						info := toolCalls[tc.Index]
+						args := ""
+						if tc.Function != nil {
+							args = tc.Function.Arguments
+						}
+						pendingToolEvents = append(pendingToolEvents, StreamEvent{
+							Type:       StreamEventToolDelta,
+							ToolCallID: info.id,
+							ToolInput:  args,
+						})
+					}
+				}
+				continue
+			}
+
+			if choice.FinishReason != nil {
+				fr := *choice.FinishReason
+				finishReason = fr
+				if fr == "tool_calls" {
+					indices := make([]int, 0, len(toolCalls))
+					for idx := range toolCalls {
+						indices = append(indices, idx)
+					}
+					sort.Ints(indices)
+					for _, idx := range indices {
+						info := toolCalls[idx]
+						pendingToolEnds = append(pendingToolEnds, StreamEvent{
+							Type:       StreamEventToolEnd,
+							ToolCallID: info.id,
+						})
+					}
+				}
+				continue
+			}
+
+			continue
+		}
+	}
+
+	return NewEventStream(httpResp.Body, nextFunc), nil
+}
+
+// handleErrorResponse maps HTTP error responses to ProviderError.
+func (o *Requesty) handleErrorResponse(status int, body []byte) *ProviderError {
+	message := http.StatusText(status)
+	var errResp requestyErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		message = errResp.Error.Message
+	}
+
+	return &ProviderError{
+		Category: o.mapStatusToCategory(status),
+		Status:   status,
+		Message:  message,
+	}
+}
+
+// mapStatusToCategory maps HTTP status codes to error categories.
+func (o *Requesty) mapStatusToCategory(status int) ErrorCategory {
+	switch status {
+	case 401, 403:
+		return ErrCategoryAuth
+	case 400, 404:
+		return ErrCategoryBadRequest
+	case 429:
+		return ErrCategoryRateLimit
+	case 500, 502, 503:
+		return ErrCategoryServer
+	default:
+		return ErrCategoryServer
+	}
+}

--- a/internal/provider/requesty_test.go
+++ b/internal/provider/requesty_test.go
@@ -1,0 +1,504 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- Constructor tests ---
+
+func TestNewRequesty(t *testing.T) {
+	cases := []struct {
+		name        string
+		apiKey      string
+		opts        []RequestyOption
+		wantErr     bool
+		wantErrMsg  string
+		wantBaseURL string
+		wantReferer string
+		wantTitle   string
+	}{
+		{
+			name:       "empty API key errors",
+			apiKey:     "",
+			wantErr:    true,
+			wantErrMsg: "API key is required",
+		},
+		{
+			name:        "valid API key",
+			apiKey:      "test-key",
+			wantBaseURL: defaultRequestyBaseURL,
+		},
+		{
+			name:        "custom base URL",
+			apiKey:      "test-key",
+			opts:        []RequestyOption{WithRequestyBaseURL("https://custom.example.com/v1")},
+			wantBaseURL: "https://custom.example.com/v1",
+		},
+		{
+			name:        "all options set",
+			apiKey:      "test-key",
+			opts:        []RequestyOption{WithRequestyReferer("https://example.com"), WithRequestyTitle("My App")},
+			wantBaseURL: defaultRequestyBaseURL,
+			wantReferer: "https://example.com",
+			wantTitle:   "My App",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o, err := NewRequesty(tc.apiKey, tc.opts...)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.wantErrMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if o == nil {
+				t.Fatal("expected non-nil Requesty")
+			}
+			if tc.wantBaseURL != "" && o.baseURL != tc.wantBaseURL {
+				t.Errorf("baseURL = %q, want %q", o.baseURL, tc.wantBaseURL)
+			}
+			if o.referer != tc.wantReferer {
+				t.Errorf("referer = %q, want %q", o.referer, tc.wantReferer)
+			}
+			if o.title != tc.wantTitle {
+				t.Errorf("title = %q, want %q", o.title, tc.wantTitle)
+			}
+		})
+	}
+}
+
+// --- Non-streaming Send tests ---
+
+func TestRequesty_Send_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-OpenRouter-Cache-Status", "HIT")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"model": "anthropic/claude-sonnet-4",
+			"choices": []map[string]interface{}{
+				{
+					"message":              map[string]string{"content": "Hello from Requesty"},
+					"finish_reason":        "stop",
+					"native_finish_reason": "end_turn",
+				},
+			},
+			"usage": map[string]interface{}{
+				"prompt_tokens":     10,
+				"completion_tokens": 5,
+				"cost":              0.00014,
+			},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	resp, err := o.Send(context.Background(), &Request{
+		Model:    "anthropic/claude-sonnet-4",
+		System:   "You are helpful.",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "Hello from Requesty" {
+		t.Errorf("expected 'Hello from Requesty', got %q", resp.Content)
+	}
+	if resp.Model != "anthropic/claude-sonnet-4" {
+		t.Errorf("expected model 'anthropic/claude-sonnet-4', got %q", resp.Model)
+	}
+	if resp.InputTokens != 10 {
+		t.Errorf("expected 10 input tokens, got %d", resp.InputTokens)
+	}
+	if resp.OutputTokens != 5 {
+		t.Errorf("expected 5 output tokens, got %d", resp.OutputTokens)
+	}
+	if resp.Cost != 0.00014 {
+		t.Errorf("expected cost 0.00014, got %f", resp.Cost)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("expected native stop reason 'end_turn', got %q", resp.StopReason)
+	}
+	if resp.CacheStatus != "HIT" {
+		t.Errorf("expected cache status 'HIT', got %q", resp.CacheStatus)
+	}
+}
+
+func TestRequesty_Send_RequestFormat(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotCT, gotModel string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		gotModel, _ = gotBody["model"].(string)
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "OK"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	_, err := o.Send(context.Background(), &Request{
+		Model:    "openai/gpt-5",
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("expected POST, got %q", gotMethod)
+	}
+	if gotPath != "/chat/completions" {
+		t.Errorf("expected path /chat/completions, got %q", gotPath)
+	}
+	if !strings.HasPrefix(gotAuth, "Bearer ") {
+		t.Errorf("expected Bearer auth, got %q", gotAuth)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("expected application/json, got %q", gotCT)
+	}
+	if gotModel != "openai/gpt-5" {
+		t.Errorf("expected model 'openai/gpt-5', got %q", gotModel)
+	}
+}
+
+func TestRequesty_Send_AttributionHeaders(t *testing.T) {
+	var gotReferer, gotTitle string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("HTTP-Referer")
+		gotTitle = r.Header.Get("X-Title")
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "OK"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key",
+		WithRequestyBaseURL(server.URL),
+		WithRequestyReferer("https://github.com/jrswab/axe"),
+		WithRequestyTitle("Axe CLI"),
+	)
+	_, err := o.Send(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotReferer != "https://github.com/jrswab/axe" {
+		t.Errorf("referer = %q, want %q", gotReferer, "https://github.com/jrswab/axe")
+	}
+	if gotTitle != "Axe CLI" {
+		t.Errorf("title = %q, want %q", gotTitle, "Axe CLI")
+	}
+}
+
+func TestRequesty_Send_NoAttributionHeadersByDefault(t *testing.T) {
+	var gotReferer, gotTitle string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("HTTP-Referer")
+		gotTitle = r.Header.Get("X-Title")
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "OK"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]int{"prompt_tokens": 1, "completion_tokens": 1},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	_, err := o.Send(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotReferer != "" {
+		t.Errorf("expected no referer, got %q", gotReferer)
+	}
+	if gotTitle != "" {
+		t.Errorf("expected no title, got %q", gotTitle)
+	}
+}
+
+func TestRequesty_Send_GracefulDegradation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "OK"}, "finish_reason": "stop"},
+			},
+			"usage": map[string]int{
+				"prompt_tokens":     1,
+				"completion_tokens": 1,
+				// cost omitted intentionally
+			},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	resp, err := o.Send(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Cost != 0 {
+		t.Errorf("expected cost 0 when absent, got %f", resp.Cost)
+	}
+	if resp.CacheStatus != "" {
+		t.Errorf("expected empty cache status when header absent, got %q", resp.CacheStatus)
+	}
+}
+
+func TestRequesty_Send_ErrorResponses(t *testing.T) {
+	tests := []struct {
+		status  int
+		wantCat ErrorCategory
+	}{
+		{400, ErrCategoryBadRequest},
+		{401, ErrCategoryAuth},
+		{403, ErrCategoryAuth},
+		{404, ErrCategoryBadRequest},
+		{429, ErrCategoryRateLimit},
+		{500, ErrCategoryServer},
+		{502, ErrCategoryServer},
+		{503, ErrCategoryServer},
+	}
+
+	for _, tc := range tests {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"error": map[string]string{"message": "something went wrong"},
+				})
+			}))
+			defer server.Close()
+
+			o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+			_, err := o.Send(context.Background(), &Request{
+				Model:    "test-model",
+				Messages: []Message{{Role: "user", Content: "Hello"}},
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			provErr, ok := err.(*ProviderError)
+			if !ok {
+				t.Fatalf("expected *ProviderError, got %T", err)
+			}
+			if provErr.Category != tc.wantCat {
+				t.Errorf("category = %q, want %q", provErr.Category, tc.wantCat)
+			}
+		})
+	}
+}
+
+// --- Streaming tests ---
+
+func TestRequesty_SendStream_TextDeltas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("X-OpenRouter-Cache-Status", "MISS")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher")
+		}
+
+		events := []string{
+			`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}],"model":"openai/gpt-5"}`,
+			`data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}],"model":"openai/gpt-5"}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+			`data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2,"cost":0.00001}}`,
+			`data: [DONE]`,
+		}
+		for _, ev := range events {
+			_, _ = w.Write([]byte(ev + "\n\n"))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "openai/gpt-5",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var texts []string
+	var doneEvent *StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		if ev.Type == StreamEventText {
+			texts = append(texts, ev.Text)
+		}
+		if ev.Type == StreamEventDone {
+			doneEvent = &ev
+		}
+	}
+
+	if len(texts) != 2 || texts[0] != "Hello" || texts[1] != " world" {
+		t.Errorf("texts = %v, want [Hello,  world]", texts)
+	}
+	if doneEvent == nil {
+		t.Fatal("expected StreamEventDone")
+	}
+	if doneEvent.InputTokens != 3 {
+		t.Errorf("input tokens = %d, want 3", doneEvent.InputTokens)
+	}
+	if doneEvent.OutputTokens != 2 {
+		t.Errorf("output tokens = %d, want 2", doneEvent.OutputTokens)
+	}
+	if doneEvent.Cost != 0.00001 {
+		t.Errorf("cost = %f, want 0.00001", doneEvent.Cost)
+	}
+	if doneEvent.CacheStatus != "MISS" {
+		t.Errorf("cache status = %q, want MISS", doneEvent.CacheStatus)
+	}
+}
+
+func TestRequesty_SendStream_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]string{"message": "invalid key"},
+		})
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	_, err := o.SendStream(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	provErr, ok := err.(*ProviderError)
+	if !ok {
+		t.Fatalf("expected *ProviderError, got %T", err)
+	}
+	if provErr.Category != ErrCategoryAuth {
+		t.Errorf("category = %q, want %q", provErr.Category, ErrCategoryAuth)
+	}
+}
+
+func TestRequesty_SendStream_ToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher")
+		}
+
+		events := []string{
+			`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"run_command"}}]}}]}`,
+			`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":\"echo hi"}}]}}]}`,
+			`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]}}]}`,
+			`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: {"usage":{"prompt_tokens":10,"completion_tokens":5}}`,
+			`data: [DONE]`,
+		}
+		for _, ev := range events {
+			_, _ = w.Write([]byte(ev + "\n\n"))
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	o, _ := NewRequesty("test-key", WithRequestyBaseURL(server.URL))
+	stream, err := o.SendStream(context.Background(), &Request{
+		Model:    "test-model",
+		Messages: []Message{{Role: "user", Content: "Run echo hi"}},
+		Tools: []Tool{{
+			Name:        "run_command",
+			Description: "Run a shell command",
+			Parameters: map[string]ToolParameter{
+				"command": {Type: "string", Description: "command to run", Required: true},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	var toolStarts int
+	var toolEnds int
+	var doneEvent *StreamEvent
+	for {
+		ev, err := stream.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("stream error: %v", err)
+		}
+		switch ev.Type {
+		case StreamEventToolStart:
+			toolStarts++
+		case StreamEventToolEnd:
+			toolEnds++
+		case StreamEventDone:
+			doneEvent = &ev
+		}
+	}
+
+	if toolStarts != 1 {
+		t.Errorf("tool starts = %d, want 1", toolStarts)
+	}
+	if toolEnds != 1 {
+		t.Errorf("tool ends = %d, want 1", toolEnds)
+	}
+	if doneEvent == nil {
+		t.Fatal("expected StreamEventDone")
+	}
+}


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router, so the wiring follows the OpenRouter provider closely.

Changes:
- `internal/provider/requesty.go`: new `Requesty` provider mirroring `OpenRouter` (default base URL `https://router.requesty.ai/v1`, `Authorization: Bearer` auth, optional `HTTP-Referer`/`X-Title` headers). Dropped the OpenRouter-only categories header.
- `internal/provider/registry.go`: register `requesty` in `supportedProviders` and the `New()` dispatch.
- `internal/config/config.go`: map `requesty` -> `REQUESTY_API_KEY`.
- `internal/provider/requesty_test.go`: tests mirroring `openrouter_test.go`.

Model naming is `provider/model` (e.g. `openai/gpt-4o-mini`), same as OpenRouter.

Verified: `go build ./...`, `go vet`, `go test ./internal/provider/ ./internal/config/` all pass, and a live call through `provider.New("requesty", key, "")` against the real endpoint returns a completion.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This update adds Requesty as an OpenAI-compatible provider. It supports Bearer authentication, attribution headers, synchronous and streaming completions, and tool calls.

## Changelog

### Added
- Requesty provider with default base URL `https://router.requesty.ai/v1`.
- `REQUESTY_API_KEY` configuration mapping.
- Optional `HTTP-Referer` and `X-Title` headers.
- Requesty provider registration and constructor helper.
- Tests for requests, responses, streaming, tool calls, and errors.

### Changed
- Provider selection now supports `requesty`.
- Custom Requesty base URLs now trim trailing slashes.
- Model names use the `provider/model` format.
- Requesty requests omit the OpenRouter-specific categories header.

### Fixed
- Streaming tool-call handling now tolerates missing function payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->