### PR TITLE
feat: add Eden AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Eden AI provider support (OpenAI-compatible, EU-based gateway)
+
 ## [1.10.0] - 2026-05-05
 
 ### Added

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -6,6 +6,7 @@
 | OpenAI | `openai` | `OPENAI_API_KEY` | `https://api.openai.com` |
 | Google Gemini | `google` | `GEMINI_API_KEY` | `https://generativelanguage.googleapis.com` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` | `https://api.minimax.io/anthropic` |
+| Eden AI | `edenai` | `EDENAI_API_KEY` | `https://api.edenai.run/v3` |
 | Ollama | `ollama` | (none required) | `http://localhost:11434` |
 | OpenCode | `opencode` | `OPENCODE_API_KEY` | Configurable |
 | AWS Bedrock | `bedrock` | (uses AWS credentials) | Region-based |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ var knownAPIKeyEnvVars = map[string]string{
 	"google":     "GEMINI_API_KEY",
 	"minimax":    "MINIMAX_API_KEY",
 	"openrouter": "OPENROUTER_API_KEY",
+	"edenai":     "EDENAI_API_KEY",
 }
 
 // APIKeyEnvVar returns the environment variable name used to resolve the API key

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -343,6 +343,38 @@ func TestResolveAPIKey_MiniMax(t *testing.T) {
 	}
 }
 
+func TestAPIKeyEnvVar_EdenAI(t *testing.T) {
+	if got := APIKeyEnvVar("edenai"); got != "EDENAI_API_KEY" {
+		t.Errorf("expected EDENAI_API_KEY, got %q", got)
+	}
+}
+
+func TestResolveAPIKey_EdenAI(t *testing.T) {
+	// Env var takes precedence over config file.
+	t.Setenv("EDENAI_API_KEY", "edenai-key-from-env")
+	cfg := &GlobalConfig{
+		Providers: map[string]ProviderConfig{
+			"edenai": {APIKey: "edenai-key-from-config"},
+		},
+	}
+	if got := cfg.ResolveAPIKey("edenai"); got != "edenai-key-from-env" {
+		t.Errorf("expected 'edenai-key-from-env', got %q", got)
+	}
+
+	// Config file value used when env var is empty.
+	t.Setenv("EDENAI_API_KEY", "")
+	if got := cfg.ResolveAPIKey("edenai"); got != "edenai-key-from-config" {
+		t.Errorf("expected 'edenai-key-from-config', got %q", got)
+	}
+
+	// Empty string when neither is set.
+	t.Setenv("EDENAI_API_KEY", "")
+	emptyCfg := &GlobalConfig{Providers: map[string]ProviderConfig{}}
+	if got := emptyCfg.ResolveAPIKey("edenai"); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
 // --- ResolveRegion tests ---
 
 func TestResolveRegion_AWS_REGION(t *testing.T) {
@@ -406,12 +438,12 @@ func TestResolveRegion_UnknownProvider(t *testing.T) {
 
 func TestResolveOpenRouterAttribution(t *testing.T) {
 	cases := []struct {
-		name       string
-		env        map[string]string
-		cfg        *GlobalConfig
-		provider   string
-		fn         string // "referer", "title", or "categories"
-		want       string
+		name     string
+		env      map[string]string
+		cfg      *GlobalConfig
+		provider string
+		fn       string // "referer", "title", or "categories"
+		want     string
 	}{
 		{
 			name:     "referer env overrides config",

--- a/internal/provider/edenai.go
+++ b/internal/provider/edenai.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	// defaultEdenAIBaseURL is the default Eden AI API base URL. Eden AI is an
+	// EU-based, OpenAI-compatible gateway, so the base already includes the /v3
+	// version segment, mirroring how the OpenAI default includes /v1.
+	defaultEdenAIBaseURL = "https://api.edenai.run/v3"
+)
+
+// NewEdenAI creates a new Eden AI provider. Eden AI exposes an OpenAI-compatible
+// Chat Completions API, so it reuses the OpenAI provider implementation with a
+// different base URL (the same thin-wrapper approach MiniMax uses over the
+// Anthropic provider). Returns an error if apiKey is empty.
+func NewEdenAI(apiKey string, opts ...OpenAIOption) (*OpenAI, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+
+	o := &OpenAI{
+		apiKey:  apiKey,
+		baseURL: defaultEdenAIBaseURL,
+		client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o, nil
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -12,6 +12,7 @@ var supportedProviders = map[string]bool{
 	"minimax":    true,
 	"bedrock":    true,
 	"openrouter": true,
+	"edenai":     true,
 }
 
 // Supported reports whether providerName is a known provider.
@@ -76,8 +77,15 @@ func New(providerName, apiKey, baseURL string) (Provider, error) {
 		}
 		return NewOpenRouter(apiKey, opts...)
 
+	case "edenai":
+		var opts []OpenAIOption
+		if baseURL != "" {
+			opts = append(opts, WithOpenAIBaseURL(baseURL))
+		}
+		return NewEdenAI(apiKey, opts...)
+
 	default:
-		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, openai, ollama, opencode, google, minimax, bedrock, openrouter", providerName)
+		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, openai, ollama, opencode, google, minimax, bedrock, openrouter, edenai", providerName)
 	}
 }
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -112,7 +112,7 @@ func TestNew_MissingAPIKeyOpenAI(t *testing.T) {
 }
 
 func TestSupported_KnownProviders(t *testing.T) {
-	for _, name := range []string{"anthropic", "openai", "ollama", "google", "minimax", "bedrock", "openrouter", "opencode"} {
+	for _, name := range []string{"anthropic", "openai", "ollama", "google", "minimax", "bedrock", "openrouter", "opencode", "edenai"} {
 		if !Supported(name) {
 			t.Errorf("expected %q to be supported", name)
 		}
@@ -208,7 +208,7 @@ func TestNew_UnsupportedProvider_ErrorMessage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported provider")
 	}
-	for _, name := range []string{"anthropic", "openai", "ollama", "opencode", "google", "minimax", "bedrock", "openrouter"} {
+	for _, name := range []string{"anthropic", "openai", "ollama", "opencode", "google", "minimax", "bedrock", "openrouter", "edenai"} {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("expected error to mention %q, got %q", name, err.Error())
 		}
@@ -284,5 +284,41 @@ func TestNew_MiniMaxMissingAPIKey(t *testing.T) {
 func TestSupported_MiniMax(t *testing.T) {
 	if !Supported("minimax") {
 		t.Error("expected 'minimax' to be supported")
+	}
+}
+
+func TestNew_EdenAI(t *testing.T) {
+	p, err := New("edenai", "test-key", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNew_EdenAIWithBaseURL(t *testing.T) {
+	p, err := New("edenai", "test-key", "http://custom:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNew_EdenAIMissingAPIKey(t *testing.T) {
+	_, err := New("edenai", "", "")
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !strings.Contains(err.Error(), "API key is required") {
+		t.Errorf("expected 'API key is required', got %q", err.Error())
+	}
+}
+
+func TestSupported_EdenAI(t *testing.T) {
+	if !Supported("edenai") {
+		t.Error("expected 'edenai' to be supported")
 	}
 }


### PR DESCRIPTION
## What

Adds Eden AI as a provider.

Eden AI is an EU-based, OpenAI-compatible LLM gateway (one API key, one endpoint, many upstream vendors). Its `/v3` API speaks the OpenAI Chat Completions protocol, so the provider reuses the existing OpenAI implementation with a different base URL, the same thin-wrapper approach MiniMax uses over the Anthropic provider (`NewMiniMax` returns `*Anthropic`; `NewEdenAI` returns `*OpenAI`).

Model ids are vendor-prefixed, e.g. `edenai/openai/gpt-4o-mini`, `edenai/anthropic/claude-haiku-4-5`, `edenai/mistral/mistral-small-latest`. `parseModel` splits on the first `/`, so `edenai` selects the provider and the remaining `<vendor>/<model>` is sent through to Eden AI unchanged.

## Changes

- `internal/provider/edenai.go`: `NewEdenAI` (thin wrapper over the OpenAI provider, base URL `https://api.edenai.run/v3`).
- `internal/provider/registry.go`: `edenai` added to `supportedProviders`, the `New` dispatch, and the unsupported-provider error list.
- `internal/config/config.go`: `edenai` -> `EDENAI_API_KEY` in `knownAPIKeyEnvVars`.
- `internal/provider/registry_test.go` and `internal/config/config_test.go`: tests mirroring the MiniMax ones (constructor dispatch, base URL override, missing key, `Supported`, env var, `ResolveAPIKey`).
- `docs/src/providers.md`: Eden AI row in the providers table.
- `CHANGELOG.md`: Unreleased entry.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` and `golangci-lint run` (v2, the repo's linter) are all clean.
- `go test ./internal/provider/ ./internal/config/` passes (the new tests plus the existing suite, no regression).
- Live: verified against the real Eden AI API with a real key, through `provider.New("edenai", key, "")` and `Send`. Three upstream vendors returned completions: `openai/gpt-4o-mini`, `anthropic/claude-haiku-4-5`, `mistral/mistral-small-latest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This update adds Eden AI support through the existing OpenAI-compatible provider, including provider registration, `EDENAI_API_KEY` configuration, model routing, documentation, tests, and changelog coverage.

## Changelog

### Added

- Eden AI provider support using `https://api.edenai.run/v3`.
- Support for `edenai/<vendor>/<model>` model identifiers.
- Eden AI API key resolution via `EDENAI_API_KEY`.
- Constructor, registry, configuration, and API key resolution tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->