### PR TITLE
feat(provider): add Atlas Cloud support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Atlas Cloud provider using the OpenAI-compatible Chat Completions API
+
 ## [1.10.0] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ The first directory containing a matching `<name>.toml` wins.
 | Provider | API Key Env Var | Default Base URL |
 |---|---|---|
 | Anthropic | `ANTHROPIC_API_KEY` | `https://api.anthropic.com` |
+| Atlas Cloud | `ATLASCLOUD_API_KEY` | `https://api.atlascloud.ai/v1` |
 | OpenAI | `OPENAI_API_KEY` | `https://api.openai.com` |
 | Ollama | (none required) | `http://localhost:11434` |
 | OpenCode | `OPENCODE_API_KEY` | Configurable |
@@ -589,6 +590,8 @@ The first directory containing a matching `<name>.toml` wins.
 - Model IDs: Use full Bedrock model IDs (e.g., `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`)
 
 Base URLs can be overridden with `AXE_<PROVIDER>_BASE_URL` environment variables or in `config.toml`.
+
+For Atlas Cloud, use model names such as `atlascloud/qwen/qwen3.8-max` in agent TOML.
 
 ## License
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -142,7 +142,7 @@ model = "fakeprovider/some-model"
 	if !strings.Contains(err.Error(), `unsupported provider "fakeprovider"`) {
 		t.Errorf("expected 'unsupported provider' error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "anthropic, openai, ollama") {
+	if !strings.Contains(err.Error(), "anthropic, atlascloud, openai, ollama") {
 		t.Errorf("expected supported providers list, got: %v", err)
 	}
 }

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -3,6 +3,7 @@
 | Provider | Provider Name | API Key Env Var | Default Base URL |
 |---|---|---|---|
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | `https://api.anthropic.com` |
+| Atlas Cloud | `atlascloud` | `ATLASCLOUD_API_KEY` | `https://api.atlascloud.ai/v1` |
 | OpenAI | `openai` | `OPENAI_API_KEY` | `https://api.openai.com` |
 | Google Gemini | `google` | `GEMINI_API_KEY` | `https://generativelanguage.googleapis.com` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` | `https://api.minimax.io/anthropic` |
@@ -27,6 +28,9 @@ You can store credentials and base URL overrides in `$XDG_CONFIG_HOME/axe/config
 [providers.anthropic]
 api_key = "sk-ant-..."
 
+[providers.atlascloud]
+api_key = "..."
+
 [providers.google]
 api_key = "AIza..."
 
@@ -42,6 +46,8 @@ region = "us-east-1"
 ```
 
 Base URLs can also be overridden with `AXE_<PROVIDER>_BASE_URL` environment variables (takes precedence over `config.toml`).
+
+Atlas Cloud uses the OpenAI-compatible Chat Completions API. For example, set an agent model to `atlascloud/qwen/qwen3.8-max`.
 
 ## Streaming Support
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ func Load() (*GlobalConfig, error) {
 // knownAPIKeyEnvVars maps provider names to their canonical API key environment variables.
 var knownAPIKeyEnvVars = map[string]string{
 	"anthropic":  "ANTHROPIC_API_KEY",
+	"atlascloud": "ATLASCLOUD_API_KEY",
 	"openai":     "OPENAI_API_KEY",
 	"opencode":   "OPENCODE_API_KEY",
 	"google":     "GEMINI_API_KEY",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -246,6 +246,9 @@ func TestAPIKeyEnvVar_KnownProvider(t *testing.T) {
 	if got := APIKeyEnvVar("openai"); got != "OPENAI_API_KEY" {
 		t.Errorf("expected OPENAI_API_KEY, got %q", got)
 	}
+	if got := APIKeyEnvVar("atlascloud"); got != "ATLASCLOUD_API_KEY" {
+		t.Errorf("expected ATLASCLOUD_API_KEY, got %q", got)
+	}
 }
 
 func TestAPIKeyEnvVar_UnknownProvider(t *testing.T) {
@@ -406,12 +409,12 @@ func TestResolveRegion_UnknownProvider(t *testing.T) {
 
 func TestResolveOpenRouterAttribution(t *testing.T) {
 	cases := []struct {
-		name       string
-		env        map[string]string
-		cfg        *GlobalConfig
-		provider   string
-		fn         string // "referer", "title", or "categories"
-		want       string
+		name     string
+		env      map[string]string
+		cfg      *GlobalConfig
+		provider string
+		fn       string // "referer", "title", or "categories"
+		want     string
 	}{
 		{
 			name:     "referer env overrides config",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -240,14 +240,22 @@ func TestResolveBaseURL_EmptyEnvVar(t *testing.T) {
 }
 
 func TestAPIKeyEnvVar_KnownProvider(t *testing.T) {
-	if got := APIKeyEnvVar("anthropic"); got != "ANTHROPIC_API_KEY" {
-		t.Errorf("expected ANTHROPIC_API_KEY, got %q", got)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "Anthropic", input: "anthropic", want: "ANTHROPIC_API_KEY"},
+		{name: "OpenAI", input: "openai", want: "OPENAI_API_KEY"},
+		{name: "Atlas Cloud", input: "atlascloud", want: "ATLASCLOUD_API_KEY"},
 	}
-	if got := APIKeyEnvVar("openai"); got != "OPENAI_API_KEY" {
-		t.Errorf("expected OPENAI_API_KEY, got %q", got)
-	}
-	if got := APIKeyEnvVar("atlascloud"); got != "ATLASCLOUD_API_KEY" {
-		t.Errorf("expected ATLASCLOUD_API_KEY, got %q", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := APIKeyEnvVar(tt.input); got != tt.want {
+				t.Errorf("APIKeyEnvVar(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/provider/atlascloud.go
+++ b/internal/provider/atlascloud.go
@@ -1,0 +1,22 @@
+package provider
+
+const defaultAtlasCloudBaseURL = "https://api.atlascloud.ai/v1"
+
+// AtlasCloud is an OpenAI-compatible provider configured for Atlas Cloud.
+type AtlasCloud struct {
+	*OpenAI
+}
+
+// NewAtlasCloud creates an Atlas Cloud provider using its default API endpoint.
+func NewAtlasCloud(apiKey string, baseURL string) (*AtlasCloud, error) {
+	if baseURL == "" {
+		baseURL = defaultAtlasCloudBaseURL
+	}
+
+	openAI, err := NewOpenAI(apiKey, WithOpenAIBaseURL(baseURL))
+	if err != nil {
+		return nil, err
+	}
+
+	return &AtlasCloud{OpenAI: openAI}, nil
+}

--- a/internal/provider/atlascloud.go
+++ b/internal/provider/atlascloud.go
@@ -9,6 +9,13 @@ type AtlasCloud struct {
 
 // NewAtlasCloud creates an Atlas Cloud provider using its default API endpoint.
 func NewAtlasCloud(apiKey string, baseURL string) (*AtlasCloud, error) {
+	if apiKey == "" {
+		return nil, &ProviderError{
+			Category: ErrCategoryAuth,
+			Message:  "Atlas Cloud API key is required; set ATLASCLOUD_API_KEY",
+		}
+	}
+
 	if baseURL == "" {
 		baseURL = defaultAtlasCloudBaseURL
 	}

--- a/internal/provider/atlascloud_test.go
+++ b/internal/provider/atlascloud_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import "testing"
+
+func TestNewAtlasCloud_DefaultBaseURL(t *testing.T) {
+	provider, err := NewAtlasCloud("test-key", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.baseURL != defaultAtlasCloudBaseURL {
+		t.Errorf("baseURL = %q, want %q", provider.baseURL, defaultAtlasCloudBaseURL)
+	}
+}
+
+func TestNewAtlasCloud_CustomBaseURL(t *testing.T) {
+	const customURL = "https://example.com/v1"
+	provider, err := NewAtlasCloud("test-key", customURL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if provider.baseURL != customURL {
+		t.Errorf("baseURL = %q, want %q", provider.baseURL, customURL)
+	}
+}
+
+func TestNewAtlasCloud_MissingAPIKey(t *testing.T) {
+	if _, err := NewAtlasCloud("", ""); err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestAtlasCloudSupportsStreaming(t *testing.T) {
+	provider, err := NewAtlasCloud("test-key", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := interface{}(provider).(StreamProvider); !ok {
+		t.Fatal("expected Atlas Cloud to support streaming")
+	}
+}

--- a/internal/provider/atlascloud_test.go
+++ b/internal/provider/atlascloud_test.go
@@ -1,40 +1,87 @@
 package provider
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
-func TestNewAtlasCloud_DefaultBaseURL(t *testing.T) {
-	provider, err := NewAtlasCloud("test-key", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestNewAtlasCloud(t *testing.T) {
+	type input struct {
+		apiKey  string
+		baseURL string
 	}
-	if provider.baseURL != defaultAtlasCloudBaseURL {
-		t.Errorf("baseURL = %q, want %q", provider.baseURL, defaultAtlasCloudBaseURL)
+	type want struct {
+		baseURL      string
+		errCategory  ErrorCategory
+		errContains  string
+		streaming    bool
 	}
-}
 
-func TestNewAtlasCloud_CustomBaseURL(t *testing.T) {
-	const customURL = "https://example.com/v1"
-	provider, err := NewAtlasCloud("test-key", customURL)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name  string
+		input input
+		want  want
+	}{
+		{
+			name:  "default base URL",
+			input: input{apiKey: "test-key"},
+			want:  want{baseURL: defaultAtlasCloudBaseURL},
+		},
+		{
+			name:  "custom base URL",
+			input: input{apiKey: "test-key", baseURL: "https://example.com/v1"},
+			want:  want{baseURL: "https://example.com/v1"},
+		},
+		{
+			name:  "missing API key",
+			input: input{},
+			want: want{
+				errCategory: ErrCategoryAuth,
+				errContains: "ATLASCLOUD_API_KEY",
+			},
+		},
+		{
+			name:  "streaming support",
+			input: input{apiKey: "test-key"},
+			want: want{
+				baseURL:   defaultAtlasCloudBaseURL,
+				streaming: true,
+			},
+		},
 	}
-	if provider.baseURL != customURL {
-		t.Errorf("baseURL = %q, want %q", provider.baseURL, customURL)
-	}
-}
 
-func TestNewAtlasCloud_MissingAPIKey(t *testing.T) {
-	if _, err := NewAtlasCloud("", ""); err == nil {
-		t.Fatal("expected error for missing API key")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewAtlasCloud(tt.input.apiKey, tt.input.baseURL)
+			if tt.want.errCategory != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				var providerErr *ProviderError
+				if !errors.As(err, &providerErr) {
+					t.Fatalf("expected ProviderError, got %T", err)
+				}
+				if providerErr.Category != tt.want.errCategory {
+					t.Errorf("error category = %q, want %q", providerErr.Category, tt.want.errCategory)
+				}
+				if !strings.Contains(providerErr.Message, tt.want.errContains) {
+					t.Errorf("error message = %q, want it to contain %q", providerErr.Message, tt.want.errContains)
+				}
+				return
+			}
 
-func TestAtlasCloudSupportsStreaming(t *testing.T) {
-	provider, err := NewAtlasCloud("test-key", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if _, ok := interface{}(provider).(StreamProvider); !ok {
-		t.Fatal("expected Atlas Cloud to support streaming")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if provider.baseURL != tt.want.baseURL {
+				t.Errorf("baseURL = %q, want %q", provider.baseURL, tt.want.baseURL)
+			}
+			if tt.want.streaming {
+				if _, ok := interface{}(provider).(StreamProvider); !ok {
+					t.Fatal("expected Atlas Cloud to support streaming")
+				}
+			}
+		})
 	}
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -5,6 +5,7 @@ import "fmt"
 // supportedProviders lists all provider names accepted by New.
 var supportedProviders = map[string]bool{
 	"anthropic":  true,
+	"atlascloud": true,
 	"openai":     true,
 	"ollama":     true,
 	"opencode":   true,
@@ -28,6 +29,9 @@ func New(providerName, apiKey, baseURL string) (Provider, error) {
 			opts = append(opts, WithBaseURL(baseURL))
 		}
 		return NewAnthropic(apiKey, opts...)
+
+	case "atlascloud":
+		return NewAtlasCloud(apiKey, baseURL)
 
 	case "openai":
 		var opts []OpenAIOption
@@ -77,7 +81,7 @@ func New(providerName, apiKey, baseURL string) (Provider, error) {
 		return NewOpenRouter(apiKey, opts...)
 
 	default:
-		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, openai, ollama, opencode, google, minimax, bedrock, openrouter", providerName)
+		return nil, fmt.Errorf("unsupported provider %q: supported providers are anthropic, atlascloud, openai, ollama, opencode, google, minimax, bedrock, openrouter", providerName)
 	}
 }
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -15,6 +15,26 @@ func TestNew_Anthropic(t *testing.T) {
 	}
 }
 
+func TestNew_AtlasCloud(t *testing.T) {
+	p, err := New("atlascloud", "test-key", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestNew_AtlasCloudWithBaseURL(t *testing.T) {
+	p, err := New("atlascloud", "test-key", "http://custom:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
 func TestNew_Bedrock(t *testing.T) {
 	t.Setenv("AWS_ACCESS_KEY_ID", "AKID")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "SECRET")
@@ -69,7 +89,7 @@ func TestNew_UnsupportedProvider(t *testing.T) {
 	if !strings.Contains(err.Error(), `unsupported provider "groq"`) {
 		t.Errorf("expected error to mention 'unsupported provider \"groq\"', got %q", err.Error())
 	}
-	if !strings.Contains(err.Error(), "anthropic, openai, ollama, opencode, google, minimax, bedrock") {
+	if !strings.Contains(err.Error(), "anthropic, atlascloud, openai, ollama, opencode, google, minimax, bedrock") {
 		t.Errorf("expected error to list supported providers, got %q", err.Error())
 	}
 }
@@ -112,7 +132,7 @@ func TestNew_MissingAPIKeyOpenAI(t *testing.T) {
 }
 
 func TestSupported_KnownProviders(t *testing.T) {
-	for _, name := range []string{"anthropic", "openai", "ollama", "google", "minimax", "bedrock", "openrouter", "opencode"} {
+	for _, name := range []string{"anthropic", "atlascloud", "openai", "ollama", "google", "minimax", "bedrock", "openrouter", "opencode"} {
 		if !Supported(name) {
 			t.Errorf("expected %q to be supported", name)
 		}
@@ -208,7 +228,7 @@ func TestNew_UnsupportedProvider_ErrorMessage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported provider")
 	}
-	for _, name := range []string{"anthropic", "openai", "ollama", "opencode", "google", "minimax", "bedrock", "openrouter"} {
+	for _, name := range []string{"anthropic", "atlascloud", "openai", "ollama", "opencode", "google", "minimax", "bedrock", "openrouter"} {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("expected error to mention %q, got %q", name, err.Error())
 		}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -16,22 +16,29 @@ func TestNew_Anthropic(t *testing.T) {
 }
 
 func TestNew_AtlasCloud(t *testing.T) {
-	p, err := New("atlascloud", "test-key", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "default base URL", want: defaultAtlasCloudBaseURL},
+		{name: "custom base URL", input: "http://custom:8080", want: "http://custom:8080"},
 	}
-	if p == nil {
-		t.Fatal("expected non-nil provider")
-	}
-}
 
-func TestNew_AtlasCloudWithBaseURL(t *testing.T) {
-	p, err := New("atlascloud", "test-key", "http://custom:8080")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p == nil {
-		t.Fatal("expected non-nil provider")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := New("atlascloud", "test-key", tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			atlasCloud, ok := p.(*AtlasCloud)
+			if !ok {
+				t.Fatalf("provider type = %T, want *AtlasCloud", p)
+			}
+			if atlasCloud.baseURL != tt.want {
+				t.Errorf("baseURL = %q, want %q", atlasCloud.baseURL, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class provider backed by the existing OpenAI-compatible implementation
- resolve `ATLASCLOUD_API_KEY` and support config or `AXE_ATLASCLOUD_BASE_URL` overrides
- document the provider and cover registry, configuration, default endpoint, and streaming behavior

## Testing

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run` (v2.8.0, 0 issues)
- live streaming run with `atlascloud/qwen/qwen3.8-max` returned the expected response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This update adds Atlas Cloud as an OpenAI-compatible provider. It supports API key resolution, custom base URLs, streaming, registry integration, tests, and documentation.

### Added

- Atlas Cloud provider with default and custom base URL support.
- `ATLASCLOUD_API_KEY` configuration mapping.
- Atlas Cloud registry and streaming support.
- Tests for provider creation, validation, configuration, and streaming.
- Documentation and an unreleased changelog entry.

### Changed

- Unsupported-provider messages now include `atlascloud`.
- README now documents Atlas Cloud configuration and model naming.
- Test coverage now includes Atlas Cloud provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->